### PR TITLE
fix: remove conflicting abstract method from Extension base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 **Bug Fixes**
 
+-   Fixed fatal error when loading v2 extensions caused by conflicting `registered_controllers()` declarations on `PopupMaker\Plugin\Extension`.
 -   Fixed the "Preview" button in the classic editor not opening popups — a regression introduced in 1.22.0. You can once again preview popups directly from the editor without having to save and view the live page. Thanks to @marklchaves for the fix.
 -   Fixed missing styles for Popup Maker blocks on the front end in some installs — blocks now render with the correct styling without a console warning about a missing stylesheet.
 -   Fixed "Disable popup open tracking" privacy setting not being fully respected — with analytics turned off, popup links no longer get tracking parameters appended and click beacons are no longer sent.

--- a/classes/Plugin/Extension.php
+++ b/classes/Plugin/Extension.php
@@ -13,6 +13,8 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Abstract base class for all Popup Maker extensions.
  *
+ * Override {@see Container::registered_controllers()} in child classes.
+ *
  * @since 1.21.0
  */
 abstract class Extension extends Container {
@@ -35,13 +37,6 @@ abstract class Extension extends Container {
 		// Get core plugin instance.
 		$this->core = \PopupMaker\plugin();
 	}
-
-	/**
-	 * Register all controllers.
-	 *
-	 * @return array<string,\PopupMaker\Base\Controller>
-	 */
-	abstract protected function registered_controllers();
 
 	/**
 	 * Get core plugin instance.


### PR DESCRIPTION
## Summary
- Removes the duplicate abstract `registered_controllers()` declaration from `PopupMaker\Plugin\Extension`.
- v2 extensions extend `Extension` → `Container`; the redeclared abstract method caused fatals during boot.

## Test plan
- [ ] Activate a v2 extension (Exit Intent, Scroll Triggers, or Scheduling) against core with this branch.
- [ ] Confirm plugin boots without fatal errors.
- [ ] Confirm extension controllers still register and frontend assets load.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a fatal error that occurred when loading v2 extensions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/PopupMaker/Popup-Maker/pull/1221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->