### PR TITLE
fix: validate tab existence before restoring from sessionStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 
 **Fixes**
 
+-   Fixed Time Delay trigger settings tab displaying blank when switching from Click Trigger advanced tab. Closes #1109.
 -   Fixed trigger modal "Add" button label not displaying due to incorrect i18n function usage. Props to @DAnn2012.
 -   Fixed Divi 4 block editor compatibility issue where the popup editor would fail to load when the block editor was enabled. The classic editor is now automatically enforced for Divi 4 users.
 -   Fixed license key not deactivating properly.

--- a/assets/js/src/admin/general/plugins/tabs.js
+++ b/assets/js/src/admin/general/plugins/tabs.js
@@ -29,10 +29,15 @@
 							: $this.parents( '[id]' ).attr( 'id' );
 
 					if ( typeof storage[ id ] !== 'undefined' ) {
-						// If we have a stored tab, set it as the first tab.
-						$firstTab = $tabList
+						// If we have a stored tab, check if it exists for this trigger type.
+						var $storedTab = $tabList
 							.find( 'a[href="' + storage[ id ] + '"]' )
 							.parent();
+
+						// Only use stored tab if it exists, otherwise fall back to first tab.
+						if ( $storedTab.length > 0 ) {
+							$firstTab = $storedTab;
+						}
 					}
 
 					if ( $this.hasClass( 'vertical-tabs' ) ) {


### PR DESCRIPTION
## Summary
Fixes Time Delay trigger settings tab displaying blank when switching from Click Trigger advanced tab.

## Changes
- Added validation to check if stored tab exists for current trigger type
- Falls back to first tab if stored tab doesn't exist
- Prevents blank tab display when switching between trigger types with different tab configurations

## Testing
- Edit Click Trigger advanced settings
- Switch to Time Delay trigger
- General tab now displays correctly instead of blank

Closes #1109

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where Time Delay trigger settings tab would display blank when switching from Click Trigger advanced tab.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->