### PR TITLE
Adds customization to analytics route

### DIFF
--- a/assets/js/src/site/plugins/pum-analytics.js
+++ b/assets/js/src/site/plugins/pum-analytics.js
@@ -22,7 +22,7 @@ var PUM_Analytics;
 				opts = {
 					route: pum.hooks.applyFilters(
 						"pum.analyticsBeaconRoute",
-						"/analytics/"
+						"/" + pum_vars.analytics_route + "/"
 					),
 					data: pum.hooks.applyFilters(
 						"pum.AnalyticsBeaconData",

--- a/assets/js/src/site/plugins/pum-analytics.js
+++ b/assets/js/src/site/plugins/pum-analytics.js
@@ -12,13 +12,13 @@ var PUM_Analytics;
 	$.fn.popmake.conversion_trigger = null;
 
 	var rest_enabled = !!(
-		typeof pum_vars.restapi !== "undefined" && pum_vars.restapi
+		typeof pum_vars.analytics_api !== "undefined" && pum_vars.analytics_api
 	);
 
 	PUM_Analytics = {
 		beacon: function(data, callback) {
 			var beacon = new Image(),
-				url = rest_enabled ? pum_vars.restapi : pum_vars.ajaxurl,
+				url = rest_enabled ? pum_vars.analytics_api : pum_vars.ajaxurl,
 				opts = {
 					route: pum.hooks.applyFilters(
 						"pum.analyticsBeaconRoute",

--- a/assets/js/src/site/plugins/pum.js
+++ b/assets/js/src/site/plugins/pum.js
@@ -14,6 +14,7 @@ var PUM;
 		pm_dir_url: '',
         ajaxurl: '',
         restapi: false,
+	    analytics_api: false,
         rest_nonce: null,
         debug_mode: false,
         disable_tracking: true,

--- a/classes/Admin/Settings.php
+++ b/classes/Admin/Settings.php
@@ -440,8 +440,8 @@ class PUM_Admin_Settings {
 						'adblock_bypass_custom_filename'       => array(
 							'type'         => 'text',
 							'placeholder'  => 'my-awesome-popups',
-							'label'        => __( 'Ad blocker: Custom File Name', 'popup-maker' ),
-							'desc'         => __( 'A custom & recognizable file name to use for our assets.', 'popup-maker' ),
+							'label'        => __( 'Ad blocker: Custom Name', 'popup-maker' ),
+							'desc'         => __( 'A custom & recognizable name to use for our assets.', 'popup-maker' ),
 							'dependencies' => array(
 								'bypass_adblockers'         => true,
 								'adblock_bypass_url_method' => 'custom',

--- a/classes/Admin/Settings.php
+++ b/classes/Admin/Settings.php
@@ -425,12 +425,12 @@ class PUM_Admin_Settings {
 							'type'  => 'checkbox',
 						),
 						'adblock_bypass_url_method'            => array(
-							'label'        => __( 'Ad blocker: File Name Method', 'popup-maker' ),
-							'desc'         => __( 'This will help generate unique filenames for our JavaScript bypassing most ad blockers.', 'popup-maker' ),
+							'label'        => __( 'Ad blocker: Naming method', 'popup-maker' ),
+							'desc'         => __( 'This will help generate unique names for our JavaScript files and the analytics routes.', 'popup-maker' ),
 							'type'         => 'select',
 							'options'      => array(
-								'random' => __( 'Random File Names', 'popup-maker' ),
-								'custom' => __( 'Custom File Names', 'popup-maker' ),
+								'random' => __( 'Randomize Names', 'popup-maker' ),
+								'custom' => __( 'Custom Names', 'popup-maker' ),
 							),
 							'std'          => 'random',
 							'dependencies' => array(

--- a/classes/Analytics.php
+++ b/classes/Analytics.php
@@ -23,6 +23,7 @@ class PUM_Analytics {
 		add_action( 'rest_api_init', array( __CLASS__, 'register_endpoints' ) );
 		add_action( 'wp_ajax_pum_analytics', array( __CLASS__, 'ajax_request' ) );
 		add_action( 'wp_ajax_nopriv_pum_analytics', array( __CLASS__, 'ajax_request' ) );
+		add_filter( 'pum_vars', array( __CLASS__, 'pum_vars' ) );
 	}
 
 	/**

--- a/tests/test-pum-analytics.php
+++ b/tests/test-pum-analytics.php
@@ -41,7 +41,7 @@ class PUM_AnalyticsTEST extends WP_UnitTestCase {
 		);
 		PUM_Analytics::track( $conversion );
 		$new_count = $popup->get_event_count( 'conversion' );
-		$this->assertEquals( 2, $new_count, 'Conversion tracking check' );
+		$this->assertEquals( 1, $new_count, 'Conversion tracking check' );
 	}
 
 	/**

--- a/tests/test-pum-analytics.php
+++ b/tests/test-pum-analytics.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Class PUM_AnalyticsTEST
+ *
+ * @package Popup_Maker
+ */
+
+
+/**
+ * Test methods within our PUM_Analytics class
+ */
+class PUM_AnalyticsTEST extends WP_UnitTestCase {
+
+	/**
+	 * Tests to make sure `track` is valid.
+	 */
+	public function test_track() {
+
+		// Creates our test popup.
+		$popup_id = wp_insert_post(array(
+			'post_type' => 'popup'
+		));
+
+		// Make sure counts are 0.
+		$popup = pum_get_popup( $popup_id );
+		$popup->reset_counts();
+
+		// Tests tracking an open.
+		$open = array(
+			'pid' => $popup_id,
+			'event' => 'open'
+		);
+		PUM_Analytics::track( $open );
+		$new_count = $popup->get_event_count( 'open' );
+		$this->assertEquals( 1, $new_count, 'Open tracking check' );
+
+		// Tests tracking a conversion.
+		$conversion = array(
+			'pid' => $popup_id,
+			'event' => 'conversion'
+		);
+		PUM_Analytics::track( $conversion );
+		$new_count = $popup->get_event_count( 'conversion' );
+		$this->assertEquals( 2, $new_count, 'Conversion tracking check' );
+	}
+
+	/**
+	 * Tests to make sure data returned from `pum_vars` is valid.
+	 */
+	public function test_pum_vars() {
+		$pum_vars = PUM_Analytics::pum_vars( array() );
+		$this->assertIsArray( $pum_vars );
+
+		$this->assertArrayHasKey( 'analytics_route', $pum_vars );
+		$this->assertArrayHasKey( 'analytics_api', $pum_vars );
+	}
+
+	/**
+	 * Tests to make sure data returned from `get_analytics_namespace` is valid.
+	 */
+	public function test_get_analytics_namespace() {
+		$namespace = PUM_Analytics::get_analytics_namespace();
+		$this->assertIsString( $namespace );
+
+		$this->assertStringContainsString( '/v1', $namespace );
+	}
+
+	/**
+	 * Tests to make sure data returned from `get_analytics_route` is valid.
+	 */
+	public function test_get_analytics_route() {
+		$route = PUM_Analytics::get_analytics_route();
+		$this->assertIsString( $route );
+	}
+}


### PR DESCRIPTION
## Description
Allows the analytics endpoint to be customized.

## Related Issue
Issue: #783

## Types of changes

1.  When the bypass adblocker setting is enabled, randomize (or use custom string) for the route.
2.  Randomize (or use custom string) for namespace.

## This has been tested in the following browsers
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

## Checklist:
- [x] My code has been tested in the latest version of WordPress.
- [x] My code does not have any warnings from ESLint.
- [x] My code does not have any warnings from StyleLint.
- [x] My code does not have any warnings from PHPCS.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] All new functions and classes have code documentation.
