### PR TITLE
fix: emit block-library-style.css for CTA block frontend styles (#1198)

### DIFF
--- a/packages/block-library/src/index.ts
+++ b/packages/block-library/src/index.ts
@@ -2,6 +2,7 @@ import domReady from '@wordpress/dom-ready';
 
 // import './lib/call-to-action';
 
+import './style.scss';
 import * as blocks from './lib';
 
 declare global {

--- a/packages/block-library/src/lib/cta-button/index.ts
+++ b/packages/block-library/src/lib/cta-button/index.ts
@@ -1,5 +1,4 @@
 import './editor.scss';
-import './style.scss';
 
 /**
  * WordPress dependencies

--- a/packages/block-library/src/lib/cta-buttons/index.ts
+++ b/packages/block-library/src/lib/cta-buttons/index.ts
@@ -1,5 +1,4 @@
 import './editor.scss';
-import './style.scss';
 
 /**
  * WordPress dependencies

--- a/packages/block-library/src/style.scss
+++ b/packages/block-library/src/style.scss
@@ -1,0 +1,7 @@
+/**
+ * Frontend block styles for the block-library package entry.
+ *
+ * Imported from src/index.ts so webpack emits block-library-style.css.
+ */
+@import './lib/cta-button/style';
+@import './lib/cta-buttons/style';


### PR DESCRIPTION
## Summary

Closes #1198.

Built and confirmed the bug on `1.22.0`:

```bash
# Before (1.22.0 tag)
dist/packages/block-library.css          # 8.6KB — editor + frontend styles merged, wrong handle
dist/packages/block-library-style.css    # MISSING — 404 for popup-maker-block-library-style
```

The release registers/enqueues `dist/packages/block-library-style.css`, but webpack never emitted that file.

**Root cause:** `LimitChunkCountPlugin` (`maxChunks: 1`) prevented `splitChunks` from separating frontend `style.scss` into its own CSS artifact. The old `MiniCssExtractPlugin` filename logic also checked `chunk.name.includes('style')`, which never matched the unnamed style-split chunks.

**Generation fix (already on develop via b920b656):**
- Remove `LimitChunkCountPlugin`
- Add explicit `splitChunks.cacheGroups.style` for `style.scss` imports
- Fix `MiniCssExtractPlugin` / `RtlCssPlugin` to emit `{runtime}-style.css` for unnamed style chunks

Verified after fix:

```bash
dist/packages/block-library.css          # 1.6KB — editor styles only
dist/packages/block-library-style.css    # 7.0KB — frontend CTA block styles
dist/packages/block-library-style-rtl.css
```

**This PR adds:** a root `packages/block-library/src/style.scss` entry point (per issue recommendation) imported from `src/index.ts`, consolidating frontend block styles so webpack reliably picks them up for the `-style.css` split.

## Test plan

- [x] `NODE_ENV=production npm run build` on branch produces `dist/packages/block-library-style.css`
- [x] `block-library-style.css` contains frontend CTA selectors (e.g. `.wp-block-popup-maker-cta-button__link`)
- [x] `block-library.css` contains editor-only styles (~1.6KB)
- [ ] Frontend page with CTA button block loads `popup-maker-block-library-style` without 404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reorganized block library style management and configuration. Updated stylesheet imports and bundling for block components, including CTA button blocks, to ensure styles are properly loaded and applied. These changes improve the organization and consistency of component styling throughout the block library while maintaining full functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PopupMaker/Popup-Maker/pull/1219?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->