### PR TITLE
Add form integration files to main site.js

### DIFF
--- a/classes/Integration/Form/CalderaForms.php
+++ b/classes/Integration/Form/CalderaForms.php
@@ -82,12 +82,6 @@ class PUM_Integration_Form_CalderaForms extends PUM_Abstract_Integration_Form {
 	 * @return array
 	 */
 	public function custom_scripts( $js = [] ) {
-		$js[ $this->key ] = [
-			'content'  => file_get_contents( Popup_Maker::$DIR . 'assets/js/pum-integration-' . $this->key . PUM_Site_Assets::$suffix . '.js' ),
-			'priority' => 8,
-		];
-
-
 		return $js;
 	}
 

--- a/classes/Integration/Form/ContactForm7.php
+++ b/classes/Integration/Form/ContactForm7.php
@@ -109,11 +109,6 @@ class PUM_Integration_Form_ContactForm7 extends PUM_Abstract_Integration_Form {
 	 * @return array
 	 */
 	public function custom_scripts( $js = [] ) {
-		$js[ $this->key ] = [
-			'content'  => file_get_contents( Popup_Maker::$DIR . 'assets/js/pum-integration-' . $this->key . PUM_Site_Assets::$suffix . '.js' ),
-			'priority' => 8,
-		];
-
 		return $js;
 	}
 

--- a/classes/Integration/Form/FormidableForms.php
+++ b/classes/Integration/Form/FormidableForms.php
@@ -117,11 +117,6 @@ class PUM_Integration_Form_FormidableForms extends PUM_Abstract_Integration_Form
 	 * @return array
 	 */
 	public function custom_scripts( $js = [] ) {
-		$js[ $this->key ] = [
-			'content'  => file_get_contents( Popup_Maker::$DIR . 'assets/js/pum-integration-' . $this->key . PUM_Site_Assets::$suffix . '.js' ),
-			'priority' => 8,
-		];
-
 		return $js;
 	}
 

--- a/classes/Integration/Form/GravityForms.php
+++ b/classes/Integration/Form/GravityForms.php
@@ -84,11 +84,6 @@ class PUM_Integration_Form_GravityForms extends PUM_Abstract_Integration_Form {
 	 * @return array
 	 */
 	public function custom_scripts( $js = [] ) {
-		$js[ $this->key ] = [
-			'content'  => file_get_contents( Popup_Maker::$DIR . 'assets/js/pum-integration-' . $this->key . PUM_Site_Assets::$suffix . '.js' ),
-			'priority' => 8,
-		];
-
 		return $js;
 	}
 

--- a/classes/Integration/Form/MC4WP.php
+++ b/classes/Integration/Form/MC4WP.php
@@ -77,11 +77,6 @@ class PUM_Integration_Form_MC4WP extends PUM_Abstract_Integration_Form {
 	 * @return array
 	 */
 	public function custom_scripts( $js = [] ) {
-		$js[ $this->key ] = [
-			'content'  => file_get_contents( Popup_Maker::$DIR . 'assets/js/pum-integration-' . $this->key . PUM_Site_Assets::$suffix . '.js' ),
-			'priority' => 8,
-		];
-
 		return $js;
 	}
 

--- a/classes/Integration/Form/NinjaForms.php
+++ b/classes/Integration/Form/NinjaForms.php
@@ -101,11 +101,6 @@ class PUM_Integration_Form_NinjaForms extends PUM_Abstract_Integration_Form {
 	 * @return array
 	 */
 	public function custom_scripts( $js = [] ) {
-		$js[ $this->key ] = [
-			'content'  => file_get_contents( Popup_Maker::$DIR . 'assets/js/pum-integration-' . $this->key . PUM_Site_Assets::$suffix . '.js' ),
-			'priority' => 8,
-		];
-
 		return $js;
 	}
 

--- a/classes/Integration/Form/PirateForms.php
+++ b/classes/Integration/Form/PirateForms.php
@@ -145,11 +145,6 @@ class PUM_Integration_Form_PirateForms extends PUM_Abstract_Integration_Form {
 	 * @return array
 	 */
 	public function custom_scripts( $js = [] ) {
-		$js[ $this->key ] = [
-			'content'  => file_get_contents( Popup_Maker::$DIR . 'assets/js/pum-integration-' . $this->key . PUM_Site_Assets::$suffix . '.js' ),
-			'priority' => 8,
-		];
-
 		return $js;
 	}
 

--- a/classes/Integration/Form/WPForms.php
+++ b/classes/Integration/Form/WPForms.php
@@ -88,11 +88,6 @@ class PUM_Integration_Form_WPForms extends PUM_Abstract_Integration_Form {
 	 * @return array
 	 */
 	public function custom_scripts( $js = [] ) {
-		$js[ $this->key ] = [
-			'content'  => file_get_contents( Popup_Maker::$DIR . 'assets/js/pum-integration-' . $this->key . PUM_Site_Assets::$suffix . '.js' ),
-			'priority' => 8,
-		];
-
 		return $js;
 	}
 

--- a/tasks/js.js
+++ b/tasks/js.js
@@ -1,88 +1,119 @@
-/*******************************************************************************
- * Copyright (c) 2019, WP Popup Maker
- ******************************************************************************/
+/****************************************
+ * Copyright (c) 2020, Popup Maker
+ ****************************************/
 
-require('./webpack');
+require("./webpack");
 
-const gulp = require('gulp'),
-    $fn = require('gulp-load-plugins')({camelize: true}),
-    path = require('path'),
-    fs = require('fs'),
-    config = require('./config.json'),
-    merge = require('merge-stream'),
-    jsDistPath = path.join(config.root.dist, config.js.dist),
-    jsDevPath = path.join(config.root.dev, config.js.dev);
+const gulp = require("gulp"),
+	$fn = require("gulp-load-plugins")({ camelize: true }),
+	path = require("path"),
+	fs = require("fs"),
+	config = require("./config.json"),
+	merge = require("merge-stream"),
+	jsDistPath = path.join(config.root.dist, config.js.dist),
+	jsDevPath = path.join(config.root.dev, config.js.dev);
 
 const allowedDirectories = [
-	'bar',
-    'batch',
-    'general',
-    'marketing',
-	'pointer',
-    'popup-editor',
-    'settings-page',
-    'shortcode-ui',
-    'theme-editor',
+	"bar",
+	"batch",
+	"general",
+	"marketing",
+	"pointer",
+	"popup-editor",
+	"settings-page",
+	"shortcode-ui",
+	"theme-editor"
 ];
 
 function getFolders(dir) {
-    return fs.readdirSync(dir)
-        .filter(function (file) {
-            const allowed = allowedDirectories.filter((item) => file.indexOf(item) >= 0).length;
+	return fs.readdirSync(dir).filter(function(file) {
+		const allowed = allowedDirectories.filter(
+			item => file.indexOf(item) >= 0
+		).length;
 
-            return allowed && fs.statSync(path.join(dir, file)).isDirectory();
-        });
+		return allowed && fs.statSync(path.join(dir, file)).isDirectory();
+	});
 }
 
 function js_admin() {
-    const adminJsDevPath = path.join(jsDevPath, 'admin');
+	const adminJsDevPath = path.join(jsDevPath, "admin");
 
-    const folders = getFolders(adminJsDevPath),
-        // process each sub-folder
-        tasks = folders.map(function (folder) {
-            return gulp.src(path.join(adminJsDevPath, folder, '/**/*.js'), {allowEmpty: true})
-                .pipe($fn.plumber({errorHandler: $fn.notify.onError('Error: <%= error.message %>')}))
-                .pipe($fn.order([
-                    "**/**/*.js",
-                    "**/**/*.js",
-                    'general.js'
-                ], {base: path.join(adminJsDevPath, folder)}))
-                // concat into foldername.js
-                .pipe($fn.concat('admin-' + folder + '.js'))
-                .pipe(gulp.dest(jsDistPath))
-                .pipe($fn.uglify())
-                .pipe($fn.rename({extname: '.min.js'}))
-                .pipe(gulp.dest(jsDistPath));
-        });
+	const folders = getFolders(adminJsDevPath),
+		// process each sub-folder
+		tasks = folders.map(function(folder) {
+			return (
+				gulp
+					.src(path.join(adminJsDevPath, folder, "/**/*.js"), {
+						allowEmpty: true
+					})
+					.pipe(
+						$fn.plumber({
+							errorHandler: $fn.notify.onError(
+								"Error: <%= error.message %>"
+							)
+						})
+					)
+					.pipe(
+						$fn.order(["**/**/*.js", "**/**/*.js", "general.js"], {
+							base: path.join(adminJsDevPath, folder)
+						})
+					)
+					// concat into foldername.js
+					.pipe($fn.concat("admin-" + folder + ".js"))
+					.pipe(gulp.dest(jsDistPath))
+					.pipe($fn.uglify())
+					.pipe($fn.rename({ extname: ".min.js" }))
+					.pipe(gulp.dest(jsDistPath))
+			);
+		});
 
-   return merge(tasks);
+	return merge(tasks);
 }
 
 js_admin.description = "Build admin Javascript assets.";
 
 function js_site() {
-    return gulp.src([path.join(jsDevPath, 'site', '/**/*.js'), path.join(jsDistPath, 'pum-integration-*.js')], {allowEmpty: true})
-        .pipe($fn.plumber({errorHandler: $fn.notify.onError('Error: <%= error.message %>')}))
-        .pipe($fn.order([
-            "**/compatibility.js",
-            "**/pum.js",
-            "**/**/*.js",
-            'general.js',
-	        'pum-integration-*.js'
-        ]))
-	    .pipe($fn.concat('site.js'))
-	    .pipe(gulp.dest(jsDistPath))
-	    .pipe($fn.uglify())
-	    .pipe($fn.rename({extname: '.min.js'}))
-	    .pipe(gulp.dest(jsDistPath));
+	return gulp
+		.src(
+			[
+				path.join(jsDevPath, "site", "/**/*.js"),
+				path.join(jsDistPath, "pum-integration-*.js")
+			],
+			{ allowEmpty: true }
+		)
+		.pipe(
+			$fn.plumber({
+				errorHandler: $fn.notify.onError("Error: <%= error.message %>")
+			})
+		)
+		.pipe(
+			$fn.order([
+				"**/compatibility.js",
+				"**/pum.js",
+				"**/**/*.js",
+				"general.js",
+				"pum-integration-*.js"
+			])
+		)
+		.pipe($fn.concat("site.js"))
+		.pipe(gulp.dest(jsDistPath))
+		.pipe($fn.uglify())
+		.pipe($fn.rename({ extname: ".min.js" }))
+		.pipe(gulp.dest(jsDistPath));
 }
 
 js_site.description = "Build site Javascript assets.";
 
 gulp.task(js_admin);
 gulp.task(js_site);
-gulp.task('js', gulp.series(gulp.parallel(['webpack', 'webpack:blockEditor']), gulp.parallel(['js_admin', 'js_site'])));
+gulp.task(
+	"js",
+	gulp.series(
+		gulp.parallel(["webpack", "webpack:blockEditor"]),
+		gulp.parallel(["js_admin", "js_site"])
+	)
+);
 
-let js = gulp.task('js');
+const js = gulp.task("js");
 
 js.description = "Build all Javascript assets.";

--- a/tasks/js.js
+++ b/tasks/js.js
@@ -61,26 +61,27 @@ function js_admin() {
 js_admin.description = "Build admin Javascript assets.";
 
 function js_site() {
-    return gulp.src([path.join(jsDevPath, 'site', '/**/*.js')], {allowEmpty: true})
+    return gulp.src([path.join(jsDevPath, 'site', '/**/*.js'), path.join(jsDistPath, 'pum-integration-*.js')], {allowEmpty: true})
         .pipe($fn.plumber({errorHandler: $fn.notify.onError('Error: <%= error.message %>')}))
         .pipe($fn.order([
             "**/compatibility.js",
             "**/pum.js",
             "**/**/*.js",
-            'general.js'
+            'general.js',
+	        'pum-integration-*.js'
         ]))
-        .pipe($fn.concat('site.js'))
-        .pipe(gulp.dest(jsDistPath))
-        .pipe($fn.uglify())
-        .pipe($fn.rename({extname: '.min.js'}))
-        .pipe(gulp.dest(jsDistPath));
+	    .pipe($fn.concat('site.js'))
+	    .pipe(gulp.dest(jsDistPath))
+	    .pipe($fn.uglify())
+	    .pipe($fn.rename({extname: '.min.js'}))
+	    .pipe(gulp.dest(jsDistPath));
 }
 
 js_site.description = "Build site Javascript assets.";
 
 gulp.task(js_admin);
 gulp.task(js_site);
-gulp.task('js', gulp.parallel(['webpack', 'webpack:blockEditor', 'js_admin', 'js_site']));
+gulp.task('js', gulp.series(gulp.parallel(['webpack', 'webpack:blockEditor']), gulp.parallel(['js_admin', 'js_site'])));
 
 let js = gulp.task('js');
 

--- a/tasks/js.js
+++ b/tasks/js.js
@@ -77,7 +77,8 @@ function js_site() {
 		.src(
 			[
 				path.join(jsDevPath, "site", "/**/*.js"),
-				path.join(jsDistPath, "pum-integration-*.js")
+				path.join(jsDistPath, "pum-integration-*.js"),
+				"!" + path.join(jsDistPath, "pum-integration-*.min.js")
 			],
 			{ allowEmpty: true }
 		)


### PR DESCRIPTION
## Description
Adds all form integration JS files into our main site JS to ensure they are added to the asset cache.

## Related Issue
Issue: #755 

## This has been tested in the following browsers
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

## Checklist:
- [x] My code has been tested in the latest version of WordPress.
- [x] My code does not have any warnings from ESLint.
- [x] My code does not have any warnings from StyleLint.
- [x] My code does not have any warnings from PHPCS.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] All new functions and classes have code documentation.
