### PR TITLE
fix: prevent double protocol URLs in subscribers page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 -   Fixed license key not deactivating properly.
 -   Fixed issue where license keys were being saved as asterisks instead of the actual key.
 -   Fixed issue where filter `replace_editor` was being used as an action without returning the value.
+-   Fixed Subscribers page sort columns throwing 404 errors due to malformed URLs with double protocols (e.g., `https://http//site.com`). Closes #1092.
 
 ## v1.21.5 - 2025-10-13
 

--- a/classes/ListTable.php
+++ b/classes/ListTable.php
@@ -839,7 +839,10 @@ class PUM_ListTable {
 		$host        = isset( $_SERVER['HTTP_HOST'] ) ? esc_url_raw( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : wp_parse_url( home_url(), PHP_URL_HOST );
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 
-		$current_url = set_url_scheme( $host . $request_uri );
+		// Strip any existing protocol from host to prevent double protocol issues (https://http//site.com).
+		$host = preg_replace( '#^https?://#', '', $host );
+
+		$current_url = set_url_scheme( 'http://' . $host . $request_uri );
 
 		$current_url = remove_query_arg( $removable_query_args, $current_url );
 
@@ -1136,6 +1139,9 @@ class PUM_ListTable {
 
 		$host        = isset( $_SERVER['HTTP_HOST'] ) ? sanitize_url( wp_unslash( $_SERVER['HTTP_HOST'] ) ) : wp_parse_url( home_url(), PHP_URL_HOST );
 		$request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+
+		// Strip any existing protocol from host to prevent double protocol issues (https://http//site.com).
+		$host = preg_replace( '#^https?://#', '', $host );
 
 		$current_url = set_url_scheme( 'http://' . $host . $request_uri );
 


### PR DESCRIPTION
## Summary
Fixes subscribers page sort columns throwing 404 errors due to malformed URLs.

## Changes
- Strip existing protocol from HTTP_HOST before prepending
- Prevents double protocol URLs like `https://http//site.com`
- Applied fix to both `get_sortable_link()` and `prepare_items()` methods

## Error Fixed
Sort column links generating URLs like:
```
https://http//site.com/wp-admin/admin.php?page=pum-subscribers
```

## Testing
- Navigate to Popup Maker > Subscribers
- Click any sortable column header
- URLs now properly formatted, sorting works correctly

Closes #1092

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where sorting columns on the Subscribers page would result in 404 errors caused by malformed URLs with double protocols.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->