### PR TITLE
Attempt to fix readme deployment by adding ActionScheduler to workflow

### DIFF
--- a/.github/workflows/deploy-readme-assets.yml
+++ b/.github/workflows/deploy-readme-assets.yml
@@ -8,7 +8,12 @@ jobs:
         name: Push to master
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@master
+            - name: Checkout master
+              uses: actions/checkout@master
+
+            - name: Install ActionScheduler
+              run: composer install --prefer-dist --no-progress --no-suggest
+
             - name: WordPress.org plugin asset/readme update
               uses: 10up/action-wordpress-plugin-asset-update@stable
               env:

--- a/readme.txt
+++ b/readme.txt
@@ -1,4 +1,4 @@
-=== Popup Maker - Popup Forms, Opt-ins & More ===
+=== Popup Maker - Popup for opt-ins, lead gen, & more ===
 Contributors: danieliser, codeatlantic
 Author URI: https://wppopupmaker.com/?utm_campaign=readme&utm_medium=referral&utm_source=readme-header&utm_content=author-url
 Plugin URI: https://wppopupmaker.com/?utm_campaign=readme&utm_medium=referral&utm_source=readme-header&utm_content=plugin-url


### PR DESCRIPTION
Right now, our workflow is failing due to it thinking we want to remove ActionScheduler from the SVN repo since it is not present in the git repo. So, we will try to install actionscheduler during the readme deployment check.