### PR TITLE
feat(admin): add sorting by Enabled status in popup list table

### DIFF
--- a/classes/Admin/Popups.php
+++ b/classes/Admin/Popups.php
@@ -1359,6 +1359,7 @@ class PUM_Admin_Popups {
 	 */
 	public static function sortable_columns( $columns ) {
 		$columns['popup_title'] = 'popup_title';
+		$columns['enabled']     = 'enabled';
 		$columns['views']       = 'views';
 		$columns['conversions'] = 'conversions';
 
@@ -1385,6 +1386,16 @@ class PUM_Admin_Popups {
 								// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 								'meta_key' => 'popup_title',
 								'orderby'  => 'meta_value',
+							]
+						);
+						break;
+					case 'enabled':
+						$vars = array_merge(
+							$vars,
+							[
+								// phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+								'meta_key' => 'enabled',
+								'orderby'  => 'meta_value_num',
 							]
 						);
 						break;


### PR DESCRIPTION
Allows administrators to sort popups by their enabled/disabled status in the admin list table, making it easier to find and manage active or inactive popups.

## Changes
- Added `enabled` column to sortable columns list
- Added sort query handler using correct `enabled` meta key with `meta_value_num` for numeric 0/1 sorting

Supersedes #1127 with corrected meta key and orderby type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added sorting capability for popup enabled/disabled status in the admin management interface, allowing administrators to organize popups by their active status.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->