### PR TITLE
Add --no-dev flag for readme deploy workflow

### DIFF
--- a/.github/workflows/deploy-readme-assets.yml
+++ b/.github/workflows/deploy-readme-assets.yml
@@ -12,7 +12,7 @@ jobs:
               uses: actions/checkout@master
 
             - name: Install ActionScheduler
-              run: composer install --prefer-dist --no-progress --no-suggest
+              run: composer install --prefer-dist --no-progress --no-dev
 
             - name: WordPress.org plugin asset/readme update
               uses: 10up/action-wordpress-plugin-asset-update@stable


### PR DESCRIPTION
Add the --no-dev as we don't need PHPUnit, PHPCS, etc... here.

Also, removed the deprecated --no-suggest flag.