### PR TITLE
Check that easy modal compatibility option is not empty as well as isset

### DIFF
--- a/includes/importer/easy-modal-v2.php
+++ b/includes/importer/easy-modal-v2.php
@@ -208,7 +208,7 @@ function popmake_emodal_v2_import() {
 
 function popmake_emodal_init() {
 	global $popmake_options;
-	if ( isset( $popmake_options['enable_easy_modal_compatibility_mode'] ) ) {
+	if ( isset( $popmake_options['enable_easy_modal_compatibility_mode'] ) && ! empty( $popmake_options['enable_easy_modal_compatibility_mode'] ) ) {
 		if ( ! shortcode_exists( 'modal' ) ) {
 			add_shortcode( 'modal', 'popmake_emodal_shortcode_modal' );
 		}

--- a/includes/importer/easy-modal-v2.php
+++ b/includes/importer/easy-modal-v2.php
@@ -207,8 +207,7 @@ function popmake_emodal_v2_import() {
 
 
 function popmake_emodal_init() {
-	global $popmake_options;
-	if ( isset( $popmake_options['enable_easy_modal_compatibility_mode'] ) && ! empty( $popmake_options['enable_easy_modal_compatibility_mode'] ) ) {
+	if ( pum_get_option( 'enable_easy_modal_compatibility_mode' ) ) {
 		if ( ! shortcode_exists( 'modal' ) ) {
 			add_shortcode( 'modal', 'popmake_emodal_shortcode_modal' );
 		}


### PR DESCRIPTION
This resolves #687. See that issue for details.

In the `if` statement, in addition to checking that the option is set, we make sure it's not empty before proceeding.