### PR TITLE
Updating extend page to be more aligned with new pricing

### DIFF
--- a/assets/sass/admin-extensions-page.scss
+++ b/assets/sass/admin-extensions-page.scss
@@ -5,14 +5,15 @@
 .upgrade-wrapper {
 	background-color: white;
 	margin: 1em 0;
-	padding: 2em 1em;
+	padding: 3em 1em;
 
 	.upgrade-wrapper-hero {
 		font-size: 16px;
+		margin: 0 0 2em;
 
 		p {
 			font-size: 16px;
-			margin: 0;
+			margin: 0 0 0.3em;
 		}
 
 		ul {
@@ -20,10 +21,15 @@
 			padding-left: 20px;
 			list-style: disc;
 		}
+
+		a {
+			margin: 0.5em 0 0;
+		}
 	}
 
 	h2 {
 		font-size: 2em;
+		margin: 0 0 0.5em;
 	}
 }
 

--- a/assets/sass/admin-extensions-page.scss
+++ b/assets/sass/admin-extensions-page.scss
@@ -2,6 +2,31 @@
  * Copyright (c) 2019, Code Atlantic LLC
  ******************************************************/
 
+.upgrade-wrapper {
+	background-color: white;
+	margin: 1em 0;
+	padding: 2em 1em;
+
+	.upgrade-wrapper-hero {
+		font-size: 16px;
+
+		p {
+			font-size: 16px;
+			margin: 0;
+		}
+
+		ul {
+			margin: 0;
+			padding-left: 20px;
+			list-style: disc;
+		}
+	}
+
+	h2 {
+		font-size: 2em;
+	}
+}
+
 .extensions-available {
 	display: flex;
 	flex-wrap: wrap;

--- a/classes/Admin/Extend.php
+++ b/classes/Admin/Extend.php
@@ -42,12 +42,12 @@ class PUM_Admin_Extend {
 						<li>Conditions - Show popups to visitors from a certain site, from search engines, using certain browsers, who has viewed X pages, and more </li>
 						<li>And much more!</li>
 					</ul>
-					<a href="#" class="button button-primary">View pricing</a>
+					<a href="https://wppopupmaker.com/pricing/?utm_campaign=upsell&utm_medium=plugin&utm_source=plugin-extension-page&utm_content=hero-cta" class="button button-primary" target="_blank" rel="noreferrer noopener">View pricing</a>
 				</section>
 				<section class="upgrade-wrapper-features">
-					<h2>Our Most Popular Premuium Features</h2>
+					<h2>Our Most Popular Premium Features</h2>
 					<?php self::render_extension_list(); ?>
-					<a href="https://wppopupmaker.com/extensions/?utm_source=plugin-extension-page&utm_medium=text-link&utm_campaign=upsell&utm_content=browse-all-bottom" class="button-primary" title="<?php _e( 'See All Premium Features', 'popup-maker' ); ?>" target="_blank"><?php _e( 'Browse All Extensions', 'popup-maker' ); ?></a>
+					<a href="https://wppopupmaker.com/extensions/?utm_campaign=upsell&utm_medium=plugin&utm_source=plugin-extension-page&utm_content=browse-all-bottom" class="button-primary" title="<?php _e( 'See All Premium Features', 'popup-maker' ); ?>" target="_blank" rel="noreferrer noopener"><?php _e( 'See All Premium Features', 'popup-maker' ); ?></a>
 				</section>
 			</article>
 		</div>
@@ -108,7 +108,7 @@ class PUM_Admin_Extend {
 				foreach ( $extensions as $extension ) : ?>
                     <li class="available-extension-inner <?php echo esc_attr( $extension['slug'] ); ?>">
                         <h3>
-                            <a target="_blank" href="<?php echo esc_url( $extension['homepage'] ); ?>?utm_source=plugin-extension-page&utm_medium=extension-title-<?php echo $i; ?>&utm_campaign=<?php echo $campaign; ?>&utm_content=<?php echo esc_attr( urlencode( str_replace( ' ', '+', $extension['name'] ) ) ); ?>">
+                            <a target="_blank" href="<?php echo esc_url( $extension['homepage'] ); ?>?utm_source=plugin-extension-page&utm_medium=plugin&utm_campaign=upsell&utm_content=<?php echo esc_attr( urlencode( str_replace( ' ', '+', $extension['name'] ) ) ); ?>-<?php echo esc_attr( $i ); ?>">
 								<?php echo esc_html( $extension['name'] ) ?>
                             </a>
                         </h3>
@@ -118,7 +118,7 @@ class PUM_Admin_Extend {
                         <p><?php echo esc_html( $extension['excerpt'] ); ?></p>
 
                         <span class="action-links">
-						<a class="button" target="_blank" href="<?php echo esc_url( $extension['homepage'] ); ?>?utm_source=plugin-extension-page&utm_medium=extension-button-<?php echo $i; ?>&utm_campaign=<?php echo $campaign; ?>&utm_content=<?php echo esc_attr( urlencode( str_replace( ' ', '+', $extension['name'] ) ) ); ?>"><?php _e( 'Learn more', 'popup-maker' ); ?></a>
+						<a class="button" target="_blank" href="<?php echo esc_url( $extension['homepage'] ); ?>?utm_source=plugin-extension-page&utm_medium=plugin&utm_campaign=upsell&utm_content=<?php echo esc_attr( urlencode( str_replace( ' ', '+', $extension['name'] ) ) ); ?>-<?php echo esc_attr( $i ); ?>"><?php _e( 'Learn more', 'popup-maker' ); ?></a>
 					</span>
 
                         <!--					--><?php

--- a/classes/Admin/Extend.php
+++ b/classes/Admin/Extend.php
@@ -118,7 +118,7 @@ class PUM_Admin_Extend {
                         <p><?php echo esc_html( $extension['excerpt'] ); ?></p>
 
                         <span class="action-links">
-						<a class="button" target="_blank" href="<?php echo esc_url( $extension['homepage'] ); ?>?utm_source=plugin-extension-page&utm_medium=extension-button-<?php echo $i; ?>&utm_campaign=<?php echo $campaign; ?>&utm_content=<?php echo esc_attr( urlencode( str_replace( ' ', '+', $extension['name'] ) ) ); ?>"><?php _e( 'Get this Extension', 'popup-maker' ); ?></a>
+						<a class="button" target="_blank" href="<?php echo esc_url( $extension['homepage'] ); ?>?utm_source=plugin-extension-page&utm_medium=extension-button-<?php echo $i; ?>&utm_campaign=<?php echo $campaign; ?>&utm_content=<?php echo esc_attr( urlencode( str_replace( ' ', '+', $extension['name'] ) ) ); ?>"><?php _e( 'Learn more', 'popup-maker' ); ?></a>
 					</span>
 
                         <!--					--><?php

--- a/classes/Admin/Extend.php
+++ b/classes/Admin/Extend.php
@@ -28,34 +28,29 @@ class PUM_Admin_Extend {
 	 * Renders the support page contents.
 	 */
 	public static function page() {
-		// Set a new campaign for tracking purposes
-		$campaign   = 'PUMExtensionsPage';
-
 		?>
-        <div class="wrap">
-			<h1><?php _e( 'Extend Popup Maker with Additional Premium Features', 'popup-maker' ) ?></h1>
+		<div class="wrap">
+			<h1><?php _e( 'Upgrade', 'popup-maker' ) ?></h1>
 			<?php PUM_Upsell::display_addon_tabs(); ?>
-            <div id="poststuff">
-                <div id="post-body" class="metabox-holder">
-                    <div id="post-body-content">
-						<br class="clear" />
-						<a href="https://wppopupmaker.com/extensions/?utm_source=plugin-extension-page&utm_medium=text-link&utm_campaign=<?php echo $campaign; ?>&utm_content=browse-all" class="button-primary" title="<?php _e( 'Browse All Extensions', 'popup-maker' ); ?>" target="_blank"><?php _e( 'Browse All Extensions', 'popup-maker' ); ?></a>
-                        <br class="clear" />
-
-						<div class="pum-tabs-container">
-							<?php self::render_extension_list(); ?>
-
-							<br class="clear" />
-
-							<a href="https://wppopupmaker.com/extensions/?utm_source=plugin-extension-page&utm_medium=text-link&utm_campaign=<?php echo $campaign; ?>&utm_content=browse-all-bottom" class="button-primary" title="<?php _e( 'Browse All Extensions', 'popup-maker' ); ?>" target="_blank"><?php _e( 'Browse All Extensions', 'popup-maker' ); ?></a>
-
-							<br class="clear" /> <br class="clear" /> <br class="clear" />
-							<hr class="clear" /><br class="clear" />
-						</div>
-                    </div>
-                </div>
-            </div>
-        </div>
+			<article class="upgrade-wrapper">
+				<section class="upgrade-wrapper-hero">
+					<h2>Drive Even More Opt-Ins and Sales With Our Premium Features</h2>
+					<p>Our premium plans give you more:</p>
+					<ul>
+						<li>Triggers - Scroll, Exit-intent, Add-to-cart, and more</li>
+						<li>Integrations - MailChimp, WooCommerce, and more</li>
+						<li>Conditions - Show popups to visitors from a certain site, from search engines, using certain browsers, who has viewed X pages, and more </li>
+						<li>And much more!</li>
+					</ul>
+					<a href="#" class="button button-primary">View pricing</a>
+				</section>
+				<section class="upgrade-wrapper-features">
+					<h2>Our Most Popular Premuium Features</h2>
+					<?php self::render_extension_list(); ?>
+					<a href="https://wppopupmaker.com/extensions/?utm_source=plugin-extension-page&utm_medium=text-link&utm_campaign=upsell&utm_content=browse-all-bottom" class="button-primary" title="<?php _e( 'See All Premium Features', 'popup-maker' ); ?>" target="_blank"><?php _e( 'Browse All Extensions', 'popup-maker' ); ?></a>
+				</section>
+			</article>
+		</div>
 		<?php
 	}
 

--- a/classes/Admin/Pages.php
+++ b/classes/Admin/Pages.php
@@ -58,7 +58,7 @@ class PUM_Admin_Pages {
 				'callback'    => array( 'PUM_Admin_Settings', 'page' ),
 			),
 			'extensions' => array(
-				'page_title'  => __( 'Extend', 'popup-maker' ),
+				'page_title'  => __( 'Upgrade', 'popup-maker' ),
 				'capability'  => 'edit_posts',
 				'callback'    => array( 'PUM_Admin_Extend', 'page' ),
 			),

--- a/classes/Upsell.php
+++ b/classes/Upsell.php
@@ -163,7 +163,7 @@ class PUM_Upsell {
 					'url'  => admin_url( 'edit.php?post_type=popup_theme' ),
 				),
 				'integrations' => array(
-					'name' => esc_html__( 'Extensions', 'popup-maker' ),
+					'name' => esc_html__( 'Upgrade', 'popup-maker' ),
 					'url'  => admin_url( 'edit.php?post_type=popup&page=pum-extensions&view=integrations' ),
 				),
 			);


### PR DESCRIPTION
## Description
Changes how the extend page is positioned to put more emphasis on the new pricing structure.

## Related Issue
Issue: #913 

## Types of changes

1. Renames page as "Upgrade"
2. Adds new hero section sending people to the pricing page
3. Positions the extensions as premium features within our premium product

## Screenshots

* Current rough outline:
![image](https://user-images.githubusercontent.com/9730040/102107041-48119a00-3dff-11eb-9f7a-c32ddd75e178.png)


## This has been tested in the following browsers
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

## Checklist:
- [x] My code has been tested in the latest version of WordPress.
- [x] My code does not have any warnings from ESLint.
- [x] My code does not have any warnings from StyleLint.
- [x] My code does not have any warnings from PHPCS.
- [x] My code follows the WordPress code style.
- [x] My code follows the accessibility standards. <!-- Guidelines: https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/ -->
- [x] All new functions and classes have code documentation.
