### PR TITLE
fixed: aria-labelledby attribute handling to prevent double double quotes from outputting #1088

### DIFF
--- a/templates/popup.php
+++ b/templates/popup.php
@@ -6,10 +6,12 @@
  * @copyright Copyright (c) 2024, Code Atlantic LLC
  */
 
-$labelledby = pum_get_popup_title() !== '' ? 'aria-labelledby="pum_popup_title_' . pum_get_popup_id() . '"' : '';
+$labelledby = pum_get_popup_title() !== '' ? 'pum_popup_title_' . pum_get_popup_id() : '';
 
 ?>
-<div id="pum-<?php pum_popup_ID(); ?>" role="dialog" aria-modal="false" <?php echo esc_attr( $labelledby ); ?> class="<?php pum_popup_classes(); ?>" <?php pum_popup_data_attr(); ?>>
+<div id="pum-<?php pum_popup_ID(); ?>" role="dialog" aria-modal="false" 
+    <?php if ( $labelledby ) : ?>aria-labelledby="<?php echo esc_attr( $labelledby ); ?>"<?php endif; ?> 
+    class="<?php pum_popup_classes(); ?>" <?php pum_popup_data_attr(); ?>>
 
 	<div id="popmake-<?php pum_popup_ID(); ?>" class="<?php pum_popup_classes( null, 'container' ); ?>">
 


### PR DESCRIPTION
## Description
This PR ensures proper attribute escaping to maintain security and prevent rendering issues in the DOM.

Since `pum_get_popup_title()` and `pum_get_popup_id()` are trusted sources this could have been easily solved by removing the `esc_attr`, but I opted to leave it for extra security and it may be required to meet WPCS.

<!-- If this is a new feature or major change, you must link to an issue that explains use case. -->
Related Issue: #1088 (Add proper escaping to `aria-labelledby` for popups)

## Types of changes
Bug fix.

## Screenshots
![Screenshot 2025-01-16 at 1 02 31 PM](https://github.com/user-attachments/assets/177e35c1-7741-4d69-a70f-68b28c2d825d)

## This has been tested in the following browsers

- [x] Chrome
- [x] Firefox
- [ ] Edge
- [ ] Safari

## Merge Checklist

- [ ] This PR passes all automated checks (will appear once pull request is submitted)
- [ ] My code has been tested in the latest version of WordPress.
- [ ] My code does not have any warnings from ESLint.
- [ ] My code does not have any warnings from StyleLint.
- [ ] My code does not have any warnings from PHPCS.
- [ ] My code follows [the WordPress coding standards](https://developer.wordpress.org/coding-standards/).
- [ ] My code follows [the accessibility standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/).
- [ ] All new functions and classes have code documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Accessibility Improvements**
	- Enhanced popup dialog accessibility by refining how the `aria-labelledby` attribute is constructed and rendered.
	- Improved conditional handling of accessibility labels in popup templates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->