### PR TITLE
indexed columns are utf8 and table creation check

### DIFF
--- a/classes/Abstract/Database.php
+++ b/classes/Abstract/Database.php
@@ -33,10 +33,16 @@ abstract class PUM_Abstract_Database {
 	 * Get things started
 	 */
 	public function __construct() {
+		global $wpdb;
+
 		$current_db_version = get_option( $this->table_name . '_db_version' );
 
 		if ( ! $current_db_version || $current_db_version < $this->version ) {
 			// Install the table.
+			@$this->create_table();
+		}
+
+		if ( $wpdb->get_var( "SHOW TABLES LIKE '$this->table_name()'" ) != $this->table_name() ) {
 			@$this->create_table();
 		}
 	}

--- a/classes/Abstract/Database.php
+++ b/classes/Abstract/Database.php
@@ -40,10 +40,10 @@ abstract class PUM_Abstract_Database {
 		if ( ! $current_db_version || $current_db_version < $this->version ) {
 			// Install the table.
 			@$this->create_table();
-		}
 
-		if ( $wpdb->get_var( "SHOW TABLES LIKE '$this->table_name()'" ) != $this->table_name() ) {
-			@$this->create_table();
+			if ( $wpdb->get_var( "SHOW TABLES LIKE '$this->table_name'" ) == $this->table_name ) {
+				update_option( $this->table_name . '_db_version', $this->version );
+			}
 		}
 	}
 

--- a/classes/DB/Subscribers.php
+++ b/classes/DB/Subscribers.php
@@ -106,8 +106,6 @@ class PUM_DB_Subscribers extends PUM_Abstract_Database {
 		) $charset_collate;";
 
 		dbDelta( $sql );
-
-		update_option( $this->table_name . '_db_version', $this->version );
 	}
 
 	public function get_by_email( $email = '' ) {

--- a/classes/DB/Subscribers.php
+++ b/classes/DB/Subscribers.php
@@ -86,10 +86,10 @@ class PUM_DB_Subscribers extends PUM_Abstract_Database {
 
 		$sql = "CREATE TABLE " . $this->table_name() . " (
 			`ID` BIGINT(20) NOT NULL AUTO_INCREMENT,
-			`email_hash` VARCHAR(255) NOT NULL,
+			`email_hash` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
 			`popup_id` BIGINT(20) NOT NULL,
 			`user_id` BIGINT(20) NOT NULL,
-			`email` VARCHAR(255) NOT NULL,
+			`email` VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_unicode_ci NOT NULL,
 			`name` VARCHAR(255) NOT NULL,
 			`fname` VARCHAR(255) NOT NULL,
 			`lname` VARCHAR(255) NOT NULL,


### PR DESCRIPTION
use utf8 charset for indexed columns, and test existence of table to see if creation is needed

See https://wordpress.org/support/topic/export-personal-data-error/