### PR TITLE
1.11.2 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### v1.11.2 - 08/12/2020
+* Fix: `wp_make_content_images_responsive` is deprecated, use `wp_filter_content_tags()` instead
+
 ### v1.11.1 - 07/22/2020
 * Fix: Form submission cookies no longer set with Contact Form 7 5.2 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
-### v1.11.2 - 08/12/2020
+### v1.11.2 - 08/14/2020
 * Fix: `wp_make_content_images_responsive` is deprecated, use `wp_filter_content_tags()` instead
+* Fix: IE 11 does not support JS Promises
 
 ### v1.11.1 - 07/22/2020
 * Fix: Form submission cookies no longer set with Contact Form 7 5.2 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
-### v1.11.2 - 08/14/2020
+### v1.11.2 - 08/17/2020
 * Fix: `wp_make_content_images_responsive` is deprecated, use `wp_filter_content_tags()` instead
 * Fix: IE 11 does not support JS Promises
+* Fix: Missing permission_callback on REST endpoint
 
 ### v1.11.1 - 07/22/2020
 * Fix: Form submission cookies no longer set with Contact Form 7 5.2 

--- a/assets/js/src/site/vendor/promise-polyfill.js
+++ b/assets/js/src/site/vendor/promise-polyfill.js
@@ -1,0 +1,301 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(factory());
+}(this, (function () { 'use strict';
+
+/**
+ * @this {Promise}
+ */
+function finallyConstructor(callback) {
+  var constructor = this.constructor;
+  return this.then(
+    function(value) {
+      // @ts-ignore
+      return constructor.resolve(callback()).then(function() {
+        return value;
+      });
+    },
+    function(reason) {
+      // @ts-ignore
+      return constructor.resolve(callback()).then(function() {
+        // @ts-ignore
+        return constructor.reject(reason);
+      });
+    }
+  );
+}
+
+// Store setTimeout reference so promise-polyfill will be unaffected by
+// other code modifying setTimeout (like sinon.useFakeTimers())
+var setTimeoutFunc = setTimeout;
+
+function isArray(x) {
+  return Boolean(x && typeof x.length !== 'undefined');
+}
+
+function noop() {}
+
+// Polyfill for Function.prototype.bind
+function bind(fn, thisArg) {
+  return function() {
+    fn.apply(thisArg, arguments);
+  };
+}
+
+/**
+ * @constructor
+ * @param {Function} fn
+ */
+function Promise(fn) {
+  if (!(this instanceof Promise))
+    throw new TypeError('Promises must be constructed via new');
+  if (typeof fn !== 'function') throw new TypeError('not a function');
+  /** @type {!number} */
+  this._state = 0;
+  /** @type {!boolean} */
+  this._handled = false;
+  /** @type {Promise|undefined} */
+  this._value = undefined;
+  /** @type {!Array<!Function>} */
+  this._deferreds = [];
+
+  doResolve(fn, this);
+}
+
+function handle(self, deferred) {
+  while (self._state === 3) {
+    self = self._value;
+  }
+  if (self._state === 0) {
+    self._deferreds.push(deferred);
+    return;
+  }
+  self._handled = true;
+  Promise._immediateFn(function() {
+    var cb = self._state === 1 ? deferred.onFulfilled : deferred.onRejected;
+    if (cb === null) {
+      (self._state === 1 ? resolve : reject)(deferred.promise, self._value);
+      return;
+    }
+    var ret;
+    try {
+      ret = cb(self._value);
+    } catch (e) {
+      reject(deferred.promise, e);
+      return;
+    }
+    resolve(deferred.promise, ret);
+  });
+}
+
+function resolve(self, newValue) {
+  try {
+    // Promise Resolution Procedure: https://github.com/promises-aplus/promises-spec#the-promise-resolution-procedure
+    if (newValue === self)
+      throw new TypeError('A promise cannot be resolved with itself.');
+    if (
+      newValue &&
+      (typeof newValue === 'object' || typeof newValue === 'function')
+    ) {
+      var then = newValue.then;
+      if (newValue instanceof Promise) {
+        self._state = 3;
+        self._value = newValue;
+        finale(self);
+        return;
+      } else if (typeof then === 'function') {
+        doResolve(bind(then, newValue), self);
+        return;
+      }
+    }
+    self._state = 1;
+    self._value = newValue;
+    finale(self);
+  } catch (e) {
+    reject(self, e);
+  }
+}
+
+function reject(self, newValue) {
+  self._state = 2;
+  self._value = newValue;
+  finale(self);
+}
+
+function finale(self) {
+  if (self._state === 2 && self._deferreds.length === 0) {
+    Promise._immediateFn(function() {
+      if (!self._handled) {
+        Promise._unhandledRejectionFn(self._value);
+      }
+    });
+  }
+
+  for (var i = 0, len = self._deferreds.length; i < len; i++) {
+    handle(self, self._deferreds[i]);
+  }
+  self._deferreds = null;
+}
+
+/**
+ * @constructor
+ */
+function Handler(onFulfilled, onRejected, promise) {
+  this.onFulfilled = typeof onFulfilled === 'function' ? onFulfilled : null;
+  this.onRejected = typeof onRejected === 'function' ? onRejected : null;
+  this.promise = promise;
+}
+
+/**
+ * Take a potentially misbehaving resolver function and make sure
+ * onFulfilled and onRejected are only called once.
+ *
+ * Makes no guarantees about asynchrony.
+ */
+function doResolve(fn, self) {
+  var done = false;
+  try {
+    fn(
+      function(value) {
+        if (done) return;
+        done = true;
+        resolve(self, value);
+      },
+      function(reason) {
+        if (done) return;
+        done = true;
+        reject(self, reason);
+      }
+    );
+  } catch (ex) {
+    if (done) return;
+    done = true;
+    reject(self, ex);
+  }
+}
+
+Promise.prototype['catch'] = function(onRejected) {
+  return this.then(null, onRejected);
+};
+
+Promise.prototype.then = function(onFulfilled, onRejected) {
+  // @ts-ignore
+  var prom = new this.constructor(noop);
+
+  handle(this, new Handler(onFulfilled, onRejected, prom));
+  return prom;
+};
+
+Promise.prototype['finally'] = finallyConstructor;
+
+Promise.all = function(arr) {
+  return new Promise(function(resolve, reject) {
+    if (!isArray(arr)) {
+      return reject(new TypeError('Promise.all accepts an array'));
+    }
+
+    var args = Array.prototype.slice.call(arr);
+    if (args.length === 0) return resolve([]);
+    var remaining = args.length;
+
+    function res(i, val) {
+      try {
+        if (val && (typeof val === 'object' || typeof val === 'function')) {
+          var then = val.then;
+          if (typeof then === 'function') {
+            then.call(
+              val,
+              function(val) {
+                res(i, val);
+              },
+              reject
+            );
+            return;
+          }
+        }
+        args[i] = val;
+        if (--remaining === 0) {
+          resolve(args);
+        }
+      } catch (ex) {
+        reject(ex);
+      }
+    }
+
+    for (var i = 0; i < args.length; i++) {
+      res(i, args[i]);
+    }
+  });
+};
+
+Promise.resolve = function(value) {
+  if (value && typeof value === 'object' && value.constructor === Promise) {
+    return value;
+  }
+
+  return new Promise(function(resolve) {
+    resolve(value);
+  });
+};
+
+Promise.reject = function(value) {
+  return new Promise(function(resolve, reject) {
+    reject(value);
+  });
+};
+
+Promise.race = function(arr) {
+  return new Promise(function(resolve, reject) {
+    if (!isArray(arr)) {
+      return reject(new TypeError('Promise.race accepts an array'));
+    }
+
+    for (var i = 0, len = arr.length; i < len; i++) {
+      Promise.resolve(arr[i]).then(resolve, reject);
+    }
+  });
+};
+
+// Use polyfill for setImmediate for performance gains
+Promise._immediateFn =
+  // @ts-ignore
+  (typeof setImmediate === 'function' &&
+    function(fn) {
+      // @ts-ignore
+      setImmediate(fn);
+    }) ||
+  function(fn) {
+    setTimeoutFunc(fn, 0);
+  };
+
+Promise._unhandledRejectionFn = function _unhandledRejectionFn(err) {
+  if (typeof console !== 'undefined' && console) {
+    console.warn('Possible Unhandled Promise Rejection:', err); // eslint-disable-line no-console
+  }
+};
+
+/** @suppress {undefinedVars} */
+var globalNS = (function() {
+  // the only reliable means to get the global object is
+  // `Function('return this')()`
+  // However, this causes CSP violations in Chrome apps.
+  if (typeof self !== 'undefined') {
+    return self;
+  }
+  if (typeof window !== 'undefined') {
+    return window;
+  }
+  if (typeof global !== 'undefined') {
+    return global;
+  }
+  throw new Error('unable to locate global object');
+})();
+
+if (!('Promise' in globalNS)) {
+  globalNS['Promise'] = Promise;
+} else if (!globalNS.Promise.prototype['finally']) {
+  globalNS.Promise.prototype['finally'] = finallyConstructor;
+}
+
+})));

--- a/classes/Analytics.php
+++ b/classes/Analytics.php
@@ -151,9 +151,10 @@ class PUM_Analytics {
 		$namespace = 'pum/v' . $version;
 
 		register_rest_route( $namespace, 'analytics', apply_filters( 'pum_analytics_rest_route_args', array(
-			'methods'  => 'GET',
-			'callback' => array( __CLASS__, 'analytics_endpoint' ),
-			'args'     => array(
+			'methods'             => 'GET',
+			'callback'            => array( __CLASS__, 'analytics_endpoint' ),
+			'permission_callback' => '__return_true',
+			'args'                => array(
 				'event' => array(
 					'required'    => true,
 					'description' => __( 'Event Type', 'popup-maker' ),

--- a/classes/Site.php
+++ b/classes/Site.php
@@ -50,14 +50,18 @@ class PUM_Site {
 		 * @sinceWP 5.4
 		 */
 		if ( version_compare( $wp_version, '5.0.0', '>=' ) ) {
-			add_filter( 'pum_popup_content', [ __CLASS__, 'do_blocks' ], 9 );
+			add_filter( 'pum_popup_content', array( __CLASS__, 'do_blocks' ), 9 );
 		}
 		add_filter( 'pum_popup_content', 'wptexturize' );
 		add_filter( 'pum_popup_content', 'convert_smilies', 20 );
 		add_filter( 'pum_popup_content', 'wpautop' );
 		add_filter( 'pum_popup_content', 'shortcode_unautop' );
 		add_filter( 'pum_popup_content', 'prepend_attachment' );
-		add_filter( 'pum_popup_content', 'wp_make_content_images_responsive' );
+		if ( version_compare( $wp_version, '5.5', '>=' ) ) {
+			add_filter( 'pum_popup_content', 'wp_filter_content_tags' );
+		} else {
+			add_filter( 'pum_popup_content', 'wp_make_content_images_responsive' );
+		}
 
 		/**
 		 * Copied & from wp-includes/default-filters.php:172:178.
@@ -67,7 +71,7 @@ class PUM_Site {
 		 * @since 1.10.0
 		 * @sinceWP 5.4
 		 */
-		$do_shortcode_handler = pum_get_option( 'disable_shortcode_compatibility_mode' ) ? 'do_shortcode' : ['PUM_Helpers', 'do_shortcode' ];
+		$do_shortcode_handler = pum_get_option( 'disable_shortcode_compatibility_mode' ) ? 'do_shortcode' : array( 'PUM_Helpers', 'do_shortcode' );
 		add_filter( 'pum_popup_content', $do_shortcode_handler, 11 );
 	}
 
@@ -92,7 +96,7 @@ class PUM_Site {
 		$priority = has_filter( 'pum_popup_content', 'wpautop' );
 		if ( false !== $priority && doing_filter( 'pum_popup_content' ) && has_blocks( $content ) ) {
 			remove_filter( 'pum_popup_content', 'wpautop', $priority );
-			add_filter( 'pum_popup_content', [ __CLASS__, '_restore_wpautop_hook' ], $priority + 1 );
+			add_filter( 'pum_popup_content', array( __CLASS__, '_restore_wpautop_hook' ), $priority + 1 );
 		}
 
 		return $output;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "popup-maker",
-  "version": "1.11.1",
+  "version": "1.11.2",
   "description": "WordPress Popup Plugin",
   "homepage": "https://wppopupmaker.com",
   "author": "Code Atlantic LLC",

--- a/popup-maker.php
+++ b/popup-maker.php
@@ -3,7 +3,7 @@
  * Plugin Name:  Popup Maker
  * Plugin URI:   https://wppopupmaker.com/?utm_campaign=PluginInfo&utm_source=plugin-header&utm_medium=plugin-uri
  * Description:  Easily create & style popups with any content. Theme editor to quickly style your popups. Add forms, social media boxes, videos & more.
- * Version:      1.11.1
+ * Version:      1.11.2
  * Author:       Popup Maker
  * Author URI:   https://wppopupmaker.com/?utm_campaign=PluginInfo&utm_source=plugin-header&utm_medium=author-uri
  * License:      GPL2 or later
@@ -93,7 +93,7 @@ class Popup_Maker {
 	/**
 	 * @var string Plugin Version
 	 */
-	public static $VER = '1.11.1';
+	public static $VER = '1.11.2';
 
 	/**
 	 * @var int DB Version

--- a/readme.txt
+++ b/readme.txt
@@ -136,8 +136,9 @@ There are several common causes for this, check [this guide for help](https://do
 
 View our [complete changelog](https://github.com/PopupMaker/Popup-Maker/blob/master/CHANGELOG.md) for up-to-date information on what has been going on with the development of Popup Maker.
 
-= v1.11.2 - 08/12/2020 =
+= v1.11.2 - 08/14/2020 =
 * Fix: `wp_make_content_images_responsive` is deprecated, use `wp_filter_content_tags()` instead
+* Fix: IE 11 does not support JS Promises
 
 = v1.11.1 - 07/22/2020 =
 * Fix: Form submission cookies no longer set with Contact Form 7 5.2

--- a/readme.txt
+++ b/readme.txt
@@ -5,9 +5,9 @@ Plugin URI: https://wppopupmaker.com/?utm_capmaign=Readme&utm_source=readme-head
 Donate link:
 Tags:  marketing, popup, popups, optin, advertising, conversion, responsive popups, promotion, popover, pop-up, pop over, lightbox, conversion, modal
 Requires at least: 4.1
-Tested up to: 5.4
+Tested up to: 5.5
 Requires PHP: 5.6
-Stable tag: 1.11.1
+Stable tag: 1.11.2
 License: GPLv2 or later
 License URI:  http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -135,6 +135,9 @@ There are several common causes for this, check [this guide for help](https://do
 == Changelog ==
 
 View our [complete changelog](https://github.com/PopupMaker/Popup-Maker/blob/master/CHANGELOG.md) for up-to-date information on what has been going on with the development of Popup Maker.
+
+= v1.11.2 - 08/12/2020 =
+* Fix: `wp_make_content_images_responsive` is deprecated, use `wp_filter_content_tags()` instead
 
 = v1.11.1 - 07/22/2020 =
 * Fix: Form submission cookies no longer set with Contact Form 7 5.2

--- a/readme.txt
+++ b/readme.txt
@@ -136,9 +136,10 @@ There are several common causes for this, check [this guide for help](https://do
 
 View our [complete changelog](https://github.com/PopupMaker/Popup-Maker/blob/master/CHANGELOG.md) for up-to-date information on what has been going on with the development of Popup Maker.
 
-= v1.11.2 - 08/14/2020 =
+= v1.11.2 - 08/17/2020 =
 * Fix: `wp_make_content_images_responsive` is deprecated, use `wp_filter_content_tags()` instead
 * Fix: IE 11 does not support JS Promises
+* Fix: Missing permission_callback on REST endpoint
 
 = v1.11.1 - 07/22/2020 =
 * Fix: Form submission cookies no longer set with Contact Form 7 5.2


### PR DESCRIPTION
* Fix: `wp_make_content_images_responsive` is deprecated, use `wp_filter_content_tags()` instead
* Fix: IE 11 does not support JS Promises
* Fix: Missing permission_callback on REST endpoint

Fixes #852 and Fixes #867 and Fixes #870 