### PR TITLE
Fix Jetpack synced form rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 -   Improved PHP 8.3 and 8.4 compatibility by safely handling extension-added post and metadata fields without deprecated dynamic properties, with expanded automated compatibility coverage through PHP 8.4.
 
+**Fixes**
+
+-   Added a compatibility safeguard for Jetpack synced forms that pass object-valued field attributes into string escaping.
+
 ## v1.24.0 - 2026-08-03
 
 **Security**

--- a/classes/Controllers/Compatibility.php
+++ b/classes/Controllers/Compatibility.php
@@ -31,6 +31,7 @@ class Compatibility extends Controller {
 			'Compatibility\SEO\Yoast'              => new \PopupMaker\Controllers\Compatibility\SEO\Yoast( $this->container ),
 			'Compatibility\Builder\Divi'           => new \PopupMaker\Controllers\Compatibility\Builder\Divi( $this->container ),
 			'Compatibility\Plugin\ACF'             => new \PopupMaker\Controllers\Compatibility\Plugin\ACF( $this->container ),
+			'Compatibility\Plugin\Jetpack'         => new \PopupMaker\Controllers\Compatibility\Plugin\Jetpack( $this->container ),
 			'Compatibility\Plugin\PostDuplication' => new \PopupMaker\Controllers\Compatibility\Plugin\PostDuplication( $this->container ),
 		] );
 	}

--- a/classes/Controllers/Compatibility/Plugin/Jetpack.php
+++ b/classes/Controllers/Compatibility/Plugin/Jetpack.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Jetpack compatibility controller.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Controllers\Compatibility\Plugin;
+
+use PopupMaker\Plugin\Controller;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Work around object-valued Jetpack form attributes causing rendering fatals.
+ */
+class Jetpack extends Controller {
+
+	/**
+	 * Check if Jetpack Forms is available.
+	 *
+	 * @return bool
+	 */
+	public function controller_enabled() {
+		return class_exists( '\Automattic\Jetpack\Forms\ContactForm\Contact_Form' );
+	}
+
+	/**
+	 * Initialize Jetpack compatibility hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_filter( 'render_block_data', [ $this, 'normalize_popup_form_block_data' ] );
+	}
+
+	/**
+	 * Normalize Jetpack field block data rendered from popup content.
+	 *
+	 * Jetpack Forms converts field block attributes back into shortcode
+	 * attributes when rendering synced forms. Its converter supports arrays,
+	 * but object-valued attributes cause a fatal error when escaped as strings.
+	 *
+	 * @param mixed $parsed_block Parsed block data.
+	 * @return mixed Normalized block data.
+	 */
+	public function normalize_popup_form_block_data( $parsed_block ) {
+		if ( ! doing_filter( 'pum_popup_content' ) || ! is_array( $parsed_block ) ) {
+			return $parsed_block;
+		}
+
+		$block_name = isset( $parsed_block['blockName'] ) && is_string( $parsed_block['blockName'] ) ? $parsed_block['blockName'] : '';
+
+		if ( 0 !== strpos( $block_name, 'jetpack/field-' ) ) {
+			return $parsed_block;
+		}
+
+		return $this->convert_objects_to_arrays( $parsed_block );
+	}
+
+	/**
+	 * Recursively convert stdClass values to arrays.
+	 *
+	 * @param mixed $value Value to normalize.
+	 * @return mixed Normalized value.
+	 */
+	private function convert_objects_to_arrays( $value ) {
+		if ( $value instanceof \stdClass ) {
+			$value = (array) $value;
+		}
+
+		if ( is_array( $value ) ) {
+			foreach ( $value as $key => $item ) {
+				$value[ $key ] = $this->convert_objects_to_arrays( $item );
+			}
+		}
+
+		return $value;
+	}
+}

--- a/tests/php/tests/Jetpack_Compatibility_Test.php
+++ b/tests/php/tests/Jetpack_Compatibility_Test.php
@@ -1,0 +1,125 @@
+<?php
+/**
+ * Jetpack compatibility controller tests.
+ *
+ * @package Popup_Maker
+ */
+
+use PopupMaker\Controllers\Compatibility\Plugin\Jetpack;
+
+/**
+ * Test Jetpack Forms rendering compatibility.
+ */
+class Jetpack_Compatibility_Test extends WP_UnitTestCase {
+
+	/**
+	 * Controller under test.
+	 *
+	 * @var Jetpack
+	 */
+	private $controller;
+
+	/**
+	 * Set up test fixtures.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->controller = new Jetpack( new stdClass() );
+		$this->controller->init();
+	}
+
+	/**
+	 * Remove compatibility hooks.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		remove_filter( 'render_block_data', [ $this->controller, 'normalize_popup_form_block_data' ] );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test object-valued Jetpack field attributes are normalized recursively.
+	 */
+	public function test_normalizes_jetpack_field_block_attribute_objects() {
+		$parsed_block = [
+			'blockName'   => 'jetpack/field-name',
+			'attrs'       => [
+				'label'    => 'Name',
+				'metadata' => (object) [
+					'bindings' => (object) [
+						'label' => (object) [
+							'value' => 'Contact name',
+						],
+					],
+				],
+			],
+			'innerBlocks' => [
+				[
+					'blockName' => 'jetpack/label',
+					'attrs'     => [
+						'metadata' => (object) [
+							'value' => 'Name',
+						],
+					],
+				],
+			],
+		];
+
+		$normalized = $this->normalize_during_popup_rendering( $parsed_block );
+
+		$this->assertIsArray( $normalized['attrs']['metadata'] );
+		$this->assertIsArray( $normalized['attrs']['metadata']['bindings'] );
+		$this->assertSame( 'Contact name', $normalized['attrs']['metadata']['bindings']['label']['value'] );
+		$this->assertIsArray( $normalized['innerBlocks'][0]['attrs']['metadata'] );
+	}
+
+	/**
+	 * Test unrelated blocks and rendering outside popups remain unchanged.
+	 */
+	public function test_normalization_is_limited_to_jetpack_fields_in_popups() {
+		$metadata      = (object) [ 'value' => 'unchanged' ];
+		$jetpack_block = [
+			'blockName' => 'jetpack/field-name',
+			'attrs'     => [ 'metadata' => $metadata ],
+		];
+		$core_block    = [
+			'blockName' => 'core/paragraph',
+			'attrs'     => [ 'metadata' => $metadata ],
+		];
+
+		$this->assertSame( $metadata, apply_filters( 'render_block_data', $jetpack_block, $jetpack_block, null )['attrs']['metadata'] );
+		$this->assertSame( $metadata, $this->normalize_during_popup_rendering( $core_block )['attrs']['metadata'] );
+	}
+
+	/**
+	 * Test malformed filter values are left unchanged.
+	 */
+	public function test_malformed_block_data_is_left_unchanged() {
+		$this->assertSame( 'invalid', $this->controller->normalize_popup_form_block_data( 'invalid' ) );
+	}
+
+	/**
+	 * Apply render_block_data while popup content is being filtered.
+	 *
+	 * @param array<string, mixed> $parsed_block Parsed block data.
+	 * @return array<string, mixed> Filtered block data.
+	 */
+	private function normalize_during_popup_rendering( $parsed_block ) {
+		$normalized = null;
+		$callback   = function ( $content ) use ( $parsed_block, &$normalized ) {
+			$normalized = apply_filters( 'render_block_data', $parsed_block, $parsed_block, null );
+			return $content;
+		};
+
+		add_filter( 'pum_popup_content', $callback, 1 );
+		apply_filters( 'pum_popup_content', '', 0 );
+		remove_filter( 'pum_popup_content', $callback, 1 );
+
+		return $normalized;
+	}
+}


### PR DESCRIPTION
## Summary

- add a dedicated Jetpack compatibility controller
- normalize `stdClass` values in Jetpack field block data before Jetpack converts the values to shortcode attributes
- limit the safeguard to `jetpack/field-*` blocks rendered while filtering Popup Maker content
- add regression coverage for recursive normalization and scope boundaries

## Root cause

Jetpack Forms 16.1-beta.2 converts synced-form field block attributes back into shortcode attributes. Its conversion supports arrays, but object-valued attributes eventually reach `esc_html()`, causing `Object of class stdClass could not be converted to string`.

Popup Maker reaches this upstream rendering path while preloading popup content through WordPress's standard shortcode handling. The same form data can fail when rendered from another hook, such as `wp_footer`, so this change is a narrowly scoped compatibility safeguard rather than a replacement for an upstream Jetpack fix.

## Impact

Affected popups render without taking down the frontend. Blocks outside Popup Maker content, non-Jetpack blocks, and Jetpack field blocks rendered elsewhere remain unchanged.

## Validation

- PHPUnit: 871 tests, 1,781 assertions, 29 skipped
- PHPCS passed for the changed PHP source files
- PHPStan passed for the changed PHP source files
- `git diff --check` passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility between Jetpack Forms and popup content.
  - Prevented rendering failures when Jetpack form field attributes contain object-valued data.
  - Limited normalization to relevant Jetpack form fields rendered inside popups, preserving unrelated content.
  - Added safeguards for malformed form data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->