### PR TITLE
fix(i18n): correct Turkish format placeholder

### DIFF
--- a/languages/popup-maker-tr_TR.po
+++ b/languages/popup-maker-tr_TR.po
@@ -4419,7 +4419,7 @@ msgid ""
 "another <strong>%2$s–%3$s</strong> left on the table."
 msgstr ""
 "Şu ana kadar <strong>%1$s dönüşüm</strong> yakaladınız. Çıkış niyeti, "
-"vazgeçen ziyaretçilerin genellikle %10–15%%’ini geri kazanır — sizin "
+"vazgeçen ziyaretçilerin genellikle 10–15%%’ini geri kazanır — sizin "
 "trafiğinizde bu, masada bırakılan <strong>ek %2$s–%3$s</strong> demek."
 
 #: classes/Services/Notifications/FeatureAnnouncements.php:829


### PR DESCRIPTION
Remove an accidental leading percent sign that made a translated php-format string invalid. msgfmt validation passes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Turkish translation for the exit-intent notification by removing an extra percent sign from the discount placeholder.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->