### PR TITLE
Adds new periodical tips

### DIFF
--- a/classes/Admin/Onboarding.php
+++ b/classes/Admin/Onboarding.php
@@ -289,11 +289,11 @@ class PUM_Admin_Onboarding {
 		$tips = array(
 			array(
 				'msg'  => 'Did you know: Popup Maker has a setting to let you try to bypass adblockers? Enabling it randomizes cache filenames and other endpoints to try to get around adblockers.',
-				'link' => 'http://localhost:10012/wp-admin/edit.php?post_type=popup&page=pum-settings#pum-settings_misc',
+				'link' => admin_url( 'edit.php?post_type=popup&page=pum-settings&tab=pum-settings_misc' ),
 			),
 			array(
 				'msg'  => "Want to use the block editor to create your popups? Enable it over on Popup Maker's settings page.",
-				'link' => 'http://localhost:10012/wp-admin/edit.php?post_type=popup&page=pum-settings',
+				'link' => admin_url( 'edit.php?post_type=popup&page=pum-settings' ),
 			),
 			array(
 				'msg'  => 'Using the Popup Maker menu in your admin bar, you can open and close popups, check conditions, reseet cookies, and more!',
@@ -309,7 +309,7 @@ class PUM_Admin_Onboarding {
 			$tips[] = array(
 				array(
 					'msg'  => 'Want to organize your popups? Enable categories on the settings page to group similar popups together!',
-					'link' => 'http://localhost:10012/wp-admin/edit.php?post_type=popup&page=pum-settings',
+					'link' => admin_url( 'edit.php?post_type=popup&page=pum-settings&tab=pum-settings_misc' ),
 				),
 			);
 		}

--- a/classes/Admin/Onboarding.php
+++ b/classes/Admin/Onboarding.php
@@ -346,7 +346,7 @@ class PUM_Admin_Onboarding {
 	 * @since 1.13.0
 	 */
 	public static function should_show_tip() {
-		return current_user_can( 'manage_options' ) && ! self::has_turned_off_tips();
+		return current_user_can( 'manage_options' ) && strtotime( self::get_installed_on() . ' +3 days' ) < time() && ! self::has_turned_off_tips();
 	}
 
 	/**
@@ -357,6 +357,20 @@ class PUM_Admin_Onboarding {
 	 */
 	public static function has_turned_off_tips() {
 		return true === pum_get_option( 'disable_tips', false ) || 1 === intval( pum_get_option( 'disable_tips', false ) );
+	}
+
+	/**
+	 * Get the datetime string for when PM was installed.
+	 *
+	 * @return string
+	 * @since 1.13.0
+	 */
+	public static function get_installed_on() {
+		$installed_on = get_option( 'pum_installed_on', false );
+		if ( ! $installed_on ) {
+			$installed_on = current_time( 'mysql' );
+		}
+		return $installed_on;
 	}
 
 	/**

--- a/classes/Admin/Onboarding.php
+++ b/classes/Admin/Onboarding.php
@@ -15,9 +15,53 @@ class PUM_Admin_Onboarding {
 	 * Enqueues and sets up pointers across our admin pages.
 	 */
 	public static function init() {
+		if ( is_admin() && current_user_can( 'manage_options' ) ) {
+			add_filter( 'pum_alert_list', array( __CLASS__, 'tips_alert' ) );
+		}
 		add_filter( 'pum_admin_pointers-popup', array( __CLASS__, 'popup_editor_main_tour' ) );
 		add_filter( 'pum_admin_pointers-edit-popup', array( __CLASS__, 'all_popups_main_tour' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'set_up_pointers' ) );
+	}
+
+	/**
+	 * Adds a 'tip' alert occasionally inside PM's admin area
+	 *
+	 * @param array $alerts The alerts currently in the alert system.
+	 * @return array Alerts for the alert system.
+	 * @since 1.13.0
+	 */
+	public static function tips_alert( $alerts ) {
+		if ( ! self::should_show_tip() ) {
+			return $alerts;
+		}
+
+		$tip = self::get_random_tip();
+
+		$alerts[] = array(
+			'code'        => 'pum_tip_alert',
+			'type'        => 'info',
+			'message'     => $tip['msg'],
+			'priority'    => 10,
+			'dismissible' => '1 month',
+			'global'      => false,
+			'actions'     => array(
+				array(
+					'primary' => true,
+					'type'    => 'link',
+					'action'  => '',
+					'href'    => $tip['link'],
+					'text'    => __( 'Learn more', 'popup-maker' ),
+				),
+				array(
+					'primary' => false,
+					'type'    => 'action',
+					'action'  => 'dismiss',
+					'text'    => __( 'Dismiss', 'popup-maker' ),
+				),
+			),
+		);
+
+		return $alerts;
 	}
 
 	/**
@@ -214,6 +258,24 @@ class PUM_Admin_Onboarding {
 	}
 
 	/**
+	 * Retrieves a random tip
+	 *
+	 * @return array An array containing tip
+	 * @since 1.13.0
+	 */
+	public static function get_random_tip() {
+		$tips = array(
+			array(
+				'msg'  => '',
+				'link' => '',
+			),
+		);
+
+		$random_tip = array_rand( $tips );
+		return $tips[ $random_tip ];
+	}
+
+	/**
 	 * Retrieves all dismissed pointers by user
 	 *
 	 * @param int|bool $user_id The ID of the user or false for current user.
@@ -235,8 +297,19 @@ class PUM_Admin_Onboarding {
 	}
 
 	/**
+	 * Whether or not we should show tip alert
+	 *
+	 * @return bool
+	 * @since 1.13.0
+	 */
+	public static function should_show_tip() {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
 	 * Ensures pointer is set up correctly.
-	 * @param array $pointer The pointer
+	 *
+	 * @param array $pointer The pointer.
 	 * @return bool
 	 * @since 1.11.0
 	 */

--- a/classes/Admin/Onboarding.php
+++ b/classes/Admin/Onboarding.php
@@ -266,8 +266,12 @@ class PUM_Admin_Onboarding {
 	public static function get_random_tip() {
 		$tips = array(
 			array(
-				'msg'  => '',
-				'link' => '',
+				'msg'  => 'Did you know: Popup Maker has a setting to let you try to bypass adblockers? Enabling it randomizes cache filenames and other endpoints to try to get around adblockers.',
+				'link' => 'http://localhost:10012/wp-admin/edit.php?post_type=popup&page=pum-settings#pum-settings_misc',
+			),
+			array(
+				'msg'  => "Want to use the block editor to create your popups? Enable it over on Popup Maker's settings page.",
+				'link' => 'http://localhost:10012/wp-admin/edit.php?post_type=popup&page=pum-settings',
 			),
 		);
 

--- a/classes/Admin/Settings.php
+++ b/classes/Admin/Settings.php
@@ -490,6 +490,10 @@ class PUM_Admin_Settings {
 							'type'  => 'checkbox',
 							'label' => __( 'Disable the Popup Maker shortcode button', 'popup-maker' ),
 						),
+						'disable_tips'                 => array(
+							'type'  => 'checkbox',
+							'label' => __( 'Disable Popup Maker occasionally showing random tips to improve your popups.', 'popup-maker' ),
+						),
 						'complete_uninstall'                   => array(
 							'type'     => 'checkbox',
 							'label'    => __( 'Delete all Popup Maker data on deactivation', 'popup-maker' ),

--- a/classes/Utils/Alerts.php
+++ b/classes/Utils/Alerts.php
@@ -348,7 +348,7 @@ class PUM_Utils_Alerts {
 					<div class="pum-alert <?php echo '' !== $alert['type'] ? 'pum-alert__' . esc_attr( $alert['type'] ) : ''; ?>">
 
 						<?php if ( ! empty( $alert['message'] ) ) : ?>
-							<p><?php echo esc_html( $alert['message'] ); ?></p>
+							<p><?php echo $alert['message']; ?></p>
 						<?php endif; ?>
 
 						<?php if ( ! empty( $alert['html'] ) ) : ?>

--- a/classes/Utils/Alerts.php
+++ b/classes/Utils/Alerts.php
@@ -345,10 +345,10 @@ class PUM_Utils_Alerts {
 
 				<div class="pum-alert-holder" data-code="<?php echo $alert['code']; ?>" class="<?php echo $alert['dismissible'] ? 'is-dismissible' : ''; ?>" data-dismissible="<?php echo esc_attr( $alert['dismissible'] ); ?>">
 
-					<div class="pum-alert <?php echo $alert['type'] != '' ? 'pum-alert__' . $alert['type'] : ''; ?>">
+					<div class="pum-alert <?php echo '' !== $alert['type'] ? 'pum-alert__' . esc_attr( $alert['type'] ) : ''; ?>">
 
 						<?php if ( ! empty( $alert['message'] ) ) : ?>
-							<p><?php echo $alert['message']; ?></p>
+							<p><?php echo esc_html( $alert['message'] ); ?></p>
 						<?php endif; ?>
 
 						<?php if ( ! empty( $alert['html'] ) ) : ?>
@@ -357,10 +357,11 @@ class PUM_Utils_Alerts {
 
 						<?php if ( ! empty( $alert['actions'] ) && is_array( $alert['actions'] ) ) : ?>
 							<ul>
-								<?php foreach ( $alert['actions'] as $action ) {
-									$link_text = ! empty( $action['primary'] ) && true === $action['primary'] ? '<strong>' . esc_html($action['text']) . '</strong>' : esc_html($action['text']);
+								<?php
+								foreach ( $alert['actions'] as $action ) {
+									$link_text = ! empty( $action['primary'] ) && true === $action['primary'] ? '<strong>' . esc_html( $action['text'] ) . '</strong>' : esc_html( $action['text'] );
 									if ( 'link' === $action['type'] ) {
-										$url = $action['href'];
+										$url        = $action['href'];
 										$attributes = 'target="_blank" rel="noreferrer noopener"';
 									} else {
 										$url = add_query_arg( array(
@@ -369,10 +370,11 @@ class PUM_Utils_Alerts {
 											'pum_dismiss_alert' => $action['action'],
 											'expires'           => $expires,
 										));
+
 										$attributes = 'class="pum-dismiss"';
 									}
 									?>
-									<li><a data-action="<?php echo esc_attr($action['action']); ?>" href="<?php echo esc_url($url); ?>" <?php echo $attributes; ?> ><?php echo $link_text; ?></a></li>
+									<li><a data-action="<?php echo esc_attr( $action['action'] ); ?>" href="<?php echo esc_url( $url ); ?>" <?php echo $attributes; ?> ><?php echo $link_text; ?></a></li>
 								<?php } ?>
 							</ul>
 						<?php endif; ?>

--- a/tests/test-pum_admin_onboarding.php
+++ b/tests/test-pum_admin_onboarding.php
@@ -18,4 +18,25 @@ class PUM_Admin_OnboardingTEST extends WP_UnitTestCase {
 		$pointers = PUM_Admin_Onboarding::all_popups_main_tour( array() );
 		$this->assertIsArray( $pointers );
 	}
+
+	/**
+	 * Tests to make sure data returned from `tips_alert` is valid.
+	 */
+	public function test_tips_alert() {
+		$alerts = PUM_Admin_Onboarding::tips_alert( array() );
+		$this->assertIsArray( $alerts );
+	}
+
+	/**
+	 * Tests to make sure data returned from `get_random_tip` is valid.
+	 */
+	public function test_get_random_tip() {
+		$tip = PUM_Admin_Onboarding::get_random_tip();
+		$this->assertIsArray( $tip );
+
+		$this->assertCount( 2, $tip );
+
+		$this->assertArrayHasKey( 'msg', $tip );
+		$this->assertArrayHasKey( 'link', $tip );
+	}
 }

--- a/tests/test-pum_admin_onboarding.php
+++ b/tests/test-pum_admin_onboarding.php
@@ -39,4 +39,20 @@ class PUM_Admin_OnboardingTEST extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'msg', $tip );
 		$this->assertArrayHasKey( 'link', $tip );
 	}
+
+	/**
+	 * Tests to make sure data returned from `should_show_tip` is valid.
+	 */
+	public function test_should_show_tip() {
+		$result = PUM_Admin_Onboarding::should_show_tip();
+		$this->assertIsBool( $result );
+	}
+
+	/**
+	 * Tests to make sure data returned from `has_turned_off_tips` is valid.
+	 */
+	public function test_has_turned_off_tips() {
+		$result = PUM_Admin_Onboarding::has_turned_off_tips();
+		$this->assertIsBool( $result );
+	}
 }


### PR DESCRIPTION
## Description
Add a new system to randomly show helpful tips in the Popup Maker admin areas.

## Related Issue
Issue: #834 

## Types of changes
1. Adds new tip alerts that are randomly selected, once a month.

## Screenshots
<!-- if applicable -->

## This has been tested in the following browsers
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

## Checklist:
- [x] My code has been tested in the latest version of WordPress.
- [x] My code does not have any warnings from ESLint.
- [x] My code does not have any warnings from StyleLint.
- [x] My code does not have any warnings from PHPCS.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] All new functions and classes have code documentation.
