### PR TITLE
725 form submission cookie

### DIFF
--- a/assets/js/src/site/plugins/pum-cookies.js
+++ b/assets/js/src/site/plugins/pum-cookies.js
@@ -69,6 +69,24 @@
                 $popup.popmake('setCookie', settings);
             });
         },
+		form_submission: function (settings) {
+			var $popup = PUM.getPopup(this);
+
+			settings = $.extend({
+				form: '',
+				formInstanceId: ''
+			}, settings);
+
+			PUM.hooks.addAction('pum.integration.form.success', function (form, args) {
+				if (!settings.form.length) {
+					return;
+				}
+
+				if (PUM.integrations.checkFormKeyMatches(settings.form, settings.formInstanceId, args)) {
+					$popup.popmake('setCookie', settings);
+				}
+			});
+		},
         manual: function (settings) {
             var $popup = PUM.getPopup(this);
             $popup.on('pumSetCookie', function () {

--- a/assets/js/src/site/plugins/pum-integrations.js
+++ b/assets/js/src/site/plugins/pum-integrations.js
@@ -32,6 +32,28 @@
 			}
 
 			window.PUM.hooks.doAction('pum.integration.form.success', form, args);
+		},
+		checkFormKeyMatches: function (formIdentifier, formInstanceId, submittedFormArgs) {
+			formInstanceId = '' === formInstanceId ? formInstanceId : false;
+			// Check if the submitted form matches trigger requirements.
+			var checks = [
+				// Any supported form.
+				formIdentifier === 'any',
+
+				// Any provider form. ex. `ninjaforms_any`
+				formIdentifier === submittedFormArgs.formProvider + '_any',
+
+				// Specific provider form with or without instance ID. ex. `ninjaforms_1` or `ninjaforms_1_*`
+				// Only run this test if not checking for a specific instanceId.
+				!formInstanceId && new RegExp('^' + formIdentifier + '(_[\d]*)?').test(submittedFormArgs.formKey),
+
+				// Specific provider form with specific instance ID. ex `ninjaforms_1_1` or `calderaforms_jbakrhwkhg_1`
+				// Only run this test if we are checking for specific instanceId.
+				!!formInstanceId && formIdentifier + '_' + formInstanceId === submittedFormArgs.formKey
+			];
+
+			// If any check is true, set the cookie.
+			return -1 !== checks.indexOf(true);
 		}
 	});
 

--- a/assets/js/src/site/plugins/pum-triggers.js
+++ b/assets/js/src/site/plugins/pum-triggers.js
@@ -135,27 +135,7 @@
 					return;
 				}
 
-				var lookingFor = settings.form;
-				var instanceId = '' === settings.formInstanceId ? settings.formInstanceId : false;
-				// Check if the submitted form matches trigger requirements.
-				var checks = [
-					// Any supported form.
-					lookingFor === 'any',
-
-					// Any provider form. ex. `ninjaforms_any`
-					lookingFor === args.formProvider + '_any',
-
-					// Specific provider form with or without instance ID. ex. `ninjaforms_1` or `ninjaforms_1_*`
-					// Only run this test if not checking for a specific instanceId.
-					!instanceId && new RegExp('^' + lookingFor + '(_[\d]*)?').test(args.formKey),
-
-					// Specific provider form with specific instance ID. ex `ninjaforms_1_1` or `calderaforms_jbakrhwkhg_1`
-					// Only run this test if we are checking for specific instanceId.
-					!!instanceId && lookingFor + '_' + instanceId === args.formKey
-				];
-
-				// If any check is true, trigger the popup.
-				if (-1 !== checks.indexOf(true)) {
+				if (PUM.integrations.checkFormKeyMatches(settings.form, settings.formInstanceId, args)) {
 					onSuccess();
 				}
 			});

--- a/classes/Cookies.php
+++ b/classes/Cookies.php
@@ -133,6 +133,11 @@ class PUM_Cookies {
 				$cookie['fields'] = $this->cookie_fields();
 			}
 
+			$cookie['fields'] = PUM_Admin_Helpers::parse_tab_fields( $cookie['fields'], array(
+				'has_subtabs' => false,
+				'name'        => '%s',
+			) );
+
 			$this->cookies[ $cookie['id'] ] = $cookie;
 		}
 

--- a/classes/Cookies.php
+++ b/classes/Cookies.php
@@ -18,6 +18,11 @@ class PUM_Cookies {
 	public static $instance;
 
 	/**
+	 * @var bool
+	 */
+	public $preload_posts = false;
+
+	/**
 	 * @var array
 	 */
 	public $cookies;
@@ -35,7 +40,8 @@ class PUM_Cookies {
 	 */
 	public static function instance() {
 		if ( ! isset( self::$instance ) ) {
-			self::$instance = new self;
+			self::$instance                = new self;
+			self::$instance->preload_posts = pum_is_popup_editor();
 		}
 
 		return self::$instance;
@@ -68,19 +74,37 @@ class PUM_Cookies {
 	 */
 	public function register_cookies() {
 		$cookies = apply_filters( 'pum_registered_cookies', array(
-			'on_popup_close' => array(
+			'on_popup_close'                  => array(
 				'name' => __( 'On Popup Close', 'popup-maker' ),
 			),
-			'on_popup_open'  => array(
+			'on_popup_open'                   => array(
 				'name' => __( 'On Popup Open', 'popup-maker' ),
 			),
-			'pum_sub_form_success'             => array(
+			'form_submission'                 => [
+				'name'   => __( 'Form Submission', 'popup-maker' ),
+				'fields' => array_merge_recursive( $this->cookie_fields(), [
+					'general' => [
+						'form' => [
+							'type'    => 'select',
+							'label'   => __( 'Form', 'popup-maker' ),
+							'options' => $this->preload_posts ? array_merge( [
+								'any'                              => __( 'Any Supported Form*', 'popup-maker' ),
+								__( 'Popup Maker', 'popup-maker' ) => [
+									'pumsubform' => __( 'Subscription Form', 'popup-maker' ),
+								],
+							], PUM_Integrations::get_integrated_forms_selectlist() ) : array(),
+							'pri'     => - 1,
+						],
+					],
+				] ),
+			],
+			'pum_sub_form_success'            => array(
 				'name' => __( 'Subscription Form: Successful', 'popup-maker' ),
 			),
 			'pum_sub_form_already_subscribed' => array(
 				'name' => __( 'Subscription Form: Already Subscribed', 'popup-maker' ),
 			),
-			'manual'         => array(
+			'manual'                          => array(
 				'name' => __( 'Manual JavaScript', 'popup-maker' ),
 			),
 		) );

--- a/classes/Integrations.php
+++ b/classes/Integrations.php
@@ -373,4 +373,35 @@ class PUM_Integrations {
 		return $vars;
 	}
 
+	/**
+	 * Returns array of options for a select field to select an integrated form.
+	 *
+	 * @return array
+	 */
+	public static function get_integrated_forms_selectlist() {
+		$enabled_form_integrations = PUM_Integrations::get_enabled_form_integrations();
+
+		$options = [];
+
+		foreach ( $enabled_form_integrations as $integration ) {
+			switch ( $integration->key ) {
+				default:
+					$group_options = [
+						$integration->key . '_any' => sprintf( __( 'Any %s Form', 'popup-maker' ), $integration->label() ),
+					];
+
+					foreach ( $integration->get_form_selectlist() as $formId => $formLabel ) {
+						// ex. ninjaforms_1, contactform7_55
+						$group_options[ $integration->key . '_' . $formId ] = $formLabel;
+					}
+
+					$options[ $integration->label() ] = $group_options;
+
+					break;
+			}
+		}
+
+		return $options;
+	}
+
 }

--- a/classes/Triggers.php
+++ b/classes/Triggers.php
@@ -142,44 +142,6 @@ class PUM_Triggers {
 	}
 
 	/**
-	 * @return array
-	 */
-	public function get_form_type_options() {
-		return array_merge( [
-			'pumsubform' => __( 'Popup Maker', 'popup-maker' ) . ' - ' . __( 'Subscription Form', 'popup-maker' ),
-		], PUM_Integrations::get_enabled_forms_selectlist() );
-	}
-
-	/**
-	 * @return array
-	 */
-	public function generate_options_for_integrated_forms() {
-		$enabled_form_integrations = PUM_Integrations::get_enabled_form_integrations();
-
-		$options = [];
-
-		foreach ( $enabled_form_integrations as $integration ) {
-			switch ( $integration->key ) {
-				default:
-					$group_options = [
-						$integration->key . '_any' => sprintf( __( 'Any %s Form', 'popup-maker' ), $integration->label() ),
-					];
-
-					foreach ( $integration->get_form_selectlist() as $formId => $formLabel ) {
-						// ex. ninjaforms_1, contactform7_55
-						$group_options[ $integration->key . '_' . $formId ] = $formLabel;
-					}
-
-					$options[ $integration->label() ] = $group_options;
-
-					break;
-			}
-		}
-
-		return $options;
-	}
-
-	/**
 	 * Registers all known triggers when called.
 	 */
 	public function register_triggers() {
@@ -238,7 +200,7 @@ class PUM_Triggers {
 								__( 'Popup Maker', 'popup-maker' ) => [
 									'pumsubform' => __( 'Subscription Form', 'popup-maker' ),
 								],
-							], $this->generate_options_for_integrated_forms() ) : array(),
+							], PUM_Integrations::get_integrated_forms_selectlist() ) : array(),
 						],
 						'delay' => array(
 							'type'  => 'rangeslider',


### PR DESCRIPTION
This should handle quickly growing our form integrations with various cookie capabilities.

These should work to set cookies even when the popup isn't open.

Will need to find a way to set cookies on submission of specific forms when a popup isn't on the page later.

Resolves #725 