### PR TITLE
[WIP] Improve learn more/tooltip consistency

### DIFF
--- a/classes/Admin/Settings.php
+++ b/classes/Admin/Settings.php
@@ -448,9 +448,14 @@ class PUM_Admin_Settings {
 							),
 						),
 						'adjust_body_padding'   => array(
-							'type'    => 'checkbox',
-							'label'   => __( 'Adjust the right padding added to the body when popups are shown with an overlay.', 'popup-maker' ),
-							'doclink' => 'https://docs.wppopupmaker.com/article/314-why-does-my-site-shift-jump-or-skip-when-a-popup-is-triggered',
+							'type'  => 'checkbox',
+							'label' => __( 'Adjust the right padding added to the body when popups are shown with an overlay.', 'popup-maker' ),
+							'desc'  => sprintf(
+								/* translators: 1 & 2 are opening and closing HTML of the link around "Learn more" */
+								esc_html__( 'Use this if your popups "jump" or "shift" when opened. %1$sLearn more%2$s', 'popup-maker' ),
+								'<a target="_blank" rel="noreferrer noopener" href="https://docs.wppopupmaker.com/article/314-why-does-my-site-shift-jump-or-skip-when-a-popup-is-triggered?utm_campaign=contextual-help&utm_medium=inline-doclink&utm_source=settings-page&utm_content=adjust-right-padding">',
+								'</a>'
+							),
 						),
 						'body_padding_override' => array(
 							'type'         => 'text',

--- a/classes/Admin/Settings.php
+++ b/classes/Admin/Settings.php
@@ -256,8 +256,12 @@ class PUM_Admin_Settings {
 						'telemetry'      => array(
 							'type'  => 'checkbox',
 							'label' => __( 'Allow usage tracking?', 'popup-maker' ),
-							'desc'  => __( "Allow Popup Maker to track this plugin's usage and help us make this plugin better? No user data is sent to our servers. No sensitive data is tracked.", 'popup-maker' ) .
-									' <a href="https://docs.wppopupmaker.com/article/528-the-data-the-popup-maker-plugin-collects">' . __( 'Learn more', 'popup-maker' ) . '</a>',
+							'desc'  => sprintf(
+								/* translators: 1 & 2 are opening and closing HTML of the link around "Learn more" */
+								esc_html__( 'Allow data sharing so that we can receive a little information on how it is used and help us make this plugin better? No user data is sent to our servers. No sensitive data is tracked. %1$sLearn more%2$s', 'popup-maker' ),
+								' <a target="_blank" rel="noreferrer noopener"  href="https://docs.wppopupmaker.com/article/528-the-data-the-popup-maker-plugin-collects?utm_campaign=contextual-help&utm_medium=inline-doclink&utm_source=settings-page&utm_content=telemetry-setting">',
+								'</a>',
+							),
 						),
 					),
 				),

--- a/classes/Admin/Settings.php
+++ b/classes/Admin/Settings.php
@@ -260,7 +260,7 @@ class PUM_Admin_Settings {
 								/* translators: 1 & 2 are opening and closing HTML of the link around "Learn more" */
 								esc_html__( 'Allow data sharing so that we can receive a little information on how it is used and help us make this plugin better? No user data is sent to our servers. No sensitive data is tracked. %1$sLearn more%2$s', 'popup-maker' ),
 								' <a target="_blank" rel="noreferrer noopener"  href="https://docs.wppopupmaker.com/article/528-the-data-the-popup-maker-plugin-collects?utm_campaign=contextual-help&utm_medium=inline-doclink&utm_source=settings-page&utm_content=telemetry-setting">',
-								'</a>',
+								'</a>'
 							),
 						),
 					),

--- a/includes/modules/menus.php
+++ b/includes/modules/menus.php
@@ -41,8 +41,8 @@ class PUM_Modules_Menu {
 				'id'   => 'disabled_menu_editor',
 				'name' => __( 'Disable Popups Menu Editor', 'popup-maker' ),
 				'desc' => sprintf(
-					_x( 'Use this if there is a conflict with your theme or another plugin in the nav menu editor. %sSee Details%s', '%s represent opening and closing link html', 'popup-maker' ),
-					'<a href="https://docs.wppopupmaker.com/article/297-popup-maker-is-overwriting-my-menu-editor-functions-how-can-i-fix-this" target="_blank">',
+					esc_html_x( 'Use this if there is a conflict with your theme or another plugin in the nav menu editor. %sLearn more%s', '%s represent opening and closing link html', 'popup-maker' ),
+					'<a href="https://docs.wppopupmaker.com/article/297-popup-maker-is-overwriting-my-menu-editor-functions-how-can-i-fix-this?utm_campaign=contextual-help&utm_medium=inline-doclink&utm_source=settings-page&utm_content=disable-popup-menu-editor" target="_blank" rel="noreferrer noopener">',
 					'</a>'
 				),
 				'type' => 'checkbox',


### PR DESCRIPTION
## Description

Improves our overall strategy for how we link to documentation and provide more details.

## Related Issue

Issue: #912 

## Types of changes
<!-- What types of changes does your code introduce?  -->

## Screenshots
<!-- if applicable -->

## This has been tested in the following browsers
- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Checklist:
- [ ] This PR passes all automated checks (will appear once pull request is submitted)
- [ ] My code has been tested in the latest version of WordPress.
- [ ] My code does not have any warnings from ESLint.
- [ ] My code does not have any warnings from StyleLint.
- [ ] My code does not have any warnings from PHPCS.
- [ ] My code follows [the WordPress coding standards](https://developer.wordpress.org/coding-standards/).
- [ ] My code follows [the accessibility standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/).
- [ ] All new functions and classes have code documentation.
