### PR TITLE
Conversion Counters

### DIFF
--- a/assets/js/src/integration/formidableforms.js
+++ b/assets/js/src/integration/formidableforms.js
@@ -10,7 +10,7 @@
 		const $form = $(form);
 		const formId = $form.find('input[name="form_id"]').val();
 		const $popup = PUM.getPopup(
-			$form.find('input[name="pum_form_popup_id "]').val()
+			$form.find('input[name="pum_form_popup_id"]').val()
 		);
 
 		// All the magic happens here.

--- a/assets/js/src/integration/formidableforms.js
+++ b/assets/js/src/integration/formidableforms.js
@@ -9,9 +9,13 @@
 	$(document).on("frmFormComplete", function(event, form, response) {
 		const $form = $(form);
 		const formId = $form.find('input[name="form_id"]').val();
+		const $popup = PUM.getPopup(
+			$form.find('input[name="pum_form_popup_id "]').val()
+		);
 
 		// All the magic happens here.
 		window.PUM.integrations.formSubmission($form, {
+			popup: $popup,
 			formProvider,
 			formId,
 			extras: {

--- a/assets/js/src/site/plugins/pum-analytics.js
+++ b/assets/js/src/site/plugins/pum-analytics.js
@@ -85,25 +85,28 @@ var PUM_Analytics;
 		 * Track form submission conversions
 		 */
 		$(function() {
-			PUM.hooks.addAction("pum.integration.form.success", function(form, args ) {
+			PUM.hooks.addAction("pum.integration.form.success", function(
+				form,
+				args
+			) {
 				// If the submission has already been counted in the backend, we can bail early.
 				if (args.ajax === false) {
 					return;
 				}
-				var $popup = PUM.getPopup(form),
-					data = {
-						pid:
-							parseInt($popup.popmake("getSettings").id, 10) ||
-							null,
-						event: "conversion"
-					};
+
+				// If no popup is included in the args, we can bail early since we only record conversions within popups.
+				if (args.popup.length === 0) {
+					return;
+				}
+				var data = {
+					pid:
+						parseInt(args.popup.popmake("getSettings").id, 10) ||
+						null,
+					event: "conversion"
+				};
 
 				// Shortcode popups use negative numbers, and single-popup (preview mode) shouldn't be tracked.
-				if (
-					$popup.length &&
-					data.pid > 0 &&
-					!$("body").hasClass("single-popup")
-				) {
+				if (data.pid > 0 && !$("body").hasClass("single-popup")) {
 					PUM_Analytics.beacon(data);
 				}
 			});

--- a/assets/js/src/site/plugins/pum-analytics.js
+++ b/assets/js/src/site/plugins/pum-analytics.js
@@ -4,63 +4,99 @@
  */
 
 var PUM_Analytics;
-(function ($) {
-    "use strict";
+(function($) {
+	"use strict";
 
-    $.fn.popmake.last_open_trigger = null;
-    $.fn.popmake.last_close_trigger = null;
-    $.fn.popmake.conversion_trigger = null;
+	$.fn.popmake.last_open_trigger = null;
+	$.fn.popmake.last_close_trigger = null;
+	$.fn.popmake.conversion_trigger = null;
 
-    var rest_enabled = !!(typeof pum_vars.restapi !== 'undefined' && pum_vars.restapi);
+	var rest_enabled = !!(
+		typeof pum_vars.restapi !== "undefined" && pum_vars.restapi
+	);
 
-    PUM_Analytics = {
-        beacon: function (data, callback) {
-            var beacon = new Image(),
-                url = rest_enabled ? pum_vars.restapi : pum_vars.ajaxurl,
-                opts = {
-                    route: pum.hooks.applyFilters( 'pum.analyticsBeaconRoute', '/analytics/' ),
-                    data: pum.hooks.applyFilters( 'pum.AnalyticsBeaconData', $.extend( true, {
-                        event: 'open',
-                        pid: null,
-                        _cache: (+(new Date()))
-                    }, data ) ),
-                    callback: typeof callback === 'function' ? callback : function () {
-                    }
-                };
+	PUM_Analytics = {
+		beacon: function(data, callback) {
+			var beacon = new Image(),
+				url = rest_enabled ? pum_vars.restapi : pum_vars.ajaxurl,
+				opts = {
+					route: pum.hooks.applyFilters(
+						"pum.analyticsBeaconRoute",
+						"/analytics/"
+					),
+					data: pum.hooks.applyFilters(
+						"pum.AnalyticsBeaconData",
+						$.extend(
+							true,
+							{
+								event: "open",
+								pid: null,
+								_cache: +new Date()
+							},
+							data
+						)
+					),
+					callback:
+						typeof callback === "function"
+							? callback
+							: function() {}
+				};
 
-            if (!rest_enabled) {
-                opts.data.action = 'pum_analytics';
-            } else {
-                url += opts.route;
-            }
+			if (!rest_enabled) {
+				opts.data.action = "pum_analytics";
+			} else {
+				url += opts.route;
+			}
 
-            // Create a beacon if a url is provided
-            if (url) {
-                // Attach the event handlers to the image object
-                $(beacon).on('error success load done', opts.callback);
+			// Create a beacon if a url is provided
+			if (url) {
+				// Attach the event handlers to the image object
+				$(beacon).on("error success load done", opts.callback);
 
-                // Attach the src for the script call
-                beacon.src = url + '?' + $.param(opts.data);
-            }
-        }
-    };
+				// Attach the src for the script call
+				beacon.src = url + "?" + $.param(opts.data);
+			}
+		}
+	};
 
-    if (typeof pum_vars.disable_tracking === 'undefined' || !pum_vars.disable_tracking) {
-        // Only popups from the editor should fire analytics events.
-        $(document)
-        /**
-         * Track opens for popups.
-         */
-            .on('pumAfterOpen.core_analytics', '.pum', function () {
-                var $popup = PUM.getPopup(this),
-                    data = {
-                        pid: parseInt($popup.popmake('getSettings').id, 10) || null
-                    };
+	if (
+		typeof pum_vars.disable_tracking === "undefined" ||
+		!pum_vars.disable_tracking
+	) {
+		// Only popups from the editor should fire analytics events.
+		$(document)
+			/**
+			 * Track opens for popups.
+			 */
+			.on("pumAfterOpen.core_analytics", ".pum", function() {
+				var $popup = PUM.getPopup(this),
+					data = {
+						pid:
+							parseInt($popup.popmake("getSettings").id, 10) ||
+							null
+					};
 
-                // Shortcode popups use negative numbers, and single-popup (preview mode) shouldn't be tracked.
-                if (data.pid > 0 && !$('body').hasClass('single-popup')) {
-                    PUM_Analytics.beacon(data);
-                }
-            });
-    }
-}(jQuery));
+				// Shortcode popups use negative numbers, and single-popup (preview mode) shouldn't be tracked.
+				if (data.pid > 0 && !$("body").hasClass("single-popup")) {
+					PUM_Analytics.beacon(data);
+				}
+			})
+			/**
+			 * Track form submission conversions
+			 */
+			.on("pum.integration.form.success", function() {
+				var $popup = PUM.getPopup(this),
+					data = {
+						pid:
+							parseInt($popup.popmake("getSettings").id, 10) ||
+							null,
+						event: "conversion"
+					};
+
+				// Shortcode popups use negative numbers, and single-popup (preview mode) shouldn't be tracked.
+				if (data.pid > 0 && !$("body").hasClass("single-popup")) {
+					PUM_Analytics.beacon(data);
+				}
+			});
+	}
+})(jQuery);

--- a/assets/js/src/site/plugins/pum-analytics.js
+++ b/assets/js/src/site/plugins/pum-analytics.js
@@ -80,12 +80,13 @@ var PUM_Analytics;
 				if (data.pid > 0 && !$("body").hasClass("single-popup")) {
 					PUM_Analytics.beacon(data);
 				}
-			})
-			/**
-			 * Track form submission conversions
-			 */
-			.on("pum.integration.form.success", function() {
-				var $popup = PUM.getPopup(this),
+			});
+		/**
+		 * Track form submission conversions
+		 */
+		$(function() {
+			PUM.hooks.addAction("pum.integration.form.success", function(form, args) {
+				var $popup = PUM.getPopup(form),
 					data = {
 						pid:
 							parseInt($popup.popmake("getSettings").id, 10) ||
@@ -94,9 +95,14 @@ var PUM_Analytics;
 					};
 
 				// Shortcode popups use negative numbers, and single-popup (preview mode) shouldn't be tracked.
-				if (data.pid > 0 && !$("body").hasClass("single-popup")) {
+				if (
+					$popup.length &&
+					data.pid > 0 &&
+					!$("body").hasClass("single-popup")
+				) {
 					PUM_Analytics.beacon(data);
 				}
 			});
+		});
 	}
 })(jQuery);

--- a/assets/js/src/site/plugins/pum-analytics.js
+++ b/assets/js/src/site/plugins/pum-analytics.js
@@ -85,7 +85,11 @@ var PUM_Analytics;
 		 * Track form submission conversions
 		 */
 		$(function() {
-			PUM.hooks.addAction("pum.integration.form.success", function(form, args) {
+			PUM.hooks.addAction("pum.integration.form.success", function(form, args ) {
+				// If the submission has already been counted in the backend, we can bail early.
+				if (args.ajax === false) {
+					return;
+				}
 				var $popup = PUM.getPopup(form),
 					data = {
 						pid:

--- a/classes/Admin/Popups.php
+++ b/classes/Admin/Popups.php
@@ -1317,8 +1317,7 @@ class PUM_Admin_Popups {
 	public static function sortable_columns( $columns ) {
 		$columns['popup_title'] = 'popup_title';
 		$columns['opens']       = 'opens';
-
-		// $columns['conversions'] = 'conversions';
+		$columns['conversions'] = 'conversions';
 
 		return $columns;
 	}
@@ -1350,7 +1349,6 @@ class PUM_Admin_Popups {
 							) );
 						}
 						break;
-					/*
 					case 'conversions':
 						if ( ! pum_extension_enabled( 'popup-analytics' ) ) {
 							$vars = array_merge( $vars, array(
@@ -1359,7 +1357,6 @@ class PUM_Admin_Popups {
 							) );
 						}
 						break;
-					*/
 				}
 			}
 		}

--- a/classes/Admin/Popups.php
+++ b/classes/Admin/Popups.php
@@ -1066,15 +1066,16 @@ class PUM_Admin_Popups {
 	public static function render_analytics_meta_box() {
 		global $post;
 
-		$popup = pum_get_popup( $post->ID ); ?>
+		$popup = pum_get_popup( $post->ID );
+		?>
 		<div id="pum-popup-analytics" class="pum-meta-box">
 
 			<?php do_action( 'pum_popup_analytics_metabox_before', $post->ID ); ?>
 
 			<?php
-			$opens = $popup->get_event_count( 'open', 'current' );
-			//$conversions     = $popup->get_event_count( 'conversion', 'current' );
-			//$conversion_rate = $opens > 0 && $opens >= $conversions ? $conversions / $opens * 100 : false;
+			$opens           = $popup->get_event_count( 'open' );
+			$conversions     = $popup->get_event_count( 'conversion' );
+			$conversion_rate = $opens > 0 && $opens >= $conversions ? $conversions / $opens * 100 : 0;
 			?>
 
 			<div id="pum-popup-analytics" class="pum-popup-analytics">
@@ -1082,42 +1083,38 @@ class PUM_Admin_Popups {
 				<table class="form-table">
 					<tbody>
 					<tr>
-						<td><?php _e( 'Opens', 'popup-maker' ); ?></td>
-						<td><?php echo $opens; ?></td>
+						<td><?php esc_html_e( 'Opens', 'popup-maker' ); ?></td>
+						<td><?php echo esc_html( $opens ); ?></td>
 					</tr>
-					<?php /* if ( $conversion_rate > 0 ) : ?>
-						<tr>
-							<td><?php _e( 'Conversions', 'popup-maker' ); ?></td>
-							<td><?php echo $conversions; ?></td>
-						</tr>
-					<?php endif; */ ?>
-					<?php /* if ( $conversion_rate > 0 ) : ?>
-						<tr>
-							<td><?php _e( 'Conversion Rate', 'popup-maker' ); ?></td>
-							<td><?php echo round( $conversion_rate, 2 ); ?>%</td>
-						</tr>
-					<?php endif; */ ?>
+					<tr>
+						<td><?php esc_html_e( 'Conversions', 'popup-maker' ); ?></td>
+						<td><?php echo esc_html( $conversions ); ?></td>
+					</tr>
+					<tr>
+						<td><?php esc_html_e( 'Conversion Rate', 'popup-maker' ); ?></td>
+						<td><?php echo esc_html( round( $conversion_rate, 2 ) ); ?>%</td>
+					</tr>
 					<tr class="separator">
 						<td colspan="2">
 							<label> <input type="checkbox" name="popup_reset_counts" id="popup_reset_counts" value="1" />
-								<?php _e( 'Reset Counts', 'popup-maker' ); ?>
+								<?php esc_html_e( 'Reset Counts', 'popup-maker' ); ?>
 							</label>
 							<?php if ( ( $reset = $popup->get_last_count_reset() ) ) : ?><br />
 								<small>
-									<strong><?php _e( 'Last Reset', 'popup-maker' ); ?>:</strong> <?php echo date( 'm-d-Y H:i', $reset['timestamp'] ); ?>
-									<br /> <strong><?php _e( 'Previous Opens', 'popup-maker' ); ?>:</strong> <?php echo $reset['opens']; ?>
+									<strong><?php esc_html_e( 'Last Reset', 'popup-maker' ); ?>:</strong> <?php echo esc_html( date( 'm-d-Y H:i', $reset['timestamp'] ) ); ?>
+									<br /> <strong><?php esc_html_e( 'Previous Opens', 'popup-maker' ); ?>:</strong> <?php echo esc_html( $reset['opens'] ); ?>
 
-									<?php /* if ( $reset['conversions'] > 0 ) : ?>
+									<?php if ( $reset['conversions'] > 0 ) : ?>
 										<br />
-										<strong><?php _e( 'Previous Conversions', 'popup-maker' ); ?>:</strong> <?php echo $reset['conversions']; ?>
-									<?php endif; */ ?>
+										<strong><?php esc_html_e( 'Previous Conversions', 'popup-maker' ); ?>:</strong> <?php echo esc_html( $reset['conversions'] ); ?>
+									<?php endif; ?>
 
-									<br /> <strong><?php _e( 'Lifetime Opens', 'popup-maker' ); ?>:</strong> <?php echo $popup->get_event_count( 'open', 'total' ); ?>
+									<br /> <strong><?php esc_html_e( 'Lifetime Opens', 'popup-maker' ); ?>:</strong> <?php echo esc_html( $popup->get_event_count( 'open', 'total' ) ); ?>
 
-									<?php /* if ( $popup->get_event_count( 'conversion', 'total' ) > 0 ) : ?>
+									<?php if ( $popup->get_event_count( 'conversion', 'total' ) > 0 ) : ?>
 										<br />
-										<strong><?php _e( 'Lifetime Conversions', 'popup-maker' ); ?>:</strong> <?php echo $popup->get_event_count( 'conversion', 'total' ); ?>
-									<?php endif; */ ?>
+										<strong><?php esc_html_e( 'Lifetime Conversions', 'popup-maker' ); ?>:</strong> <?php echo esc_html( $popup->get_event_count( 'conversion', 'total' ) ); ?>
+									<?php endif; ?>
 								</small>
 							<?php endif; ?>
 						</td>

--- a/classes/Admin/Popups.php
+++ b/classes/Admin/Popups.php
@@ -1275,15 +1275,17 @@ class PUM_Admin_Popups {
 					}
 					break;
 				case 'conversion_rate':
-					$opens       = $popup->get_event_count( 'open' );
-					$conversions = $popup->get_event_count( 'conversion' );
+					if ( ! pum_extension_enabled( 'popup-analytics' ) ) {
+						$opens       = $popup->get_event_count( 'open' );
+						$conversions = $popup->get_event_count( 'conversion' );
 
-					if ( $opens > 0 && $opens >= $conversions ) {
-						$conversion_rate = round( $conversions / $opens * 100, 2 );
-					} else {
-						$conversion_rate = 0;
+						if ( $opens > 0 && $opens >= $conversions ) {
+							$conversion_rate = round( $conversions / $opens * 100, 2 );
+						} else {
+							$conversion_rate = 0;
+						}
+						echo esc_html( $conversion_rate . '%' );
 					}
-					echo esc_html( $conversion_rate . '%' );
 					break;
 			}
 		}

--- a/classes/Admin/Popups.php
+++ b/classes/Admin/Popups.php
@@ -1196,8 +1196,8 @@ class PUM_Admin_Popups {
 			'popup_title' => __( 'Title', 'popup-maker' ),
 			'class'       => __( 'CSS Class', 'popup-maker' ),
 			'opens'       => __( 'Opens', 'popup-maker' ),
-			//'conversions'     => __( 'Conversions', 'popup-maker' ),
-			//'conversion_rate' => __( 'Conversion Rate', 'popup-maker' ),
+			'conversions'     => __( 'Conversions', 'popup-maker' ),
+			'conversion_rate' => __( 'Conversion Rate', 'popup-maker' ),
 		);
 
 		// Add the date column preventing our own translation.
@@ -1273,7 +1273,6 @@ class PUM_Admin_Popups {
 					}
 					break;
 
-				/*
 				 case 'conversions':
 					if ( ! pum_extension_enabled( 'popup-analytics' ) ) {
 						echo $popup->get_event_count( 'conversion' );
@@ -1286,7 +1285,6 @@ class PUM_Admin_Popups {
 					$conversion_rate = $views > 0 && $views >= $conversions ? $conversions / $views * 100 : __( 'N/A', 'popup-maker' );
 					echo round( $conversion_rate, 2 ) . '%';
 					break;
-				*/
 			}
 		}
 	}

--- a/classes/Admin/Popups.php
+++ b/classes/Admin/Popups.php
@@ -1269,21 +1269,24 @@ class PUM_Admin_Popups {
 					break;
 				case 'opens':
 					if ( ! pum_extension_enabled( 'popup-analytics' ) ) {
-						echo $popup->get_event_count( 'open' );
+						echo esc_html( $popup->get_event_count( 'open' ) );
 					}
 					break;
-
-				 case 'conversions':
+				case 'conversions':
 					if ( ! pum_extension_enabled( 'popup-analytics' ) ) {
-						echo $popup->get_event_count( 'conversion' );
+						echo esc_html( $popup->get_event_count( 'conversion' ) );
 					}
 					break;
 				case 'conversion_rate':
-					$views       = $popup->get_event_count( 'view', 'current' );
-					$conversions = $popup->get_event_count( 'conversion', 'current' );
+					$opens       = $popup->get_event_count( 'open' );
+					$conversions = $popup->get_event_count( 'conversion' );
 
-					$conversion_rate = $views > 0 && $views >= $conversions ? $conversions / $views * 100 : __( 'N/A', 'popup-maker' );
-					echo round( $conversion_rate, 2 ) . '%';
+					if ( $opens > 0 && $opens >= $conversions ) {
+						$conversion_rate = round( $conversions / $opens * 100, 2 );
+					} else {
+						$conversion_rate = 0;
+					}
+					echo esc_html( $conversion_rate . '%' );
 					break;
 			}
 		}

--- a/classes/Integration/Form/CalderaForms.php
+++ b/classes/Integration/Form/CalderaForms.php
@@ -63,8 +63,20 @@ class PUM_Integration_Form_CalderaForms extends PUM_Abstract_Integration_Form {
 	 * @param array $form
 	 */
 	public function on_success( $form ) {
+		if ( ! isset( $_REQUEST['pum_form_popup_id'] ) ) {
+			return;
+		}
+
+		$popup_id = absint( $_REQUEST['pum_form_popup_id'] );
+		if ( 0 === $popup_id ) {
+			return;
+		}
+
+		$popup = pum_get_popup( $popup_id );
+		$popup->increase_event_count( 'conversion' );
+
 		pum_integrated_form_submission( [
-			'popup_id'      => isset( $_REQUEST['pum_form_popup_id'] ) && absint( $_REQUEST['pum_form_popup_id'] ) > 0 ? absint( $_REQUEST['pum_form_popup_id'] ) : false,
+			'popup_id'      => $popup_id,
 			'form_provider' => $this->key,
 			'form_id'       => $form['ID'],
 		] );

--- a/classes/Integration/Form/CalderaForms.php
+++ b/classes/Integration/Form/CalderaForms.php
@@ -63,16 +63,8 @@ class PUM_Integration_Form_CalderaForms extends PUM_Abstract_Integration_Form {
 	 * @param array $form
 	 */
 	public function on_success( $form ) {
-		if ( ! isset( $_REQUEST['pum_form_popup_id'] ) ) {
-			return;
-		}
-
-		$popup_id = absint( $_REQUEST['pum_form_popup_id'] );
-		if ( 0 === $popup_id ) {
-			return;
-		}
-
-		$popup = pum_get_popup( $popup_id );
+		$popup_id = isset( $_REQUEST['pum_form_popup_id'] ) && absint( $_REQUEST['pum_form_popup_id'] ) > 0 ? absint( $_REQUEST['pum_form_popup_id'] ) : false;
+		$popup    = pum_get_popup( $popup_id );
 		$popup->increase_event_count( 'conversion' );
 
 		pum_integrated_form_submission( [

--- a/classes/Integration/Form/ContactForm7.php
+++ b/classes/Integration/Form/ContactForm7.php
@@ -88,16 +88,8 @@ class PUM_Integration_Form_ContactForm7 extends PUM_Abstract_Integration_Form {
 	 */
 	public function on_success( $cfdata ) {
 
-		if ( ! isset( $_REQUEST['pum_form_popup_id'] ) ) {
-			return;
-		}
-
-		$popup_id = absint( $_REQUEST['pum_form_popup_id'] );
-		if ( 0 === $popup_id ) {
-			return;
-		}
-
-		$popup = pum_get_popup( $popup_id );
+		$popup_id = isset( $_REQUEST['pum_form_popup_id'] ) && absint( $_REQUEST['pum_form_popup_id'] ) > 0 ? absint( $_REQUEST['pum_form_popup_id'] ) : false;
+		$popup    = pum_get_popup( $popup_id );
 		$popup->increase_event_count( 'conversion' );
 
 		pum_integrated_form_submission( [

--- a/classes/Integration/Form/ContactForm7.php
+++ b/classes/Integration/Form/ContactForm7.php
@@ -87,11 +87,21 @@ class PUM_Integration_Form_ContactForm7 extends PUM_Abstract_Integration_Form {
 	 * @param WPCF7_ContactForm $cfdata
 	 */
 	public function on_success( $cfdata ) {
-		/**
-		 * @see pum_integrated_form_submission
-		 */
+
+		if ( ! isset( $_REQUEST['pum_form_popup_id'] ) ) {
+			return;
+		}
+
+		$popup_id = absint( $_REQUEST['pum_form_popup_id'] );
+		if ( 0 === $popup_id ) {
+			return;
+		}
+
+		$popup = pum_get_popup( $popup_id );
+		$popup->increase_event_count( 'conversion' );
+
 		pum_integrated_form_submission( [
-			'popup_id'      => isset( $_REQUEST['pum_form_popup_id'] ) && absint( $_REQUEST['pum_form_popup_id'] ) > 0 ? absint( $_REQUEST['pum_form_popup_id'] ) : false,
+			'popup_id'      => $popup_id,
 			'form_provider' => $this->key,
 			'form_id'       => $cfdata->id(),
 		] );

--- a/classes/Integration/Form/FormidableForms.php
+++ b/classes/Integration/Form/FormidableForms.php
@@ -95,16 +95,8 @@ class PUM_Integration_Form_FormidableForms extends PUM_Abstract_Integration_Form
 			return;
 		}
 
-		if ( ! isset( $_REQUEST['pum_form_popup_id'] ) ) {
-			return;
-		}
-
-		$popup_id = absint( $_REQUEST['pum_form_popup_id'] );
-		if ( 0 === $popup_id ) {
-			return;
-		}
-
-		$popup = pum_get_popup( $popup_id );
+		$popup_id = isset( $_REQUEST['pum_form_popup_id'] ) && absint( $_REQUEST['pum_form_popup_id'] ) > 0 ? absint( $_REQUEST['pum_form_popup_id'] ) : false;
+		$popup    = pum_get_popup( $popup_id );
 		$popup->increase_event_count( 'conversion' );
 
 		pum_integrated_form_submission(

--- a/classes/Integration/Form/FormidableForms.php
+++ b/classes/Integration/Form/FormidableForms.php
@@ -95,10 +95,21 @@ class PUM_Integration_Form_FormidableForms extends PUM_Abstract_Integration_Form
 			return;
 		}
 
-		// @see pum_integrated_form_submission
+		if ( ! isset( $_REQUEST['pum_form_popup_id'] ) ) {
+			return;
+		}
+
+		$popup_id = absint( $_REQUEST['pum_form_popup_id'] );
+		if ( 0 === $popup_id ) {
+			return;
+		}
+
+		$popup = pum_get_popup( $popup_id );
+		$popup->increase_event_count( 'conversion' );
+
 		pum_integrated_form_submission(
 			[
-				'popup_id'      => isset( $_REQUEST['pum_form_popup_id'] ) && absint( $_REQUEST['pum_form_popup_id'] ) > 0 ? absint( $_REQUEST['pum_form_popup_id'] ) : false,
+				'popup_id'      => $popup_id,
 				'form_provider' => $this->key,
 				'form_id'       => $form_id,
 			]

--- a/classes/Integration/Form/GravityForms.php
+++ b/classes/Integration/Form/GravityForms.php
@@ -65,16 +65,8 @@ class PUM_Integration_Form_GravityForms extends PUM_Abstract_Integration_Form {
 	 * @param $form
 	 */
 	public function on_success( $entry, $form ) {
-		if ( ! isset( $_REQUEST['pum_form_popup_id'] ) ) {
-			return;
-		}
-
-		$popup_id = absint( $_REQUEST['pum_form_popup_id'] );
-		if ( 0 === $popup_id ) {
-			return;
-		}
-
-		$popup = pum_get_popup( $popup_id );
+		$popup_id = isset( $_REQUEST['pum_form_popup_id'] ) && absint( $_REQUEST['pum_form_popup_id'] ) > 0 ? absint( $_REQUEST['pum_form_popup_id'] ) : false;
+		$popup    = pum_get_popup( $popup_id );
 		$popup->increase_event_count( 'conversion' );
 
 		pum_integrated_form_submission( [

--- a/classes/Integration/Form/GravityForms.php
+++ b/classes/Integration/Form/GravityForms.php
@@ -65,8 +65,20 @@ class PUM_Integration_Form_GravityForms extends PUM_Abstract_Integration_Form {
 	 * @param $form
 	 */
 	public function on_success( $entry, $form ) {
+		if ( ! isset( $_REQUEST['pum_form_popup_id'] ) ) {
+			return;
+		}
+
+		$popup_id = absint( $_REQUEST['pum_form_popup_id'] );
+		if ( 0 === $popup_id ) {
+			return;
+		}
+
+		$popup = pum_get_popup( $popup_id );
+		$popup->increase_event_count( 'conversion' );
+
 		pum_integrated_form_submission( [
-			'popup_id'      => isset( $_REQUEST['pum_form_popup_id'] ) && absint( $_REQUEST['pum_form_popup_id'] ) > 0 ? absint( $_REQUEST['pum_form_popup_id'] ) : false,
+			'popup_id'      => $popup_id,
 			'form_provider' => $this->key,
 			'form_id'       => $form['id'],
 		] );

--- a/classes/Integration/Form/NinjaForms.php
+++ b/classes/Integration/Form/NinjaForms.php
@@ -66,16 +66,8 @@ class PUM_Integration_Form_NinjaForms extends PUM_Abstract_Integration_Form {
 	public function on_success_v2() {
 		global $ninja_forms_processing;
 
-		if ( ! isset( $_REQUEST['pum_form_popup_id'] ) ) {
-			return;
-		}
-
-		$popup_id = absint( $_REQUEST['pum_form_popup_id'] );
-		if ( 0 === $popup_id ) {
-			return;
-		}
-
-		$popup = pum_get_popup( $popup_id );
+		$popup_id = isset( $_REQUEST['pum_form_popup_id'] ) && absint( $_REQUEST['pum_form_popup_id'] ) > 0 ? absint( $_REQUEST['pum_form_popup_id'] ) : false;
+		$popup    = pum_get_popup( $popup_id );
 		$popup->increase_event_count( 'conversion' );
 
 		pum_integrated_form_submission( [

--- a/classes/Integration/Form/NinjaForms.php
+++ b/classes/Integration/Form/NinjaForms.php
@@ -65,8 +65,21 @@ class PUM_Integration_Form_NinjaForms extends PUM_Abstract_Integration_Form {
 	 */
 	public function on_success_v2() {
 		global $ninja_forms_processing;
+
+		if ( ! isset( $_REQUEST['pum_form_popup_id'] ) ) {
+			return;
+		}
+
+		$popup_id = absint( $_REQUEST['pum_form_popup_id'] );
+		if ( 0 === $popup_id ) {
+			return;
+		}
+
+		$popup = pum_get_popup( $popup_id );
+		$popup->increase_event_count( 'conversion' );
+
 		pum_integrated_form_submission( [
-			'popup_id'      => isset( $_REQUEST['pum_form_popup_id'] ) && absint( $_REQUEST['pum_form_popup_id'] ) > 0 ? absint( $_REQUEST['pum_form_popup_id'] ) : false,
+			'popup_id'      => $popup_id,
 			'form_provider' => $this->key,
 			'form_id'       => $ninja_forms_processing->get_form_ID(),
 		] );
@@ -76,8 +89,19 @@ class PUM_Integration_Form_NinjaForms extends PUM_Abstract_Integration_Form {
 	 * @param $form_data
 	 */
 	public function on_success_v3( $form_data ) {
+		if ( ! isset( $_REQUEST['pum_form_popup_id'] ) ) {
+			return;
+		}
+
+		$popup_id = absint( $_REQUEST['pum_form_popup_id'] );
+		if ( 0 === $popup_id ) {
+			return;
+		}
+
+		$popup = pum_get_popup( $popup_id );
+		$popup->increase_event_count( 'conversion' );
 		pum_integrated_form_submission( [
-			'popup_id'      => isset( $_REQUEST['pum_form_popup_id'] ) && absint( $_REQUEST['pum_form_popup_id'] ) > 0 ? absint( $_REQUEST['pum_form_popup_id'] ) : false,
+			'popup_id'      => $popup_id,
 			'form_provider' => $this->key,
 			'form_id'       => $form_data['form_id'],
 		] );

--- a/classes/Integration/Form/PirateForms.php
+++ b/classes/Integration/Form/PirateForms.php
@@ -127,16 +127,8 @@ class PUM_Integration_Form_PirateForms extends PUM_Abstract_Integration_Form {
 	 * @param int $entry_id Entry ID. Will return 0 if entry storage is disabled or using WPForms Lite.
 	 */
 	public function on_success( $fields, $entry, $form_data, $entry_id ) {
-		if ( ! isset( $_REQUEST['pum_form_popup_id'] ) ) {
-			return;
-		}
-
-		$popup_id = absint( $_REQUEST['pum_form_popup_id'] );
-		if ( 0 === $popup_id ) {
-			return;
-		}
-
-		$popup = pum_get_popup( $popup_id );
+		$popup_id = isset( $_REQUEST['pum_form_popup_id'] ) && absint( $_REQUEST['pum_form_popup_id'] ) > 0 ? absint( $_REQUEST['pum_form_popup_id'] ) : false;
+		$popup    = pum_get_popup( $popup_id );
 		$popup->increase_event_count( 'conversion' );
 		pum_integrated_form_submission( [
 			'popup_id'      => $popup_id,

--- a/classes/Integration/Form/PirateForms.php
+++ b/classes/Integration/Form/PirateForms.php
@@ -127,8 +127,19 @@ class PUM_Integration_Form_PirateForms extends PUM_Abstract_Integration_Form {
 	 * @param int $entry_id Entry ID. Will return 0 if entry storage is disabled or using WPForms Lite.
 	 */
 	public function on_success( $fields, $entry, $form_data, $entry_id ) {
+		if ( ! isset( $_REQUEST['pum_form_popup_id'] ) ) {
+			return;
+		}
+
+		$popup_id = absint( $_REQUEST['pum_form_popup_id'] );
+		if ( 0 === $popup_id ) {
+			return;
+		}
+
+		$popup = pum_get_popup( $popup_id );
+		$popup->increase_event_count( 'conversion' );
 		pum_integrated_form_submission( [
-			'popup_id'      => isset( $_REQUEST['pum_form_popup_id'] ) && absint( $_REQUEST['pum_form_popup_id'] ) > 0 ? absint( $_REQUEST['pum_form_popup_id'] ) : false,
+			'popup_id'      => $popup_id,
 			'form_provider' => $this->key,
 			'form_id'       => $form_data['id'],
 		] );

--- a/classes/Integration/Form/WPForms.php
+++ b/classes/Integration/Form/WPForms.php
@@ -70,16 +70,8 @@ class PUM_Integration_Form_WPForms extends PUM_Abstract_Integration_Form {
 	 * @param int $entry_id Entry ID. Will return 0 if entry storage is disabled or using WPForms Lite.
 	 */
 	public function on_success( $fields, $entry, $form_data, $entry_id ) {
-		if ( ! isset( $_REQUEST['pum_form_popup_id'] ) ) {
-			return;
-		}
-
-		$popup_id = absint( $_REQUEST['pum_form_popup_id'] );
-		if ( 0 === $popup_id ) {
-			return;
-		}
-
-		$popup = pum_get_popup( $popup_id );
+		$popup_id = isset( $_REQUEST['pum_form_popup_id'] ) && absint( $_REQUEST['pum_form_popup_id'] ) > 0 ? absint( $_REQUEST['pum_form_popup_id'] ) : false;
+		$popup    = pum_get_popup( $popup_id );
 		$popup->increase_event_count( 'conversion' );
 		pum_integrated_form_submission( [
 			'popup_id'      => $popup_id,

--- a/classes/Integration/Form/WPForms.php
+++ b/classes/Integration/Form/WPForms.php
@@ -70,8 +70,19 @@ class PUM_Integration_Form_WPForms extends PUM_Abstract_Integration_Form {
 	 * @param int $entry_id Entry ID. Will return 0 if entry storage is disabled or using WPForms Lite.
 	 */
 	public function on_success( $fields, $entry, $form_data, $entry_id ) {
+		if ( ! isset( $_REQUEST['pum_form_popup_id'] ) ) {
+			return;
+		}
+
+		$popup_id = absint( $_REQUEST['pum_form_popup_id'] );
+		if ( 0 === $popup_id ) {
+			return;
+		}
+
+		$popup = pum_get_popup( $popup_id );
+		$popup->increase_event_count( 'conversion' );
 		pum_integrated_form_submission( [
-			'popup_id'      => isset( $_REQUEST['pum_form_popup_id'] ) && absint( $_REQUEST['pum_form_popup_id'] ) > 0 ? absint( $_REQUEST['pum_form_popup_id'] ) : false,
+			'popup_id'      => $popup_id,
 			'form_provider' => $this->key,
 			'form_id'       => $form_data['id'],
 		] );


### PR DESCRIPTION
## Description
Adds basic conversion counters to popups to go with original open counters.

## Related Issue
Closes #775 

## Types of changes
Adds:
1. New columns on "All Popups" for conversions and conversion rate
2. Adds conversion info to Analytics meta box on popup editor
3. Adds an action to the form submission js to fire conversion increase to analytics endpoint
4. Adds an increase to conversion counter in the PHP code when forms are submitted without AJAX

## Screenshots
<!-- if applicable -->

## This has been tested in the following browsers
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

## Checklist:
- [x] My code has been tested in the latest version of WordPress.
- [x] My code does not have any warnings from ESLint.
- [x] My code does not have any warnings from StyleLint.
- [x] My code does not have any warnings from PHPCS.
- [x] My code follows the WordPress code style.
- [x] My code follows [the accessibility standards]( https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/).
- [x] All new functions and classes have code documentation.
