### PR TITLE
Ensure our readme deploy workflow uses PHP 7.*

### DIFF
--- a/.github/workflows/deploy-readme-assets.yml
+++ b/.github/workflows/deploy-readme-assets.yml
@@ -10,6 +10,12 @@ jobs:
         steps:
             - name: Checkout master
               uses: actions/checkout@master
+              
+            - name: Setup PHP to use 7.4 with composer v2
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: '7.4'
+                  tools: composer:v2
 
             - name: Install ActionScheduler
               run: composer install --prefer-dist --no-progress --no-dev


### PR DESCRIPTION
Our workflow is still failing as our version of PHPUnit requires PHP less than 8.0 and composer's --no-dev flag still checks the requirements of the dev packages, even if it isn't installing them.