### PR TITLE
Coding standards/ca 127 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Fix: Removes html from displaying in popup in place of privacy policy link.
 
 ## v1.17.1 - 12/04/2022
 

--- a/classes/Shortcode/Subscribe.php
+++ b/classes/Shortcode/Subscribe.php
@@ -640,7 +640,6 @@ class PUM_Shortcode_Subscribe extends PUM_Shortcode {
 						<p>
 							<small>
 							<?php
-							echo esc_html(
 								wp_kses(
 									$usage_text,
 									[
@@ -649,10 +648,9 @@ class PUM_Shortcode_Subscribe extends PUM_Shortcode {
 											'href'   => true,
 										],
 									]
-								)
-							);
+								);
 							?>
-									</small>
+							</small>
 						</p>
 					<?php endif; ?>
 				</div>


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Remove esc_html() to fix {{privacy_link}} from over escaping.

<!-- If this is a new feature or major change, you must link to an issue that explains use case. -->
Related Issue: Privacy link issue https://wordpress.org/support/topic/privacy_link-not-working-getting-a-href-code/#post-16324305

## Types of changes
<!-- What types of changes does your code introduce?  -->
Fix: Removes html from displaying in popup in place of privacy policy link.

## Screenshots
<!-- if applicable -->

## This has been tested in the following browsers

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [x] Safari

## Merge Checklist

- [ ] This PR passes all automated checks (will appear once pull request is submitted)
- [x] My code has been tested in the latest version of WordPress.
- [ ] My code does not have any warnings from ESLint.
- [ ] My code does not have any warnings from StyleLint.
- [ ] My code does not have any warnings from PHPCS.
- [x] My code follows [the WordPress coding standards](https://developer.wordpress.org/coding-standards/).
- [ ] My code follows [the accessibility standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/).
- [ ] All new functions and classes have code documentation.
