### PR TITLE
Fix deprecated usort return type

### DIFF
--- a/classes/Model/Popup.php
+++ b/classes/Model/Popup.php
@@ -1198,10 +1198,10 @@ class PUM_Model_Popup extends PUM_Abstract_Model_Post {
 	 * @param array $a Array with `timestamp` key for comparison.
 	 * @param array $b Array with `timestamp` key for comparison.
 	 *
-	 * @return bool
+	 * @return int
 	 */
 	public function compare_resets( $a, $b ) {
-		return (float) $a['timestamp'] < (float) $b['timestamp'];
+		return (float) $b['timestamp'] <=> (float) $a['timestamp'];
 	}
 
 	/**


### PR DESCRIPTION
## Description
<!-- Please describe what you have changed or added -->
Returning a boolean from a `usort` callback has been deprecated since PHP 8.0. This PR updates a callback to fix the deprecation error.

<!-- If this is a new feature or major change, you must link to an issue that explains use case. -->
Related Issue:

## Types of changes
<!-- What types of changes does your code introduce?  -->
This PR updates a `usort` callback to use the spaceship operator instead of a standard `<` comparison.

## Screenshots
<!-- if applicable -->

## This has been tested in the following browsers
Tested in Chrome; the change shouldn't have any browser-specific behavior.
- [x] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Merge Checklist

- [ ] This PR passes all automated checks (will appear once pull request is submitted)
- [x] My code has been tested in the latest version of WordPress.
- [x] My code does not have any warnings from ESLint.
- [x] My code does not have any warnings from StyleLint.
- [x] My code does not have any warnings from PHPCS.
- [x] My code follows [the WordPress coding standards](https://developer.wordpress.org/coding-standards/).
- [x] My code follows [the accessibility standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/).
- [x] All new functions and classes have code documentation.
