### PR TITLE
Hotfix 1.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v1.11.1 - 07/22/2020
+* Fix: Form submission cookies no longer set with Contact Form 7 5.2 
+
 ### v1.11.0 - 06/25/2020
 * Feature: Add new floating bar theme.
 * Feature: New guided tour of popup editor for first time users.

--- a/assets/js/src/integration/contactform7.js
+++ b/assets/js/src/integration/contactform7.js
@@ -3,27 +3,30 @@
  ******************************************************************************/
 
 {
-	const formProvider = 'contactform7';
+	const formProvider = "contactform7";
 	const $ = window.jQuery;
 
-	$( document ).on( 'wpcf7:mailsent', '.wpcf7', function ( event, details ) {
-		const $form = $( this ),
-			formId = $form.find( 'input[name="_wpcf7"]' ).val(),
+	$(document).on("wpcf7mailsent", function(event, details) {
+		var formId = event.detail.contactFormId,
+			$form = $(event.target),
 			// Converts string like wpcf7-f190-p2-o11 and reduces it to simply 11, the last o11 is the instance ID.
 			// More accurate way of doing it in case things change in the future, this version filters out all but the o param.
 			// formInstanceId = .split('-').filter((string) => string.indexOf('o') === 0)[0].replace('o','');
 			// Simpler version that simply splits and pops the last item in the array. This requires it always be the last.
-			formInstanceId = $form.attr( 'id' ).split( '-' ).pop().replace( 'o', '' );
+			formInstanceId = event.detail.id
+				.split("-")
+				.pop()
+				.replace("o", "");
 
 		// All the magic happens here.
-		window.PUM.integrations.formSubmission( $form, {
+		window.PUM.integrations.formSubmission($form, {
 			formProvider,
 			formId,
 			formInstanceId,
 			extras: {
-				details,
-			},
-		} );
+				details
+			}
+		});
 
 		/**
 		 * TODO - Move this to a backward compatiblilty file, hook it into the pum.integration.form.success action.
@@ -32,15 +35,19 @@
 		 *
 		 * This is here for backward compatibility with form actions prior to v1.9.
 		 */
-		const $settings = $form.find( 'input.wpcf7-pum' ),
-			settings = $settings.length ? JSON.parse( $settings.val() ) : false;
+		const $settings = $form.find("input.wpcf7-pum"),
+			settings = $settings.length ? JSON.parse($settings.val()) : false;
 
-		if ( typeof settings === 'object' && settings.closedelay !== undefined && settings.closedelay.toString().length >= 3 ) {
-			settings[ 'closedelay' ] = settings.closedelay / 1000;
+		if (
+			typeof settings === "object" &&
+			settings.closedelay !== undefined &&
+			settings.closedelay.toString().length >= 3
+		) {
+			settings.closedelay = settings.closedelay / 1000;
 		}
 
 		// Nothing should happen if older action settings not applied
 		// except triggering of pumFormSuccess event for old cookie method.
-		window.PUM.forms.success( $form, settings );
-	} );
+		window.PUM.forms.success($form, settings);
+	});
 }

--- a/assets/js/src/integration/contactform7.js
+++ b/assets/js/src/integration/contactform7.js
@@ -7,7 +7,7 @@
 	const $ = window.jQuery;
 
 	$(document).on("wpcf7mailsent", function(event, details) {
-		var formId = event.detail.contactFormId,
+		const formId = event.detail.contactFormId,
 			$form = $(event.target),
 			// Converts string like wpcf7-f190-p2-o11 and reduces it to simply 11, the last o11 is the instance ID.
 			// More accurate way of doing it in case things change in the future, this version filters out all but the o param.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "popup-maker",
-  "version": "1.11.0",
+  "version": "1.11.1",
   "description": "WordPress Popup Plugin",
   "homepage": "https://wppopupmaker.com",
   "author": "Code Atlantic LLC",

--- a/popup-maker.php
+++ b/popup-maker.php
@@ -3,7 +3,7 @@
  * Plugin Name:  Popup Maker
  * Plugin URI:   https://wppopupmaker.com/?utm_campaign=PluginInfo&utm_source=plugin-header&utm_medium=plugin-uri
  * Description:  Easily create & style popups with any content. Theme editor to quickly style your popups. Add forms, social media boxes, videos & more.
- * Version:      1.11.0
+ * Version:      1.11.1
  * Author:       Popup Maker
  * Author URI:   https://wppopupmaker.com/?utm_campaign=PluginInfo&utm_source=plugin-header&utm_medium=author-uri
  * License:      GPL2 or later
@@ -13,10 +13,10 @@
  *
  * @package     POPMAKE
  * @author      Daniel Iser
- * @copyright   Copyright (c) 2019, Code Atlantic LLC
+ * @copyright   Copyright (c) 2020, Code Atlantic LLC
  */
 
-// Exit if accessed directly
+// Exit if accessed directly.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -93,7 +93,7 @@ class Popup_Maker {
 	/**
 	 * @var string Plugin Version
 	 */
-	public static $VER = '1.11.0';
+	public static $VER = '1.11.1';
 
 	/**
 	 * @var int DB Version

--- a/readme.txt
+++ b/readme.txt
@@ -7,7 +7,7 @@ Tags:  marketing, popup, popups, optin, advertising, conversion, responsive popu
 Requires at least: 4.1
 Tested up to: 5.4
 Requires PHP: 5.6
-Stable tag: 1.11.0
+Stable tag: 1.11.1
 License: GPLv2 or later
 License URI:  http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -135,6 +135,9 @@ There are several common causes for this, check [this guide for help](https://do
 == Changelog ==
 
 View our [complete changelog](https://github.com/PopupMaker/Popup-Maker/blob/master/CHANGELOG.md) for up-to-date information on what has been going on with the development of Popup Maker.
+
+= v1.11.1 - 07/22/2020 =
+* Fix: Form submission cookies no longer set with Contact Form 7 5.2
 
 = v1.11.0 - 06/25/2020 =
 * Feature: Add new floating bar theme.


### PR DESCRIPTION
* Fix: Form submission cookies no longer set with Contact Form 7 5.2. Closes #851 
