### PR TITLE
New Filesystem Error Check For Asset Cache

### DIFF
--- a/classes/AssetCache.php
+++ b/classes/AssetCache.php
@@ -114,27 +114,27 @@ class PUM_AssetCache {
 
 		global $wp_filesystem;
 
+		if ( ! function_exists( 'WP_Filesystem' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/file.php' );
+		}
+
+		$results = WP_Filesystem();
+
+		if ( true !== $results ) {
+			// Prevents this from running again and set to show the admin notice.
+			update_option( 'pum_files_writeable', false );
+			update_option( '_pum_writeable_notice_dismissed', false );
+			if ( ! is_null( $results ) && is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {
+				$error = $wp_filesystem->errors->get_error_message();
+				PUM_Utils_Logging::instance()->log( sprintf( 'Cache directory is not writeable due to filesystem error. Error given: %s', esc_html( $error ) ) );
+			} else {
+				PUM_Utils_Logging::instance()->log( 'Cache directory is not writeable due to incorrect filesystem method.' );
+			}
+			return false;
+		}
+
 		// Checks and create cachedir.
 		if ( ! is_dir( self::get_cache_dir() ) ) {
-
-			if ( ! function_exists( 'WP_Filesystem' ) ) {
-				require_once( ABSPATH . 'wp-admin/includes/file.php' );
-			}
-
-			$results = WP_Filesystem();
-
-			if ( true !== $results ) {
-				// Prevents this from running again and set to show the admin notice.
-				update_option( 'pum_files_writeable', false );
-				update_option( '_pum_writeable_notice_dismissed', false );
-				if ( ! is_null( $results ) && is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {
-					$error = $wp_filesystem->errors->get_error_message();
-					PUM_Utils_Logging::instance()->log( sprintf( 'Cannot make cache directory due to filesystem error. Error given: %s', esc_html( $error ) ) );
-				} else {
-					PUM_Utils_Logging::instance()->log( 'Cannot make cache directory due to incorrect filesystem method.' );
-				}
-				return false;
-			}
 
 			/** @var WP_Filesystem_Base $wp_filesystem */
 			$wp_filesystem->mkdir( self::get_cache_dir() );

--- a/classes/AssetCache.php
+++ b/classes/AssetCache.php
@@ -70,6 +70,7 @@ class PUM_AssetCache {
 
 			if ( null === get_option( 'pum_files_writeable', null ) ) {
 				add_option( 'pum_files_writeable', true );
+				add_option( '_pum_writeable_notice_dismissed', true );
 				pum_reset_assets();
 			}
 
@@ -554,7 +555,7 @@ class PUM_AssetCache {
 	 * @since 1.9.0
 	 */
 	public static function admin_notices() {
-		if ( ! self::should_show_notice() ) {
+		if ( self::should_not_show_notice() ) {
 			return;
 		}
 
@@ -645,9 +646,9 @@ class PUM_AssetCache {
 	 * Whether or not we should show admin notice
 	 *
 	 * @since 1.9.0
-	 * @return bool True if notice should be shown
+	 * @return bool True if notice should not be shown
 	 */
-	public static function should_show_notice() {
+	public static function should_not_show_notice() {
 		return true == get_option( 'pum_files_writeable', true ) || true == get_option( '_pum_writeable_notice_dismissed', true );
 	}
 }

--- a/classes/AssetCache.php
+++ b/classes/AssetCache.php
@@ -568,7 +568,7 @@ class PUM_AssetCache {
 		?>
 		<ul>
 			<li><a href="<?php echo esc_attr( $undo_url ); ?>"><strong><?php esc_html_e( 'Try to create cache again', 'popup-maker' ); ?></strong></a></li>
-			<li><a href="<?php echo esc_attr( $dismiss_url ); ?>"><?php esc_html_e( 'Keep current method', 'popup-maker' ); ?></a></li>
+			<li><a href="<?php echo esc_attr( $dismiss_url ); ?>" class="pum-dismiss"><?php esc_html_e( 'Keep current method', 'popup-maker' ); ?></a></li>
 			<li><a href="https://docs.wppopupmaker.com/article/521-debugging-filesystem-errors?utm_source=filesystem-error-alert&utm_medium=inline-doclink&utm_campaign=filesystem-error" target="_blank" rel="noreferrer noopener"><?php esc_html_e( 'Learn more', 'popup-maker' ); ?></a></li>
 		</ul>
 		<?php
@@ -579,7 +579,7 @@ class PUM_AssetCache {
 			'message'     => esc_html__( "Popup Maker detected an issue with your file system's ability and is unable to create & save cached assets for your popup styling and settings. This may lead to suboptimal performance. Please check your filesystem and contact your hosting provide to ensure Popup Maker can create and write to cache files.", 'popup-maker' ),
 			'html'        => $html,
 			'priority'    => 1000,
-			'dismissible' => false,
+			'dismissible' => '2 weeks',
 			'global'      => true,
 		);
 		return $alerts;
@@ -598,7 +598,7 @@ class PUM_AssetCache {
 				// If try again is clicked, remove flag.
 				update_option( 'pum_files_writeable', true );
 			} else {
-				pum_update_option( 'disable_asset_cache', true );
+				pum_update_option( 'disable_asset_caching', true );
 			}
 		}
 	}

--- a/classes/AssetCache.php
+++ b/classes/AssetCache.php
@@ -567,7 +567,7 @@ class PUM_AssetCache {
 		ob_start();
 		?>
 		<ul>
-			<li><a href="<?php echo esc_attr( $undo_url ); ?>" class="button-secondary"><?php esc_html_e( 'Try to create cache again', 'popup-maker' ); ?></a></li>
+			<li><a href="<?php echo esc_attr( $undo_url ); ?>" class="button-primary"><?php esc_html_e( 'Try to create cache again', 'popup-maker' ); ?></a></li>
 			<li><a href="<?php echo esc_attr( $dismiss_url ); ?>" class="button-secondary"><?php esc_html_e( 'Keep current method', 'popup-maker' ); ?></a></li>
 			<li><a href="https://docs.wppopupmaker.com/article/521-debugging-filesystem-errors?utm_source=filesystem-error-alert&utm_medium=inline-doclink&utm_campaign=filesystem-error" class="button-secondary"><?php esc_html_e( 'Learn more', 'popup-maker' ); ?></a></li>
 		</ul>

--- a/classes/AssetCache.php
+++ b/classes/AssetCache.php
@@ -65,6 +65,11 @@ class PUM_AssetCache {
 			add_action( 'pum_save_theme', array( __CLASS__, 'reset_cache' ) );
 			add_action( 'pum_update_core_version', array( __CLASS__, 'reset_cache' ) );
 
+			if ( null === get_option( 'pum_files_writeable', null ) ) {
+				add_option( 'pum_files_writeable', true );
+				pum_reset_assets();
+			}
+
 			// Prevent reinitialization.
 			self::$initialized = true;
 		}
@@ -94,6 +99,10 @@ class PUM_AssetCache {
 			return false;
 		}
 
+		if ( true !== get_option( 'pum_files_writeable', true ) ) {
+			return false;
+		}
+
 		global $wp_filesystem;
 
 		// Check and create cachedir
@@ -107,6 +116,7 @@ class PUM_AssetCache {
 
 			// If filesystem has an error, log to our logging system and then return false.
 			if ( true !== $results ) {
+				update_option( 'pum_files_writeable', false );
 				if ( is_wp_error( $wp_filesystem->errors ) && $wp_filesystem->errors->has_errors() ) {
 					$error = $wp_filesystem->errors->get_error_message();
 					PUM_Utils_Logging::instance()->log( sprintf( 'Cannot make cache directory due to filesystem error. Error given: %s', esc_html( $error ) ) );

--- a/classes/AssetCache.php
+++ b/classes/AssetCache.php
@@ -107,7 +107,7 @@ class PUM_AssetCache {
 			return false;
 		}
 
-		if ( true !== get_option( 'pum_files_writeable', true ) ) {
+		if ( true != get_option( 'pum_files_writeable', true ) ) {
 			return false;
 		}
 
@@ -553,7 +553,7 @@ class PUM_AssetCache {
 	 * @since 1.9.0
 	 */
 	public static function admin_notices() {
-		if ( true === get_option( 'pum_files_writeable', true ) ) {
+		if ( true == get_option( 'pum_files_writeable', true ) || true == get_option( '_pum_writeable_notice_dismissed', true ) ) {
 			return;
 		}
 
@@ -561,36 +561,61 @@ class PUM_AssetCache {
 		$dismiss_url  = add_query_arg( 'pum_writeable_notice_check', 'dismiss' );
 		?>
 		<style>
-			.pum-notice p {
-				margin-bottom: 0;
+			.pum-notice .pum-notice-message {
+				display: flex;
+				flex-direction: column;
+				margin: 0.5em 0;
+				align-items: center;
 			}
-
-			.pum-notice img.logo {
-				float: right;
-				margin-left: 10px;
-				width: 128px;
+			.pum-notice div.pum-notice-message img {
+				display: none;
+				max-height: 60px;
+				height: 100%;
 				padding: 0.25em;
+				margin-left: 10px;
 				border: 1px solid #ccc;
 			}
-			.pum-notice div {
+			.pum-notice div.pum-notice-actions {
 				display: flex;
-				flex-direction: row;
+				flex-direction: column;
+				margin-bottom: 10px;
 			}
-			.pum-notice div a {
-				display: block;
-				margin-left: 10px;
+			.pum-notice div.pum-notice-actions a.button-secondary {
+				margin-bottom: 10px;
+			}
+			@media screen and (min-width:500px) {
+				.pum-notice .pum-notice-message {
+					flex-direction: row;
+				}
+				.pum-notice div.pum-notice-message img {
+					display: block;
+					width: 15%;
+				}
+			}
+			@media screen and (min-width:700px) {
+				.pum-notice div.pum-notice-message img {
+					width: 10%;
+				}
+				.pum-notice div.pum-notice-actions {
+					flex-direction: row;
+				}
+				.pum-notice div.pum-notice-actions a.button-secondary:not(:first-child) {
+					margin-left: 10px;
+				}
 			}
 		</style>
-		<div class="notice notice-error is-dismissible pum-notice">
-			<p>
-				<img class="logo" src="<?php echo POPMAKE_URL; ?>/assets/images/icon-256x256.jpg" />
-				<?php
-				esc_html_e( 'Popup Maker detected an issue with your file system and is unable to create cache for 
+		<div class="notice notice-error pum-notice">
+			<div class="pum-notice-message">
+				<p>
+					<?php
+					esc_html_e( 'Popup Maker detected an issue with your file system and is unable to create cache for 
 				the styling and settings. This may lead to suboptimal performance. Please check your filesystem and 
 				hosting provide to ensure Popup Maker can create and write to cache files.', 'popup-maker' );
-				?>
-			</p>
-			<div>
+					?>
+				</p>
+				<img class="logo" src="<?php echo POPMAKE_URL; ?>/assets/images/icon-256x256.jpg" />
+			</div>
+			<div class="pum-notice-actions">
 				<a href="<?php echo esc_attr( $undo_url ); ?>" class="button-secondary"><?php esc_html_e( 'Try to create cache again', 'popup-maker' ); ?></a>
 				<a href="<?php echo esc_attr( $dismiss_url ); ?>" class="button-secondary"><?php esc_html_e( 'Keep current method', 'popup-maker' ); ?></a>
 				<a href="#" class="button-secondary"><?php esc_html_e( 'Learn more', 'popup-maker' ); ?></a>

--- a/classes/AssetCache.php
+++ b/classes/AssetCache.php
@@ -611,12 +611,4 @@ class PUM_AssetCache {
 			}
 		}
 	}
-
-	/**
-	 * @param $theme_id
-	 */
-	public static function generate_popup_theme_style( $theme_id ) {
-	}
-
-
 }

--- a/classes/AssetCache.php
+++ b/classes/AssetCache.php
@@ -76,7 +76,7 @@ class PUM_AssetCache {
 			}
 
 			if ( is_admin() && current_user_can( 'edit_posts' ) ) {
-				add_action( 'admin_init', array( __CLASS__, 'admin_notice_check' ) );
+				add_action( 'init', array( __CLASS__, 'admin_notice_check' ) );
 			}
 
 			// Prevent reinitialization.
@@ -567,9 +567,9 @@ class PUM_AssetCache {
 		ob_start();
 		?>
 		<ul>
-			<li><a href="<?php echo esc_attr( $undo_url ); ?>" class="button-primary"><?php esc_html_e( 'Try to create cache again', 'popup-maker' ); ?></a></li>
-			<li><a href="<?php echo esc_attr( $dismiss_url ); ?>" class="button-secondary"><?php esc_html_e( 'Keep current method', 'popup-maker' ); ?></a></li>
-			<li><a href="https://docs.wppopupmaker.com/article/521-debugging-filesystem-errors?utm_source=filesystem-error-alert&utm_medium=inline-doclink&utm_campaign=filesystem-error" class="button-secondary"><?php esc_html_e( 'Learn more', 'popup-maker' ); ?></a></li>
+			<li><a href="<?php echo esc_attr( $undo_url ); ?>"><strong><?php esc_html_e( 'Try to create cache again', 'popup-maker' ); ?></strong></a></li>
+			<li><a href="<?php echo esc_attr( $dismiss_url ); ?>"><?php esc_html_e( 'Keep current method', 'popup-maker' ); ?></a></li>
+			<li><a href="https://docs.wppopupmaker.com/article/521-debugging-filesystem-errors?utm_source=filesystem-error-alert&utm_medium=inline-doclink&utm_campaign=filesystem-error" target="_blank" rel="noreferrer noopener"><?php esc_html_e( 'Learn more', 'popup-maker' ); ?></a></li>
 		</ul>
 		<?php
 		$html = ob_get_clean();

--- a/classes/AssetCache.php
+++ b/classes/AssetCache.php
@@ -3,6 +3,9 @@
  * Copyright (c) 2019, Code Atlantic LLC
  ******************************************************************************/
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 class PUM_AssetCache {
 

--- a/classes/AssetCache.php
+++ b/classes/AssetCache.php
@@ -569,7 +569,7 @@ class PUM_AssetCache {
 		<ul>
 			<li><a href="<?php echo esc_attr( $undo_url ); ?>" class="button-secondary"><?php esc_html_e( 'Try to create cache again', 'popup-maker' ); ?></a></li>
 			<li><a href="<?php echo esc_attr( $dismiss_url ); ?>" class="button-secondary"><?php esc_html_e( 'Keep current method', 'popup-maker' ); ?></a></li>
-			<li><a href="#" class="button-secondary"><?php esc_html_e( 'Learn more', 'popup-maker' ); ?></a></li>
+			<li><a href="https://docs.wppopupmaker.com/article/521-debugging-filesystem-errors?utm_source=filesystem-error-alert&utm_medium=inline-doclink&utm_campaign=filesystem-error" class="button-secondary"><?php esc_html_e( 'Learn more', 'popup-maker' ); ?></a></li>
 		</ul>
 		<?php
 		$html = ob_get_clean();
@@ -597,6 +597,8 @@ class PUM_AssetCache {
 			if ( 'undo' === $_GET['pum_writeable_notice_check'] ) {
 				// If try again is clicked, remove flag.
 				update_option( 'pum_files_writeable', true );
+			} else {
+				pum_update_option( 'disable_asset_cache', true );
 			}
 		}
 	}


### PR DESCRIPTION
Adds new checks to notify an admin if the cache cannot be created due to filesystem errors. 

Refer to #730 