### PR TITLE
docs(release): add JSDoc docstrings to extract-changelog.js

### DIFF
--- a/bin/extract-changelog.js
+++ b/bin/extract-changelog.js
@@ -39,19 +39,21 @@ if ( ! fs.existsSync( changelogPath ) ) {
 const changelogContent = fs.readFileSync( changelogPath, 'utf8' );
 
 /**
- * Escape regex metacharacters in a string
- * @param {string} str - String to escape
- * @return {string} - Escaped string safe for use in RegExp
+ * Escape regex metacharacters in a string.
+ *
+ * @param {string} str - String to escape.
+ * @return {string} Escaped string safe for use in RegExp.
  */
 function escapeRegex( str ) {
 	return str.replace( /[.+*?^$[\](){}|\\]/g, '\\$&' );
 }
 
 /**
- * Extract content for a specific version
- * @param {string} content - Full changelog content
- * @param {string} version - Version to extract (e.g., "1.0.3")
- * @return {string|null} - Extracted content or null if not found
+ * Extract the changelog section for a specific released version.
+ *
+ * @param {string} content - The full CHANGELOG.md text.
+ * @param {string} version - The version identifier to locate (e.g., "1.0.3").
+ * @return {string|null} The trimmed changelog content for the given version, or `null` if the version is not present.
  */
 function extractVersionContent( content, version ) {
 	// Escape version string to handle metacharacters like dots and plus signs
@@ -69,9 +71,11 @@ function extractVersionContent( content, version ) {
 }
 
 /**
- * Extract unreleased changes
- * @param {string} content - Full changelog content
- * @return {string|null} - Extracted unreleased content or null if not found
+ * Extract the content under the "Unreleased" section of a changelog.
+ *
+ * Captures the text after the "## Unreleased" heading up to the next "##" heading or end of file and trims surrounding whitespace.
+ * @param {string} content - Full changelog text.
+ * @return {string|null} The trimmed content of the "Unreleased" section, or `null` if the section is missing or empty.
  */
 function extractUnreleasedContent( content ) {
 	// Handles both LF and CRLF line endings
@@ -87,9 +91,10 @@ function extractUnreleasedContent( content ) {
 }
 
 /**
- * Extract latest released version content
- * @param {string} content - Full changelog content
- * @return {object|null} - Object with version and content, or null if not found
+ * Find the first released version entry after the "Unreleased" section and return its version and associated changelog text.
+ *
+ * @param {string} content - Complete CHANGELOG.md text.
+ * @return {{version: string, content: string}|null} An object with `version` (semantic version string) and `content` (trimmed section text) when a released version is found, `null` otherwise.
  */
 function extractLatestVersion( content ) {
 	// Find the first version heading after Unreleased section
@@ -120,10 +125,13 @@ function extractLatestVersion( content ) {
 }
 
 /**
- * Format content for GitHub release body
- * @param {string} content - Raw changelog content
- * @param {string} version - Version number
- * @return {string} - Formatted content
+ * Prepare changelog content for use as a GitHub release body.
+ *
+ * Normalizes list formatting and trims surrounding whitespace. If `content` is falsy,
+ * returns a header that includes `version` and the message "No changelog content available."
+ * @param {string} content - Raw changelog content to format.
+ * @param {string} version - Version label used when no content is available.
+ * @return {string} Formatted changelog text suitable for a GitHub release body.
  */
 function formatForGitHubRelease( content, version ) {
 	if ( ! content ) {


### PR DESCRIPTION
Adds comprehensive JSDoc docstrings to the changelog extraction utility script.

## Changes
- Added proper JSDoc documentation to all functions
- Fixed `@returns` → `@return` per project ESLint rules
- Resolved merge conflicts with current develop

Supersedes #1141 (CodeRabbit docstrings PR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation for changelog extraction functionality with clearer descriptions of expected behaviors and edge cases.

* **Bug Fixes**
  * Improved version pattern detection to support optional prefixes and date suffixes.
  * Better handling of missing or empty changelog sections with appropriate fallback messages.
  * Refined whitespace trimming and bullet-point formatting in generated release notes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->