### PR TITLE
Self activate the VC Editor

### DIFF
--- a/includes/integrations/visual-composer.php
+++ b/includes/integrations/visual-composer.php
@@ -1,25 +1,73 @@
 <?php
 
 // Exit if accessed directly
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+if (!defined('ABSPATH')) {
+  exit;
 }
 
-final class Popmake_VisualComposer_Integration {
-	public static function init() {
-		add_filter( 'popmake_popup_post_type_args', array( __CLASS__, 'popup_post_type_args' )  );
-	}
-
-	public static function popup_post_type_args( $popup_args ) {
-		if ( defined( 'WPB_VC_VERSION' ) || ( ! empty( $_GET['page'] ) && in_array( $_GET['page'], array( 'fl-builder-settings' ) ) ) ) {
-			$popup_args['public'] = true;
-			$popup_args['exclude_from_search'] = true;
-			$popup_args['publicly_queryable'] = true;
-			$popup_args['show_in_nav_menus'] = false;
-		}
-
-		return $popup_args;
-	}
+if (defined('WPB_VC_VERSION')) {
+  //
+  // Let's self activate the vc editor on our post type with add_filters
+  //
+  add_action('admin_init', 'Popmake_Enable_Visual_Composer');
+  function Popmake_Enable_Visual_Composer() {
+    global $pagenow;
+    $screen = Popmake_GetCurrentPostType(); // Run our function to determine the correct post type
+    // If we are on our post type
+    if ($screen == 'popup') {
+      if ($pagenow == 'post-new.php' || $pagenow == 'post.php') {
+        // Let's activate the VC Editor
+        add_filter('vc_role_access_with_post_types_get_state', '__return_true');
+        add_filter('vc_role_access_with_backend_editor_get_state', '__return_true');
+        add_filter('vc_role_access_with_frontend_editor_get_state', '__return_false');
+        add_filter('vc_check_post_type_validation', '__return_true');
+      }
+    }
+  }
+  //
+  // Let's determine the post type
+  //
+  // Check the post type since we have one
+  function Popmake_GetCurrentPostType() {
+    global $post, $typenow, $current_screen;
+    if ($post && $post->post_type) {
+      return $post->post_type;
+    }
+    // Check the global $typenow
+    else if ($typenow) {
+      return $typenow;
+    }
+    // Check the global $current_screen Object
+    else if ($current_screen && $current_screen->post_type) {
+      return $current_screen->post_type;
+    }
+    // Check the Post Type QueryString
+    else if (isset($_REQUEST['post_type'])) {
+      return sanitize_key($_REQUEST['post_type']);
+    }
+    // Try to get via get_post(); Attempt A
+    else if (empty($typenow) && !empty($_GET['post'])) {
+      $post = get_post($_GET['post']);
+      $typenow = $post->post_type;
+      return $typenow;
+    }
+    // Try to get via get_post(); Attempt B
+    else if (empty($typenow) && !empty($_POST['post_ID'])) {
+      $post = get_post($_POST['post_ID']);
+      $typenow = $post->post_type;
+      return $typenow;
+    }
+    // Try to get via get_current_screen()
+    else if (function_exists('get_current_screen')) {
+      $current = get_current_screen();
+      if (isset($current) && ($current != false) && ($current->post_type)) {
+        return $current->post_type;
+      }
+      else {
+        return null;
+      }
+    }
+    // We do not know the post type, return null
+    return null;
+  }
 }
-
-Popmake_VisualComposer_Integration::init();


### PR DESCRIPTION
The latest version of VC and Popup Maker don't work with the VC Editor on the popup post type.
I'm running some filters on the post type itself at runtime which should always work if they don't change the filter of course. Hopefully, they change this less than they change everything else, haha. 

One thing that is missing is outputting the custom css from VC's editor that VC stores as option `_wpb_shortcodes_custom_css`. I'm working on a custom theme right now, so when I write a function for this myself I will make another push after testing it on Popup Maker. 

Last... I didn't look at how you are determining the Popup Maker post types. I run my own function for determining the post type. For that I called that function `Popmake_GetCurrentPostType();`. You might replace that with the function you are using to reduce code or use my function (which has come in handy from a dev that gave it to me) for your function and still reduce the code. 

It's up to you.

_NOTE: You might want to format the code differently. I can never get code in Github to carry over from my editor correctly :(_

Just to recap on what this is doing... it is enabling Visual Composer's editor interface for the popup post type. See screenshot below. What is highlighted in red is not active/visible in the most current versions of VC and PM.

![image](https://cloud.githubusercontent.com/assets/6123260/16996410/33f93ca4-4e7f-11e6-861f-e2b96a2008c6.png)
