### PR TITLE
Fix post_type property notice

### DIFF
--- a/classes/ConditionCallbacks.php
+++ b/classes/ConditionCallbacks.php
@@ -279,6 +279,10 @@ class PUM_ConditionCallbacks {
 
 	public static function is_post_type( $post_type ) {
 		global $post;
-		return is_object( $post ) && ( is_singular( $post_type ) || $post->post_type === $post_type );
+
+		return is_object( $post ) && (
+			is_singular( $post_type ) ||
+			( property_exists( $post, 'post_type' ) && $post->post_type === $post_type )
+		);
 	}
 }


### PR DESCRIPTION
## Summary
- avoid undefined property warnings by checking `$post->post_type` exists
- revert accidental `package-lock.json` changes

## Testing
- `composer run-script tests` *(fails: Cannot acquire reference to $GLOBALS)*
- `composer run-script lint` *(fails: missing xmlwriter and SimpleXML extensions)*

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability when checking post types, preventing potential errors if the post object lacks the expected property.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->