### PR TITLE
Update Settings.php

### DIFF
--- a/classes/Admin/Settings.php
+++ b/classes/Admin/Settings.php
@@ -427,7 +427,7 @@ class PUM_Admin_Settings {
 									'}}'
 								) : '',
 								'type'         => 'text',
-								'std'          => __( 'If you opt in above we use this information to send related content, discounts and other special offers.', 'popup-maker' ),
+								'std'          => __( 'If you opt in above, we use this information to send related content, discounts, and other special offers.', 'popup-maker' ),
 								'dependencies' => [
 									'privacy_consent_always_enabled' => 'yes',
 								],

--- a/classes/Admin/Settings.php
+++ b/classes/Admin/Settings.php
@@ -427,7 +427,7 @@ class PUM_Admin_Settings {
 									'}}'
 								) : '',
 								'type'         => 'text',
-								'std'          => __( 'If you opt in above we use this information send related content, discounts and other special offers.', 'popup-maker' ),
+								'std'          => __( 'If you opt in above we use this information to send related content, discounts and other special offers.', 'popup-maker' ),
 								'dependencies' => [
 									'privacy_consent_always_enabled' => 'yes',
 								],

--- a/classes/Shortcode/Subscribe.php
+++ b/classes/Shortcode/Subscribe.php
@@ -406,7 +406,7 @@ class PUM_Shortcode_Subscribe extends PUM_Shortcode {
 								'}}'
 							) : '',
 							'type'         => 'text',
-							'std'          => pum_get_option( 'default_privacy_usage_text', __( 'If you opt in above we use this information send related content, discounts and other special offers.', 'popup-maker' ) ),
+							'std'          => pum_get_option( 'default_privacy_usage_text', __( 'If you opt in above we use this information to send related content, discounts and other special offers.', 'popup-maker' ) ),
 							'dependencies' => $privacy_enabled_dependency,
 						],
 					],

--- a/classes/Shortcode/Subscribe.php
+++ b/classes/Shortcode/Subscribe.php
@@ -406,7 +406,7 @@ class PUM_Shortcode_Subscribe extends PUM_Shortcode {
 								'}}'
 							) : '',
 							'type'         => 'text',
-							'std'          => pum_get_option( 'default_privacy_usage_text', __( 'If you opt in above we use this information to send related content, discounts and other special offers.', 'popup-maker' ) ),
+							'std'          => pum_get_option( 'default_privacy_usage_text', __( 'If you opt in above, we use this information to send related content, discounts, and other special offers.', 'popup-maker' ) ),
 							'dependencies' => $privacy_enabled_dependency,
 						],
 					],

--- a/classes/Shortcode/Subscribe.php
+++ b/classes/Shortcode/Subscribe.php
@@ -434,7 +434,7 @@ class PUM_Shortcode_Subscribe extends PUM_Shortcode {
 							'type'  => 'checkbox',
 						],
 						'openpopup_id' => [
-							'label'        => __( 'Popup ID', 'popup-maker' ),
+							'label'        => __( 'Popup Name', 'popup-maker' ),
 							'type'         => 'select',
 							'options'      => [
 								0 => __( 'Select a popup', 'popup-maker' ),


### PR DESCRIPTION
Typo in the default consent usage text.

## Description
<!-- Please describe what you have changed or added -->

Fixed a typo and added missing commas in the default **Consent Usage Text**.

Changed the **Open Popup** > **Popup ID** to **Popup Name** for accuracy.

<!-- If this is a new feature or major change, you must link to an issue that explains use case. -->
Related Issue:

## Types of changes
<!-- What types of changes does your code introduce?  -->

## Screenshots
<!-- if applicable -->

**Consent Usage Text**: https://wppopupmaker.com/docs/getting-started/shortcode-subscription-form/#consent-usage-text

**Open Popup**: https://wppopupmaker.com/docs/getting-started/shortcode-subscription-form/#open-popup

</blockquote>

## This has been tested in the following browsers

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari

## Merge Checklist

- [ ] This PR passes all automated checks (will appear once pull request is submitted)
- [ ] My code has been tested in the latest version of WordPress.
- [ ] My code does not have any warnings from ESLint.
- [ ] My code does not have any warnings from StyleLint.
- [ ] My code does not have any warnings from PHPCS.
- [ ] My code follows [the WordPress coding standards](https://developer.wordpress.org/coding-standards/).
- [ ] My code follows [the accessibility standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/).
- [ ] All new functions and classes have code documentation.
