### PR TITLE
Added PUM_ASSET_CACHE constant to disable asset cache with a PHP cons…

### DIFF
--- a/classes/AssetCache.php
+++ b/classes/AssetCache.php
@@ -77,9 +77,10 @@ class PUM_AssetCache {
 	 * @return bool
 	 */
 	public static function enabled() {
-		if (defined( 'PUM_ASSET_CACHE' ) && !PUM_ASSET_CACHE) {
+		if ( defined( 'PUM_ASSET_CACHE' ) && ! PUM_ASSET_CACHE ) {
 			return false;
 		}
+
 		return self::writeable() && ! self::$disabled;
 	}
 

--- a/classes/AssetCache.php
+++ b/classes/AssetCache.php
@@ -77,6 +77,9 @@ class PUM_AssetCache {
 	 * @return bool
 	 */
 	public static function enabled() {
+		if (defined( 'PUM_ASSET_CACHE' ) && !PUM_ASSET_CACHE) {
+			return false;
+		}
 		return self::writeable() && ! self::$disabled;
 	}
 


### PR DESCRIPTION
This commit adds a check for the PUM_ASSET_CACHE constant when determining whether to use the asset cache feature. Being able to configure this setting this way is extremely important for systems where the asset cache being enabled accidentally would be a huge mistake. For multisite systems, for example, you may need to disable the asset cache for all sites and not allow it to be enabled on any sites.

This is especially important if JS and CSS files that are placed in the `wp-content` directory (which could be named anything else with the [`UPLOADS`](https://developer.wordpress.org/reference/functions/wp_upload_dir/) constant) are not served up unless they're a media file. So if you have a plugin that copies media files but not JS and CSS to a CDN, then these cached files won't get copied over and won't be served.

Similarly, if you're running in a "stateless" mode, then it doesn't make sense for JS and CSS to be cached on one server if at any time that server can get destroyed and replaced, or if there are multiple stateless server instances and traffic can get routed to a server that doesn't have these files saved.

Please accept the PR. And thanks for a great plugin. :)