### PR TITLE
Add sorting by Enabled status in popup admin list table

### DIFF
--- a/classes/Admin/Popups.php
+++ b/classes/Admin/Popups.php
@@ -1359,6 +1359,7 @@ class PUM_Admin_Popups {
 	 */
 	public static function sortable_columns( $columns ) {
 		$columns['popup_title'] = 'popup_title';
+		$columns['enabled']     = 'enabled';
 		$columns['views']       = 'views';
 		$columns['conversions'] = 'conversions';
 
@@ -1385,6 +1386,16 @@ class PUM_Admin_Popups {
 								// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 								'meta_key' => 'popup_title',
 								'orderby'  => 'meta_value',
+							]
+						);
+						break;
+					case 'enabled':
+						$vars = array_merge(
+							$vars,
+							[
+								// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+								'meta_key' => 'enabled',
+								'orderby'  => 'meta_value_num',
 							]
 						);
 						break;


### PR DESCRIPTION
Allows administrators to sort popups by their enabled/disabled status in the admin list table, making it easier to find and manage active or inactive popups.

## Merge Checklist

- [ ] This PR passes all automated checks (will appear once pull request is submitted)
- [ ] My code has been tested in the latest version of WordPress.
- [ ] My code does not have any warnings from ESLint.
- [ ] My code does not have any warnings from StyleLint.
- [ ] My code does not have any warnings from PHPCS.
- [ ] My code follows [the WordPress coding standards](https://developer.wordpress.org/coding-standards/).
- [ ] My code follows [the accessibility standards](https://developer.wordpress.org/coding-standards/wordpress-coding-standards/accessibility/).
- [ ] All new functions and classes have code documentation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a sortable "Enabled" column to the Popup list table so you can sort popups by enabled/disabled status directly in the admin, improving visibility and management of popup states.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->