### PR TITLE
fix(i18n): checkpoint long translation runs

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -133,7 +133,10 @@ jobs:
                   fi
 
                   set +e
-                  pnpm dlx "potomatic@$POTOMATIC_VERSION" "${ARGS[@]}"
+                  # Checkpoint long runs so completed locales are preserved if
+                  # an individual provider request stops responding.
+                  timeout --signal=TERM --kill-after=30s 20m \
+                    pnpm dlx "potomatic@$POTOMATIC_VERSION" "${ARGS[@]}"
                   TRANSLATION_EXIT=$?
                   set -e
 


### PR DESCRIPTION
Stops a stalled provider request from holding the translation job for hours. The existing partial-output guard preserves and publishes every completed locale after the 20-minute checkpoint; subsequent runs fill only what remains.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved translation workflow reliability by adding timeout handling to prevent indefinite process execution. Translation operations will now terminate gracefully with automatic cleanup after specified intervals.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->