### PR TITLE
Update the microcopy in the new trigger modal

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,6 +1,7 @@
-/.wordpress-org
 /.git
 /.github
+/.vscode
+/.wordpress-org
 /assets/js/src
 /assets/sass
 /bin
@@ -20,6 +21,8 @@
 .gitattributes
 .gitignore
 .jshintrc
+.phpcs.xml.dist
+.prettierrc.js
 .scrutinizer.yml
 .stylelintignore
 .stylelintrc.json
@@ -30,10 +33,10 @@ composer.lock
 gulpfile.js
 labels.json
 npm-debug.log
-readme.md
 package.json
 package-lock.json
 phpci.yml
 phpunit.xml.dist
+postcss.config.js
+readme.md
 yarn-lock.json
-/package/action-scheduler/lib/cron-expression/LICENSE

--- a/.distignore
+++ b/.distignore
@@ -28,6 +28,7 @@
 .stylelintrc.json
 .travis.yml
 apigen.neon
+CHANGELOG.md
 composer.json
 composer.lock
 gulpfile.js

--- a/.gitattributes
+++ b/.gitattributes
@@ -19,20 +19,28 @@ tests export-ignore
 renovate.json export-ignore
 
 .browserslistrc export-ignore
+.distignore export-ignore
 .editorconfig export-ignore
 .eslintignore export-ignore
+.eslintrc.js export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .jshintrc export-ignore
+.phpcs.xml.dist export-ignore
+.prettierrc.js export-ignore
 .scrutinizer.yml export-ignore
+.stylelintignore export-ignore
+.stylelintrc.json export-ignore
 .travis.yml export-ignore
 apigen.neon export-ignore
 composer.json export-ignore
 Gruntfile.js export-ignore
 gulpfile.js export-ignore
+labels.json export-ignore
 package.json export-ignore
 phpci.yml export-ignore
 phpunit.xml export-ignore
+postcss.config.js export-ignore
 readme.txt export-ignore
 
 /bin/ export-ignore

--- a/classes/Admin/Templates.php
+++ b/classes/Admin/Templates.php
@@ -487,7 +487,7 @@ class PUM_Admin_Templates {
 					'popup_trigger_add_type'         => array(
 						'id'      => 'popup_trigger_add_type',
 						'name'    => "",
-						'label'   => __( 'Choose what type of trigger to add?', 'popup-maker' ),
+						'label'   => __( 'What kind of trigger do you want?', 'popup-maker' ),
 						'type'    => 'select',
 						'options' => PUM_Triggers::instance()->dropdown_list(),
 					),
@@ -520,7 +520,7 @@ class PUM_Admin_Templates {
 
 			print(PUM_Admin.templates.modal({
 			id: 'pum_trigger_add_type_modal',
-			title: '<?php _e( 'Choose what type of trigger to add?', 'popup-maker' ); ?>',
+			title: '<?php _e( 'New Trigger', 'popup-maker' ); ?>',
 			content: content,
 			save_button: pum_admin_vars.I10n.add || '<?php __( 'Add', 'popup-maker' ); ?>'
 			}));

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: danieliser, codeatlantic
 Author URI: https://wppopupmaker.com/?utm_campaign=readme&utm_medium=referral&utm_source=readme-header&utm_content=author-url
 Plugin URI: https://wppopupmaker.com/?utm_campaign=readme&utm_medium=referral&utm_source=readme-header&utm_content=plugin-url
 Donate link:
-Tags:  marketing, ecommerce, popup, popups, optin, conversion, promotion, pop-up, lightbox, modal
+Tags:  marketing, ecommerce, popup, popups, optin, conversion, promotion, pop-up, lightbox, modal, popupmaker
 Requires at least: 4.9
 Tested up to: 5.6
 Requires PHP: 5.6


### PR DESCRIPTION
Refactored title and label for the Add New Trigger modal.

## Description
<!-- Please describe what you have changed or added -->

<!-- If this is a new feature or major change, you must link to an issue that explains use case. -->
Related Issue: https://github.com/PopupMaker/Popup-Maker/issues/960

## Types of changes
<!-- What types of changes does your code introduce?  -->

Text content changes.

## Screenshots
<!-- if applicable -->

### Result

<img width="632" alt="popup-maker-add-trigger-title-label" src="https://user-images.githubusercontent.com/4658423/121458082-4d7d2500-c9db-11eb-8a3b-b2ae5a50c524.png">

## This has been tested in the following browsers

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

## Merge Checklist

- [x] This PR passes all automated checks (will appear once pull request is submitted)
- [x] My code has been tested in the latest version of WordPress.
- [x] My code does not have any warnings from ESLint.
- [x] My code does not have any warnings from StyleLint.
- [x] My code does not have any warnings from PHPCS.
- [x] My code follows [the WordPress coding standards](https://developer.wordpress.org/coding-standards/).
- [x] My code follows [the accessibility standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/).
- [x] All new functions and classes have code documentation.
