### PR TITLE
fix(i18n): preserve partial translation output

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -132,7 +132,20 @@ jobs:
                     ARGS+=( --max-strings-per-job "$INPUT_MAX_STRINGS" )
                   fi
 
+                  set +e
                   pnpm dlx "potomatic@$POTOMATIC_VERSION" "${ARGS[@]}"
+                  TRANSLATION_EXIT=$?
+                  set -e
+
+                  if [[ "$TRANSLATION_EXIT" -ne 0 ]]; then
+                    if git status --porcelain --untracked-files=all -- languages/ \
+                      | awk '{ print $2 }' \
+                      | grep -Eq "^languages/${PLUGIN_SLUG}-.*\\.po$"; then
+                      echo "::warning::Potomatic exited with status $TRANSLATION_EXIT after producing partial translations. Preserving them for review."
+                    else
+                      exit "$TRANSLATION_EXIT"
+                    fi
+                  fi
 
             - name: Generate runtime translations
               if: inputs.dry_run != true


### PR DESCRIPTION
Preserve generated PO files when Potomatic reaches its cost limit or returns partial translation warnings. No-output failures still fail the job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Translation workflows now preserve partially generated translation files when processing encounters an error.
  * Clear warnings are logged, while genuine failures still return the original error status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->