### PR TITLE
GH-1043: Error log tool is broken in WordPress VIP Setup

### DIFF
--- a/classes/Utils/Logging.php
+++ b/classes/Utils/Logging.php
@@ -80,7 +80,7 @@ class PUM_Utils_Logging {
 		$this->is_writable = false !== $this->fs && 'direct' === $this->fs->method;
 
 		$upload_dir = PUM_Helpers::get_upload_dir();
-		if ( ! $this->fs->is_writable( $upload_dir['basedir'] ) ) {
+		if ( is_object( $this->fs ) && ! $this->fs->is_writable( $upload_dir['basedir'] ) ) {
 			$this->is_writable = false;
 		}
 
@@ -136,7 +136,7 @@ class PUM_Utils_Logging {
 		$old_file       = trailingslashit( $upload_dir['basedir'] ) . 'pum-debug.log';
 
 		// If old file exists, move it.
-		if ( $this->fs->exists( $old_file ) ) {
+		if ( is_object( $this->fs ) && $this->fs->exists( $old_file ) ) {
 			$old_content = $this->get_file( $old_file );
 			$this->set_log_content( $old_content, true );
 
@@ -149,14 +149,14 @@ class PUM_Utils_Logging {
 			if ( $this->fs->exists( $old_file ) ) {
 				$this->fs->delete( $old_file );
 			}
-		} elseif ( ! $this->fs->exists( $this->file ) ) {
+		} elseif ( is_object( $this->fs ) && ! $this->fs->exists( $this->file ) ) {
 			$this->setup_new_log();
 		} else {
 			$this->content = $this->get_file( $this->file );
 		}
 
 		// Truncate long log files.
-		if ( $this->fs->exists( $this->file ) && $this->fs->size( $this->file ) >= 1048576 ) {
+		if ( is_object( $this->fs ) && $this->fs->exists( $this->file ) && $this->fs->size( $this->file ) >= 1048576 ) {
 			$this->truncate_log();
 		}
 	}
@@ -248,7 +248,7 @@ class PUM_Utils_Logging {
 
 		$content = '';
 
-		if ( $this->fs->exists( $file ) ) {
+		if ( is_object( $this->fs ) && $this->fs->exists( $file ) ) {
 			$content = $this->fs->get_contents( $file );
 		}
 
@@ -279,7 +279,7 @@ class PUM_Utils_Logging {
 	 * Save the current contents to file.
 	 */
 	public function save_logs() {
-		if ( ! $this->enabled() ) {
+		if ( ! $this->enabled() || ! is_object( $this->fs ) ) {
 			return;
 		}
 
@@ -323,7 +323,7 @@ class PUM_Utils_Logging {
 	 */
 	public function clear_log() {
 		// Delete the file.
-		@$this->fs->delete( $this->file );
+		is_object( $this->fs ) && @$this->fs->delete( $this->file );
 
 		if ( $this->enabled() ) {
 			$this->setup_new_log();

--- a/classes/Utils/Logging.php
+++ b/classes/Utils/Logging.php
@@ -79,7 +79,7 @@ class PUM_Utils_Logging {
 
 		$this->is_writable = false !== $this->fs && 'direct' === $this->fs->method;
 
-		if ( defined( 'VIP_GO_ENV' ) ) {
+		if ( defined( 'WPCOM_IS_VIP_ENV' ) ) {
 			$this->is_writable = false !== $this->fs && 'vip' === $this->fs->method;
 		}
 
@@ -116,7 +116,7 @@ class PUM_Utils_Logging {
 			return false;
 		}
 
-		if ( defined( 'VIP_GO_ENV' ) ) {
+		if ( defined( 'WPCOM_IS_VIP_ENV' ) ) {
 			if ( ! is_a( $wp_filesystem, 'WP_Filesystem_Base' ) ) {
 				$creds    = request_filesystem_credentials( site_url() );
 				$writable = WP_Filesystem( $creds );

--- a/classes/Utils/Logging.php
+++ b/classes/Utils/Logging.php
@@ -79,6 +79,10 @@ class PUM_Utils_Logging {
 
 		$this->is_writable = false !== $this->fs && 'direct' === $this->fs->method;
 
+		if ( defined( 'VIP_GO_ENV' ) ) {
+			$this->is_writable = false !== $this->fs && 'vip' === $this->fs->method;
+		}
+
 		$upload_dir = PUM_Helpers::get_upload_dir();
 		if ( is_object( $this->fs ) && ! $this->fs->is_writable( $upload_dir['basedir'] ) ) {
 			$this->is_writable = false;
@@ -110,6 +114,14 @@ class PUM_Utils_Logging {
 		// If for some reason the include doesn't work as expected just return false.
 		if ( ! function_exists( 'WP_Filesystem' ) ) {
 			return false;
+		}
+
+		if ( defined( 'VIP_GO_ENV' ) ) {
+			if ( ! is_a( $wp_filesystem, 'WP_Filesystem_Base' ) ) {
+				$creds    = request_filesystem_credentials( site_url() );
+				$writable = WP_Filesystem( $creds );
+				return ( $writable && 'vip' === $wp_filesystem->method ) ? $wp_filesystem : false;
+			}
 		}
 
 		$writable = WP_Filesystem( false, '', true );


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
This PR adds extra checks to avoid calling the filesystem methods with a bool value rather than the WP_Filesystem object.

<!-- If this is a new feature or major change, you must link to an issue that explains use case. -->
Related Issue: https://github.com/PopupMaker/Popup-Maker/issues/1043

## Types of changes
<!-- What types of changes does your code introduce?  -->
For some condition (e.g. in WordPress VIP instance ), the variable `$this->fs` sets with `false` boolean and multiple methods gets called with a boolean rather than the object. 
To fix that, this PR adds the `is_object()` check wherever the `$this->fs` is used.

## Screenshots
<!-- if applicable -->

## This has been tested in the following browsers

- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Merge Checklist

- [ ] This PR passes all automated checks (will appear once pull request is submitted)
- [x] My code has been tested in the latest version of WordPress.
- [ ] My code does not have any warnings from ESLint.
- [ ] My code does not have any warnings from StyleLint.
- [ ] My code does not have any warnings from PHPCS.
- [x] My code follows [the WordPress coding standards](https://developer.wordpress.org/coding-standards/).
- [ ] My code follows [the accessibility standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/).
- [ ] All new functions and classes have code documentation.
