### PR TITLE
Add 'flush popup cache' link in admin bar menu

### DIFF
--- a/assets/sass/admin-bar.scss
+++ b/assets/sass/admin-bar.scss
@@ -14,3 +14,7 @@
 #wp-admin-bar-popup-maker:hover > .ab-item::before {
 	background-image: url(/wp-content/plugins/popup-maker/assets/images/admin/icon-info-21x21.png) !important;
 }
+
+#wp-admin-bar-popup-maker li#wp-admin-bar-flush-popup-cache a {
+	color: #8c8 !important;
+}

--- a/classes/AssetCache.php
+++ b/classes/AssetCache.php
@@ -222,7 +222,7 @@ class PUM_AssetCache {
 
 		$js = "/**\n";
 		$js .= " * Do not touch this file! This file created by the Popup Maker plugin using PHP\n";
-		$js .= " * Last modified time: " . date( 'M d Y, h:s:i' ) . "\n";
+		$js .= " * Last modified time: " . date( 'M d Y, h:i:s' ) . "\n";
 		$js .= " */\n\n\n";
 		$js .= self::generate_js();
 
@@ -244,7 +244,7 @@ class PUM_AssetCache {
 
 		$css = "/**\n";
 		$css .= " * Do not touch this file! This file created by the Popup Maker plugin using PHP\n";
-		$css .= " * Last modified time: " . date( 'M d Y, h:s:i' ) . "\n";
+		$css .= " * Last modified time: " . date( 'M d Y, h:i:s' ) . "\n";
 		$css .= " */\n\n\n";
 		$css .= self::generate_css();
 

--- a/classes/AssetCache.php
+++ b/classes/AssetCache.php
@@ -71,6 +71,11 @@ class PUM_AssetCache {
 			add_action( 'pum_save_popup', array( __CLASS__, 'reset_cache' ) );
 			add_action( 'pum_save_theme', array( __CLASS__, 'reset_cache' ) );
 			add_action( 'pum_update_core_version', array( __CLASS__, 'reset_cache' ) );
+
+			if ( isset( $_GET['flush_popup_cache'] ) ) {
+				add_action( 'init', array( __CLASS__, 'reset_cache' ) );
+			}
+
 			add_filter( 'pum_alert_list', array( __CLASS__, 'cache_alert' ) );
 
 			add_action( 'pum_styles', array( __CLASS__, 'global_custom_styles' ) );

--- a/includes/modules/admin-bar.php
+++ b/includes/modules/admin-bar.php
@@ -183,15 +183,6 @@ class PUM_Modules_Admin_Bar {
 			) );
 		}
 
-		$wp_admin_bar->add_node(
-			array(
-				'id'     => 'flush-popup-cache',
-				'title'  => __( 'Flush Popup Cache', 'popup-maker' ),
-				'href'   => add_query_arg( 'flush_popup_cache', 'yes' ),
-				'parent' => 'popup-maker',
-			)
-		);
-
 		/**
 		 * Tools
 		 */
@@ -201,6 +192,15 @@ class PUM_Modules_Admin_Bar {
 			'href'   => '#popup-maker-tools',
 			'parent' => 'popup-maker',
 		) );
+
+		$wp_admin_bar->add_node(
+			array(
+				'id'     => 'flush-popup-cache',
+				'title'  => __( 'Flush Popup Cache', 'popup-maker' ),
+				'href'   => add_query_arg( 'flush_popup_cache', 'yes' ),
+				'parent' => 'pum-tools',
+			)
+		);
 
 		/**
 		 * Get Selector

--- a/includes/modules/admin-bar.php
+++ b/includes/modules/admin-bar.php
@@ -183,6 +183,15 @@ class PUM_Modules_Admin_Bar {
 			) );
 		}
 
+		$wp_admin_bar->add_node(
+			array(
+				'id'     => 'flush-popup-cache',
+				'title'  => __( 'Flush Popup Cache', 'popup-maker' ),
+				'href'   => add_query_arg( 'flush_popup_cache', 'yes' ),
+				'parent' => 'popup-maker',
+			)
+		);
+
 		/**
 		 * Tools
 		 */


### PR DESCRIPTION
## Description
New 'flush cache' system so admins can flush the asset cache from the frontend.

## Related Issue
Issue: #931 

## Types of changes
1. Adds new link in the admin bar menu for "Flush Popup Cache"
2. Adds a new check in the asset cache class for if a URL query parameter exists. If so, reset cache

## Screenshots
![image](https://user-images.githubusercontent.com/9730040/103779112-46ec1b00-5001-11eb-89a1-d17be06d3202.png)

## This has been tested in the following browsers
- [x] Chrome
- [x] Firefox
- [x] Edge
- [x] Safari

## Checklist:
- [x] This PR passes all automated checks (will appear once pull request is submitted)
- [x] My code has been tested in the latest version of WordPress.
- [x] My code does not have any warnings from ESLint.
- [x] My code does not have any warnings from StyleLint.
- [x] My code does not have any warnings from PHPCS.
- [x] My code follows [the WordPress coding standards](https://developer.wordpress.org/coding-standards/).
- [x] My code follows [the accessibility standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/).
- [x] All new functions and classes have code documentation.
