### PR TITLE
feat: add setting to disable PID URL tracking parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,15 @@
 
 ## Unreleased
 
+**Features**
+
+-   Added "Disable URL tracking parameters" privacy setting. When enabled, popup links no longer get `?pid=` appended — link clicks are tracked via browser beacons instead (less reliable but non-invasive to URLs).
+
 **Bug Fixes**
 
 -   Fixed block library frontend styles (`block-library-style.css`) missing from production builds. WordPress blocks referencing the `popup-maker-block-library-style` handle would trigger a missing asset. The webpack build config now correctly splits frontend `style.scss` from editor `editor.scss` into separate CSS files.
+-   Fixed URL tracking module ignoring the "Disable popup open tracking" privacy setting. When analytics are disabled, link tracking parameters and click beacons are now properly suppressed.
+-   Fixed PHP operator precedence bug in `pum_get_asset_group_meta()` where `(array) file_exists()` always evaluated as truthy, causing fatal errors when build artifacts were missing.
 
 ## v1.22.0 - 2026-03-31
 

--- a/assets/js/src/site/plugins/pum-url-tracking.js
+++ b/assets/js/src/site/plugins/pum-url-tracking.js
@@ -45,8 +45,14 @@
 		/**
 		 * Process all links within a popup to add tracking parameters.
 		 *
-		 * Internal links get ?pid= appended (tracked via server redirect).
-		 * External/special links get click handlers for beacon tracking.
+		 * Internal links get ?pid= appended (tracked via server redirect),
+		 * unless disable_url_params is enabled, in which case they use
+		 * beacon tracking like external links.
+		 *
+		 * External/special links always get click handlers for beacon tracking.
+		 *
+		 * When disable_tracking is true (analytics fully disabled), no
+		 * tracking of any kind is applied.
 		 *
 		 * @param {jQuery} $popup The popup element.
 		 * @param {number} pid    The popup ID.
@@ -54,33 +60,47 @@
 		processPopupLinks: function ( $popup, pid ) {
 			var self = this;
 
+			// If all analytics disabled, do nothing.
+			if ( pum_vars.disable_tracking ) {
+				return;
+			}
+
 			$popup.find( 'a[href]' ).each( function () {
 				var $link = $( this ),
 					href = $link.attr( 'href' );
 
 				if ( self.isInternalUrl( href ) ) {
-					// Get the filterable param name (defaults to 'pid').
-					var pidParam =
-						window.pum_vars?.paramNames?.popup_id || 'pid';
+					if ( pum_vars.disable_url_params ) {
+						// Beacon fallback for internal links (same as external).
+						if ( self.shouldTrackClick( href ) ) {
+							self.attachClickTracking( $link, pid, href );
+						}
+					} else {
+						// Default: append pid param for server-side tracking.
+						var pidParam =
+							window.pum_vars?.paramNames?.popup_id || 'pid';
 
-					// Internal URLs: Append PID parameter (tracked via server redirect).
-					var urlParams = {};
-					urlParams[ pidParam ] = pid;
+						var urlParams = {};
+						urlParams[ pidParam ] = pid;
 
-					// Allow extensions to add additional parameters.
-					if ( window.PUM && window.PUM.hooks ) {
-						urlParams = window.PUM.hooks.applyFilters(
-							'popupMaker.popup.linkUrlParams',
-							urlParams,
-							$popup,
-							$link
+						// Allow extensions to add additional parameters.
+						if ( window.PUM && window.PUM.hooks ) {
+							urlParams = window.PUM.hooks.applyFilters(
+								'popupMaker.popup.linkUrlParams',
+								urlParams,
+								$popup,
+								$link
+							);
+						}
+
+						var newHref = self.appendParamsToUrl(
+							href,
+							urlParams
 						);
+						$link.attr( 'href', newHref );
 					}
-
-					var newHref = self.appendParamsToUrl( href, urlParams );
-					$link.attr( 'href', newHref );
 				} else if ( self.shouldTrackClick( href ) ) {
-					// External/special links: Attach click handler for beacon tracking.
+					// External/special links: always beacon tracking.
 					self.attachClickTracking( $link, pid, href );
 				}
 			} );

--- a/assets/js/src/site/plugins/pum.js
+++ b/assets/js/src/site/plugins/pum.js
@@ -17,6 +17,7 @@
 		rest_nonce: null,
 		debug_mode: false,
 		disable_tracking: true,
+		disable_url_params: false,
 		message_position: 'top',
 		core_sub_forms_enabled: true,
 		popups: {},

--- a/classes/Admin/Settings.php
+++ b/classes/Admin/Settings.php
@@ -426,6 +426,11 @@ class PUM_Admin_Settings {
 								'label' => __( 'Disables popup open tracking?', 'popup-maker' ),
 								'desc'  => __( 'This will disable the built in analytics functionality.', 'popup-maker' ),
 							],
+							'disable_pid_url_params'      => [
+								'type'  => 'checkbox',
+								'label' => __( 'Disable URL tracking parameters?', 'popup-maker' ),
+								'desc'  => __( 'Stops adding tracking parameters (pid) to links inside popups. Link clicks will be tracked via browser beacons instead (less reliable but non-invasive).', 'popup-maker' ),
+							],
 						],
 						'forms' => [
 							'forms_disclaimer'             => [

--- a/classes/Site/Assets.php
+++ b/classes/Site/Assets.php
@@ -262,6 +262,7 @@ class PUM_Site_Assets {
 					'default_theme'          => (string) pum_get_default_theme_id(),
 					'debug_mode'             => Popup_Maker::debug_mode(),
 					'disable_tracking'       => popmake_get_option( 'disable_popup_open_tracking' ),
+					'disable_url_params'     => (bool) pum_get_option( 'disable_pid_url_params' ),
 					'home_url'               => trailingslashit( $site_home_path ),
 					'message_position'       => 'top',
 					'core_sub_forms_enabled' => ! PUM_Newsletters::$disabled,

--- a/includes/functions/developers.php
+++ b/includes/functions/developers.php
@@ -251,7 +251,7 @@ function pum_get_asset_meta( $file, $default_args = [] ) {
 function pum_get_asset_group_meta( $group, $default_args = [] ) {
 	$file = plugin()->get_path( "dist/$group-assets.php" );
 
-	$meta = (array) file_exists( $file ) ? require $file : [];
+	$meta = file_exists( $file ) ? (array) require $file : [];
 
 	foreach ( $meta as $key => $value ) {
 		$meta[ $key ] = wp_parse_args( $value, $default_args );


### PR DESCRIPTION
## Summary

- Adds a **"Disable URL tracking parameters?"** checkbox under **Settings > Privacy**
- When enabled, internal links inside popups no longer get `?pid=` appended to their URLs
- Link clicks fall back to browser beacon tracking (`sendBeacon` / image pixel) — the same method already used for external, mailto, and tel links
- When the existing "Disables popup open tracking?" setting is on, **all** tracking is now skipped (pid params, beacons, and click handlers) — previously the URL tracking module didn't respect this setting

## Changes

| File | Change |
|------|--------|
| `classes/Admin/Settings.php` | New `disable_pid_url_params` checkbox in Privacy tab |
| `classes/Site/Assets.php` | Pass `disable_url_params` to frontend `pum_vars` |
| `assets/js/src/site/plugins/pum.js` | Default `disable_url_params: false` |
| `assets/js/src/site/plugins/pum-url-tracking.js` | Respect both `disable_tracking` and `disable_url_params` flags |

## Test plan

- [ ] Default behavior: no settings changed → internal links still get `?pid=X` appended
- [ ] Enable new setting → internal links stay clean, clicking fires a beacon
- [ ] Enable "Disables popup open tracking?" → no pid params, no beacons, no click handlers
- [ ] External links always use beacon regardless of new setting
- [ ] JS builds successfully

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a privacy setting to stop appending popup tracking parameters to links; when enabled, link clicks are tracked via browser beacons instead.
  * Client-side now exposes a related toggle and respects the new setting and a global disable-tracking option.
* **Bug Fixes**
  * Fixed link-tracking logic to honor the global disable-tracking setting.
* **Other**
  * Minor robustness improvements to asset metadata handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->