### PR TITLE
Fix Elementor popup editor preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+**Features**
+
 -   Added complete Elementor support for Popup Maker popups, including direct editing and previews, correctly styled frontend rendering, and interactive widgets.
 
 ## v1.24.0 - 2026-08-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
--   Fixed the Elementor editor preview returning a 404 when editing Popup Maker popups directly and prevented popup overlays from covering the editing canvas. Popups remain non-public and are queryable only in an authorized Elementor preview request.
+-   Fixed the Elementor editor preview returning a 404 when editing Popup Maker popups directly. The editor now uses an isolated canvas that shows the popup theme, container, and close button around the live builder content. Popups remain non-public and are queryable only in an authorized builder preview request.
 
 ## v1.24.0 - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
--   Fixed the Elementor editor preview returning a 404 when editing Popup Maker popups directly. The editor now uses an isolated canvas that shows the popup theme, container, and close button around the live builder content. Popups remain non-public and are queryable only in an authorized builder preview request.
+-   Added complete Elementor support for Popup Maker popups, including direct editing and previews, correctly styled frontend rendering, and interactive widgets.
 
 ## v1.24.0 - 2026-08-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+-   Fixed the Elementor editor preview returning a 404 when editing Popup Maker popups directly and prevented popup overlays from covering the editing canvas. Popups remain non-public and are queryable only in an authorized Elementor preview request.
+
 ## v1.24.0 - 2026-08-03
 
 **Security**

--- a/assets/js/src/integration/elementor.js
+++ b/assets/js/src/integration/elementor.js
@@ -34,7 +34,7 @@
 
 	// Elementor Forms success event.
 	$( document ).on( 'submit_success', '.elementor-form', function () {
-		const $form = $( this )[ 0 ];
+		const $form = $( this );
 
 		// Get element_id from the widget container.
 		// Elementor form widgets are inside a .elementor-element-{id} container.

--- a/assets/js/src/integration/elementor.js
+++ b/assets/js/src/integration/elementor.js
@@ -26,9 +26,14 @@
 			typeof window.elementorFrontend.elementsHandler.runReadyTrigger ===
 				'function'
 		) {
-			window.elementorFrontend.elementsHandler.runReadyTrigger(
-				$( elementorRoot )
-			);
+			$( elementorRoot )
+				.find( '[data-element_type]' )
+				.addBack( '[data-element_type]' )
+				.each( function () {
+					window.elementorFrontend.elementsHandler.runReadyTrigger(
+						this
+					);
+				} );
 		}
 	};
 

--- a/assets/js/src/integration/elementor.js
+++ b/assets/js/src/integration/elementor.js
@@ -5,24 +5,60 @@
 	const formProvider = 'elementor';
 	const $ = window.jQuery;
 
-	// Elementor Forms success event.
-	$( document ).on(
-		'submit_success',
-		'.elementor-form',
-		function ( event, response ) {
-			const $form = $( this )[ 0 ];
+	const refreshWidgets = ( popup ) => {
+		const elementorRoot = popup.querySelector( '.elementor' );
 
-			// Get element_id from the widget container.
-			// Elementor form widgets are inside a .elementor-element-{id} container.
-			const $widget = $( this ).closest( '[data-id]' );
-			const elementId = $widget.length
-				? $widget.attr( 'data-id' )
-				: 'unknown';
-
-			window.PUM.integrations.formSubmission( $form, {
-				formProvider,
-				formId: elementId,
-			} );
+		if ( ! elementorRoot ) {
+			return;
 		}
-	);
+
+		if (
+			window.elementorV2 &&
+			window.elementorV2.alpinejs &&
+			typeof window.elementorV2.alpinejs.refreshTree === 'function'
+		) {
+			window.elementorV2.alpinejs.refreshTree( elementorRoot );
+		}
+
+		if (
+			window.elementorFrontend &&
+			window.elementorFrontend.elementsHandler &&
+			typeof window.elementorFrontend.elementsHandler.runReadyTrigger ===
+				'function'
+		) {
+			window.elementorFrontend.elementsHandler.runReadyTrigger(
+				$( elementorRoot )
+			);
+		}
+	};
+
+	// Elementor Forms success event.
+	$( document ).on( 'submit_success', '.elementor-form', function () {
+		const $form = $( this )[ 0 ];
+
+		// Get element_id from the widget container.
+		// Elementor form widgets are inside a .elementor-element-{id} container.
+		const $widget = $( this ).closest( '[data-id]' );
+		const elementId = $widget.length
+			? $widget.attr( 'data-id' )
+			: 'unknown';
+
+		window.PUM.integrations.formSubmission( $form, {
+			formProvider,
+			formId: elementId,
+		} );
+	} );
+
+	// Reinitialize Elementor widgets after their popup becomes visible.
+	$( document ).on( 'pumAfterOpen', '.pum', function () {
+		refreshWidgets( this );
+	} );
+
+	// The isolated builder canvas is already visible and does not open through
+	// Popup Maker's normal lifecycle.
+	$( function () {
+		$( '.pum-builder-preview-popup' ).each( function () {
+			refreshWidgets( this );
+		} );
+	} );
 }

--- a/classes/Controllers/Compatibility.php
+++ b/classes/Controllers/Compatibility.php
@@ -30,6 +30,7 @@ class Compatibility extends Controller {
 			'Compatibility\Backcompat\Filters'     => new \PopupMaker\Controllers\Compatibility\Backcompat\Filters( $this->container ),
 			'Compatibility\SEO\Yoast'              => new \PopupMaker\Controllers\Compatibility\SEO\Yoast( $this->container ),
 			'Compatibility\Builder\Divi'           => new \PopupMaker\Controllers\Compatibility\Builder\Divi( $this->container ),
+			'Compatibility\Builder\Elementor'      => new \PopupMaker\Controllers\Compatibility\Builder\Elementor( $this->container ),
 			'Compatibility\Plugin\ACF'             => new \PopupMaker\Controllers\Compatibility\Plugin\ACF( $this->container ),
 			'Compatibility\Plugin\PostDuplication' => new \PopupMaker\Controllers\Compatibility\Plugin\PostDuplication( $this->container ),
 		] );

--- a/classes/Controllers/Compatibility/Builder/Concerns/AssetBatching.php
+++ b/classes/Controllers/Compatibility/Builder/Concerns/AssetBatching.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Page builder asset batching concern.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Controllers\Compatibility\Builder\Concerns;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Batches builder asset finalization across early and late popup rendering.
+ */
+trait AssetBatching {
+
+	/**
+	 * Whether this builder has assets waiting to be finalized.
+	 *
+	 * @var bool
+	 */
+	private $builder_assets_pending = false;
+
+	/**
+	 * Register builder asset batch boundaries.
+	 *
+	 * @return void
+	 */
+	protected function register_builder_asset_batching() {
+		add_action( 'wp_enqueue_scripts', [ $this, 'flush_pending_builder_assets' ], 12 );
+		add_action( 'wp_footer', [ $this, 'flush_pending_builder_assets' ], 0 );
+	}
+
+	/**
+	 * Mark this builder's collected assets for the next batch finalization.
+	 *
+	 * @return void
+	 */
+	protected function mark_builder_assets_pending() {
+		$this->builder_assets_pending = true;
+	}
+
+	/**
+	 * Finalize one batch of builder assets when work is pending.
+	 *
+	 * @return void
+	 */
+	public function flush_pending_builder_assets() {
+		if ( ! $this->builder_assets_pending ) {
+			return;
+		}
+
+		if ( $this->finalize_builder_assets() ) {
+			$this->builder_assets_pending = false;
+		}
+	}
+
+	/**
+	 * Finalize assets registered by the builder adapter.
+	 *
+	 * @return bool Whether the pending batch was finalized.
+	 */
+	abstract protected function finalize_builder_assets();
+}

--- a/classes/Controllers/Compatibility/Builder/Concerns/BuilderPreview.php
+++ b/classes/Controllers/Compatibility/Builder/Concerns/BuilderPreview.php
@@ -1,41 +1,27 @@
 <?php
 /**
- * Page builder preview adapter base.
+ * Page builder preview concern.
  *
  * @package   PopupMaker
  * @copyright Copyright (c) 2026, Code Atlantic LLC
  */
 
-namespace PopupMaker\Controllers\Compatibility\Builder;
-
-use PopupMaker\Plugin\Controller;
+namespace PopupMaker\Controllers\Compatibility\Builder\Concerns;
 
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Shares builder request registration, preview URLs, and asset batching.
- *
- * The main Previews controller owns authorization, query restoration, popup
- * loading, and template selection for every editor.
+ * Adds builder request registration and signed standalone preview URLs.
  */
-abstract class Preview extends Controller {
+trait BuilderPreview {
 
 	/**
-	 * Whether this builder has assets waiting to be finalized.
-	 *
-	 * @var bool
-	 */
-	private $builder_assets_pending = false;
-
-	/**
-	 * Initialize shared builder adapter hooks.
+	 * Register builder preview request handling.
 	 *
 	 * @return void
 	 */
-	public function init() {
+	protected function register_builder_preview() {
 		add_filter( 'popup_maker/builder_preview_id', [ $this, 'filter_builder_preview_id' ] );
-		add_action( 'wp_enqueue_scripts', [ $this, 'flush_pending_builder_assets' ], 12 );
-		add_action( 'wp_footer', [ $this, 'flush_pending_builder_assets' ], 0 );
 	}
 
 	/**
@@ -49,39 +35,6 @@ abstract class Preview extends Controller {
 		$popup_id = absint( $popup_id );
 
 		return $popup_id ?: absint( $this->get_popup_id_from_request() );
-	}
-
-	/**
-	 * Mark this builder's collected assets for the next batch finalization.
-	 *
-	 * @return void
-	 */
-	protected function mark_builder_assets_pending() {
-		$this->builder_assets_pending = true;
-	}
-
-	/**
-	 * Finalize one batch of builder assets when work is pending.
-	 *
-	 * @return void
-	 */
-	public function flush_pending_builder_assets() {
-		if ( ! $this->builder_assets_pending ) {
-			return;
-		}
-
-		if ( $this->finalize_builder_assets() ) {
-			$this->builder_assets_pending = false;
-		}
-	}
-
-	/**
-	 * Finalize assets registered by the builder adapter.
-	 *
-	 * @return bool Whether the pending batch was finalized.
-	 */
-	protected function finalize_builder_assets() {
-		return true;
 	}
 
 	/**

--- a/classes/Controllers/Compatibility/Builder/Elementor.php
+++ b/classes/Controllers/Compatibility/Builder/Elementor.php
@@ -20,6 +20,13 @@ defined( 'ABSPATH' ) || exit;
 class Elementor extends Preview {
 
 	/**
+	 * Whether rendered Elementor popups have styles waiting to be finalized.
+	 *
+	 * @var bool
+	 */
+	private $frontend_styles_pending = false;
+
+	/**
 	 * Initialize Elementor-specific preview hooks.
 	 *
 	 * @return void
@@ -27,6 +34,8 @@ class Elementor extends Preview {
 	public function init() {
 		parent::init();
 
+		add_action( 'wp_enqueue_scripts', [ $this, 'finalize_frontend_styles' ], 12 );
+		add_action( 'wp_footer', [ $this, 'finalize_frontend_styles' ], 0 );
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_preview_styles' ], 20 );
 		add_filter( 'elementor/document/urls/wp_preview', [ $this, 'filter_wp_preview_url' ], 10, 2 );
 		add_filter( 'pum_popup_content', [ $this, 'render_popup_content' ], 1000, 2 );
@@ -107,6 +116,7 @@ class Elementor extends Preview {
 		}
 
 		do_action( 'elementor/post/render', $popup_id );
+		$this->frontend_styles_pending = true;
 
 		if (
 			$popup_id === $this->get_current_popup_preview_id() &&
@@ -119,23 +129,48 @@ class Elementor extends Preview {
 			$builder_content = $content;
 		}
 
-		$styles_enqueued = did_action( 'elementor/frontend/after_enqueue_post_styles' );
+		return $builder_content;
+	}
+
+	/**
+	 * Finalize styles once for all Elementor popups rendered in this phase.
+	 *
+	 * The priority-12 pass handles normal popup preloading. The footer pass
+	 * batches popups discovered while rendering the main page content.
+	 *
+	 * @return void
+	 */
+	public function finalize_frontend_styles() {
+		if (
+			! $this->frontend_styles_pending ||
+			! did_action( 'elementor/loaded' ) ||
+			! class_exists( '\\Elementor\\Plugin' )
+		) {
+			return;
+		}
+
+		$elementor = \Elementor\Plugin::$instance;
+
+		if ( ! isset( $elementor->frontend ) ) {
+			return;
+		}
+
+		$styles_finalized = did_action( 'elementor/frontend/after_enqueue_post_styles' );
 
 		if ( method_exists( $elementor->frontend, 'enqueue_styles' ) ) {
 			$elementor->frontend->enqueue_styles();
 		}
 
-		// Elementor only runs its style finalizer once. Run it for popup
-		// documents added after the main page styles were already finalized.
-		if ( did_action( 'elementor/frontend/after_enqueue_post_styles' ) === $styles_enqueued ) {
+		// Elementor's style enqueue method is one-shot. Re-run its registered
+		// finalizers once when this batch was rendered after that method ran.
+		if (
+			has_action( 'elementor/frontend/after_enqueue_post_styles' ) &&
+			did_action( 'elementor/frontend/after_enqueue_post_styles' ) === $styles_finalized
+		) {
 			do_action( 'elementor/frontend/after_enqueue_post_styles' );
 		}
 
-		if ( method_exists( $elementor->frontend, 'enqueue_scripts' ) ) {
-			$elementor->frontend->enqueue_scripts();
-		}
-
-		return $builder_content;
+		$this->frontend_styles_pending = false;
 	}
 
 	/**

--- a/classes/Controllers/Compatibility/Builder/Elementor.php
+++ b/classes/Controllers/Compatibility/Builder/Elementor.php
@@ -1,0 +1,122 @@
+<?php
+/**
+ * Elementor Builder Compatibility Controller.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Controllers\Compatibility\Builder;
+
+use PopupMaker\Plugin\Controller;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Enables Elementor's preview iframe for popup posts.
+ *
+ * Popup posts are intentionally not publicly queryable. Elementor previews a
+ * document through a front-end request, so restore the popup post type only for
+ * the matching popup and an authenticated user who can edit it.
+ */
+class Elementor extends Controller {
+
+	/**
+	 * Initialize compatibility hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_filter( 'request', [ $this, 'allow_popup_preview_request' ] );
+		add_filter( 'pum_popup_is_loadable', [ $this, 'disable_popups_in_preview' ], 9999 );
+	}
+
+	/**
+	 * Restore the popup post type for an authorized Elementor preview request.
+	 *
+	 * WordPress removes non-publicly-queryable post types before applying the
+	 * `request` filter. Adding it back here lets Elementor resolve its preview
+	 * iframe without exposing popups to ordinary front-end requests.
+	 *
+	 * @param mixed $query_vars Parsed WordPress query variables.
+	 *
+	 * @return mixed Filtered query variables.
+	 */
+	public function allow_popup_preview_request( $query_vars ) {
+		if ( ! is_array( $query_vars ) ) {
+			return $query_vars;
+		}
+
+		$post_id = $this->get_authorized_popup_id_from_request();
+
+		if ( ! $post_id ) {
+			return $query_vars;
+		}
+
+		$query_vars['p']         = $post_id;
+		$query_vars['post_type'] = 'popup';
+
+		return $query_vars;
+	}
+
+	/**
+	 * Prevent Popup Maker overlays from covering Elementor's editing canvas.
+	 *
+	 * @param bool $loadable Whether the popup is loadable.
+	 *
+	 * @return bool Whether the popup is loadable.
+	 */
+	public function disable_popups_in_preview( $loadable ) {
+		return $this->get_authorized_popup_id_from_request() ? false : $loadable;
+	}
+
+	/**
+	 * Get an Elementor preview popup the current user can edit.
+	 *
+	 * @return int Popup ID, or 0 when the request is not authorized.
+	 */
+	private function get_authorized_popup_id_from_request() {
+		$post_id = $this->get_popup_id_from_request();
+
+		if (
+			! $post_id ||
+			'popup' !== get_post_type( $post_id ) ||
+			! is_user_logged_in() ||
+			! current_user_can( 'edit_post', $post_id )
+		) {
+			return 0;
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * Get the popup ID from a matching Elementor preview request.
+	 *
+	 * @return int Popup ID, or 0 when the request is not a valid match.
+	 */
+	private function get_popup_id_from_request() {
+		// Elementor preview requests do not include a WordPress nonce. Access is
+		// restricted by the per-popup capability check in the calling method.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if (
+			! isset( $_GET['elementor-preview'], $_GET['p'], $_GET['post_type'] ) ||
+			! is_scalar( $_GET['elementor-preview'] ) ||
+			! is_scalar( $_GET['p'] ) ||
+			! is_scalar( $_GET['post_type'] )
+		) {
+			return 0;
+		}
+
+		$preview_id = absint( wp_unslash( $_GET['elementor-preview'] ) );
+		$post_id    = absint( wp_unslash( $_GET['p'] ) );
+		$post_type  = sanitize_key( wp_unslash( $_GET['post_type'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ( 'popup' !== $post_type || ! $preview_id || $preview_id !== $post_id ) {
+			return 0;
+		}
+
+		return $preview_id;
+	}
+}

--- a/classes/Controllers/Compatibility/Builder/Elementor.php
+++ b/classes/Controllers/Compatibility/Builder/Elementor.php
@@ -8,8 +8,6 @@
 
 namespace PopupMaker\Controllers\Compatibility\Builder;
 
-use PopupMaker\Plugin\Controller;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -19,83 +17,14 @@ defined( 'ABSPATH' ) || exit;
  * document through a front-end request, so restore the popup post type only for
  * the matching popup and an authenticated user who can edit it.
  */
-class Elementor extends Controller {
-
-	/**
-	 * Initialize compatibility hooks.
-	 *
-	 * @return void
-	 */
-	public function init() {
-		add_filter( 'request', [ $this, 'allow_popup_preview_request' ] );
-		add_filter( 'pum_popup_is_loadable', [ $this, 'disable_popups_in_preview' ], 9999 );
-	}
-
-	/**
-	 * Restore the popup post type for an authorized Elementor preview request.
-	 *
-	 * WordPress removes non-publicly-queryable post types before applying the
-	 * `request` filter. Adding it back here lets Elementor resolve its preview
-	 * iframe without exposing popups to ordinary front-end requests.
-	 *
-	 * @param mixed $query_vars Parsed WordPress query variables.
-	 *
-	 * @return mixed Filtered query variables.
-	 */
-	public function allow_popup_preview_request( $query_vars ) {
-		if ( ! is_array( $query_vars ) ) {
-			return $query_vars;
-		}
-
-		$post_id = $this->get_authorized_popup_id_from_request();
-
-		if ( ! $post_id ) {
-			return $query_vars;
-		}
-
-		$query_vars['p']         = $post_id;
-		$query_vars['post_type'] = 'popup';
-
-		return $query_vars;
-	}
-
-	/**
-	 * Prevent Popup Maker overlays from covering Elementor's editing canvas.
-	 *
-	 * @param bool $loadable Whether the popup is loadable.
-	 *
-	 * @return bool Whether the popup is loadable.
-	 */
-	public function disable_popups_in_preview( $loadable ) {
-		return $this->get_authorized_popup_id_from_request() ? false : $loadable;
-	}
-
-	/**
-	 * Get an Elementor preview popup the current user can edit.
-	 *
-	 * @return int Popup ID, or 0 when the request is not authorized.
-	 */
-	private function get_authorized_popup_id_from_request() {
-		$post_id = $this->get_popup_id_from_request();
-
-		if (
-			! $post_id ||
-			'popup' !== get_post_type( $post_id ) ||
-			! is_user_logged_in() ||
-			! current_user_can( 'edit_post', $post_id )
-		) {
-			return 0;
-		}
-
-		return $post_id;
-	}
+class Elementor extends Preview {
 
 	/**
 	 * Get the popup ID from a matching Elementor preview request.
 	 *
 	 * @return int Popup ID, or 0 when the request is not a valid match.
 	 */
-	private function get_popup_id_from_request() {
+	protected function get_popup_id_from_request() {
 		// Elementor preview requests do not include a WordPress nonce. Access is
 		// restricted by the per-popup capability check in the calling method.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended

--- a/classes/Controllers/Compatibility/Builder/Elementor.php
+++ b/classes/Controllers/Compatibility/Builder/Elementor.php
@@ -8,6 +8,10 @@
 
 namespace PopupMaker\Controllers\Compatibility\Builder;
 
+use PopupMaker\Controllers\Compatibility\Builder\Concerns\AssetBatching;
+use PopupMaker\Controllers\Compatibility\Builder\Concerns\BuilderPreview;
+use PopupMaker\Plugin\Controller;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -17,7 +21,10 @@ defined( 'ABSPATH' ) || exit;
  * document through a front-end request, so restore the popup post type only for
  * the matching popup and an authenticated user who can edit it.
  */
-class Elementor extends Preview {
+class Elementor extends Controller {
+
+	use AssetBatching;
+	use BuilderPreview;
 
 	/**
 	 * Initialize Elementor-specific preview hooks.
@@ -25,7 +32,8 @@ class Elementor extends Preview {
 	 * @return void
 	 */
 	public function init() {
-		parent::init();
+		$this->register_builder_preview();
+		$this->register_builder_asset_batching();
 
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_preview_styles' ], 20 );
 		add_filter( 'elementor/document/urls/wp_preview', [ $this, 'filter_wp_preview_url' ], 10, 2 );

--- a/classes/Controllers/Compatibility/Builder/Elementor.php
+++ b/classes/Controllers/Compatibility/Builder/Elementor.php
@@ -20,13 +20,6 @@ defined( 'ABSPATH' ) || exit;
 class Elementor extends Preview {
 
 	/**
-	 * Whether rendered Elementor popups have styles waiting to be finalized.
-	 *
-	 * @var bool
-	 */
-	private $frontend_styles_pending = false;
-
-	/**
 	 * Initialize Elementor-specific preview hooks.
 	 *
 	 * @return void
@@ -34,8 +27,6 @@ class Elementor extends Preview {
 	public function init() {
 		parent::init();
 
-		add_action( 'wp_enqueue_scripts', [ $this, 'finalize_frontend_styles' ], 12 );
-		add_action( 'wp_footer', [ $this, 'finalize_frontend_styles' ], 0 );
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_preview_styles' ], 20 );
 		add_filter( 'elementor/document/urls/wp_preview', [ $this, 'filter_wp_preview_url' ], 10, 2 );
 		add_filter( 'pum_popup_content', [ $this, 'render_popup_content' ], 1000, 2 );
@@ -116,7 +107,7 @@ class Elementor extends Preview {
 		}
 
 		do_action( 'elementor/post/render', $popup_id );
-		$this->frontend_styles_pending = true;
+		$this->mark_builder_assets_pending();
 
 		if (
 			$popup_id === $this->get_current_popup_preview_id() &&
@@ -138,21 +129,20 @@ class Elementor extends Preview {
 	 * The priority-12 pass handles normal popup preloading. The footer pass
 	 * batches popups discovered while rendering the main page content.
 	 *
-	 * @return void
+	 * @return bool Whether the pending styles were finalized.
 	 */
-	public function finalize_frontend_styles() {
+	protected function finalize_builder_assets() {
 		if (
-			! $this->frontend_styles_pending ||
 			! did_action( 'elementor/loaded' ) ||
 			! class_exists( '\\Elementor\\Plugin' )
 		) {
-			return;
+			return false;
 		}
 
 		$elementor = \Elementor\Plugin::$instance;
 
 		if ( ! isset( $elementor->frontend ) ) {
-			return;
+			return false;
 		}
 
 		$styles_finalized = did_action( 'elementor/frontend/after_enqueue_post_styles' );
@@ -170,7 +160,7 @@ class Elementor extends Preview {
 			do_action( 'elementor/frontend/after_enqueue_post_styles' );
 		}
 
-		$this->frontend_styles_pending = false;
+		return true;
 	}
 
 	/**

--- a/classes/Controllers/Compatibility/Builder/Elementor.php
+++ b/classes/Controllers/Compatibility/Builder/Elementor.php
@@ -20,6 +20,33 @@ defined( 'ABSPATH' ) || exit;
 class Elementor extends Preview {
 
 	/**
+	 * Initialize Elementor-specific preview hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		parent::init();
+
+		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_preview_styles' ], 20 );
+	}
+
+	/**
+	 * Remove page-canvas spacing from Elementor's empty section control.
+	 *
+	 * @return void
+	 */
+	public function enqueue_preview_styles() {
+		if ( ! $this->get_current_popup_preview_id() ) {
+			return;
+		}
+
+		wp_add_inline_style(
+			'popup-maker-site',
+			'body.pum-builder-preview.elementor-editor-active #elementor-add-new-section { margin: 0 auto; }'
+		);
+	}
+
+	/**
 	 * Get the popup ID from a matching Elementor preview request.
 	 *
 	 * @return int Popup ID, or 0 when the request is not a valid match.

--- a/classes/Controllers/Compatibility/Builder/Elementor.php
+++ b/classes/Controllers/Compatibility/Builder/Elementor.php
@@ -28,6 +28,114 @@ class Elementor extends Preview {
 		parent::init();
 
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_preview_styles' ], 20 );
+		add_filter( 'elementor/document/urls/wp_preview', [ $this, 'filter_wp_preview_url' ], 10, 2 );
+		add_filter( 'pum_popup_content', [ $this, 'render_popup_content' ], 1000, 2 );
+	}
+
+	/**
+	 * Use Elementor's builder preview when WordPress cannot preview popups.
+	 *
+	 * Popup posts are not publicly queryable, so WordPress returns an empty
+	 * preview URL. This authenticated URL renders the saved document through the
+	 * isolated popup canvas instead of Elementor's editor-only iframe shell.
+	 *
+	 * @param mixed $url      WordPress preview URL.
+	 * @param mixed $document Elementor document object.
+	 *
+	 * @return mixed Filtered preview URL.
+	 */
+	public function filter_wp_preview_url( $url, $document ) {
+		if (
+			! is_object( $document ) ||
+			! method_exists( $document, 'get_main_id' )
+		) {
+			return $url;
+		}
+
+		$post_id = absint( $document->get_main_id() );
+
+		if (
+			! $post_id ||
+			'popup' !== get_post_type( $post_id ) ||
+			! current_user_can( 'edit_post', $post_id )
+		) {
+			return $url;
+		}
+
+		return $this->get_standalone_preview_url( $post_id, 'elementor' );
+	}
+
+	/**
+	 * Render Elementor popup documents before frontend assets are printed.
+	 *
+	 * @param mixed $content  Popup post content.
+	 * @param mixed $popup_id Popup post ID.
+	 *
+	 * @return mixed Elementor markup, or the original popup content.
+	 */
+	public function render_popup_content( $content, $popup_id = 0 ) {
+		if (
+			! is_string( $content ) ||
+			! is_numeric( $popup_id ) ||
+			( is_admin() && ! wp_doing_ajax() ) ||
+			! did_action( 'elementor/loaded' ) ||
+			! class_exists( '\\Elementor\\Plugin' )
+		) {
+			return $content;
+		}
+
+		$popup_id  = absint( $popup_id );
+		$elementor = \Elementor\Plugin::$instance;
+
+		if (
+			! $popup_id ||
+			'popup' !== get_post_type( $popup_id ) ||
+			! isset( $elementor->documents, $elementor->frontend ) ||
+			! method_exists( $elementor->documents, 'get' )
+		) {
+			return $content;
+		}
+
+		$document = $elementor->documents->get( $popup_id );
+
+		if (
+			! is_object( $document ) ||
+			! method_exists( $document, 'is_built_with_elementor' ) ||
+			! $document->is_built_with_elementor()
+		) {
+			return $content;
+		}
+
+		do_action( 'elementor/post/render', $popup_id );
+
+		if (
+			$popup_id === $this->get_current_popup_preview_id() &&
+			method_exists( $elementor->frontend, 'get_builder_content' )
+		) {
+			$builder_content = $elementor->frontend->get_builder_content( $popup_id );
+		} elseif ( method_exists( $elementor->frontend, 'get_builder_content_for_display' ) ) {
+			$builder_content = $elementor->frontend->get_builder_content_for_display( $popup_id );
+		} else {
+			$builder_content = $content;
+		}
+
+		$styles_enqueued = did_action( 'elementor/frontend/after_enqueue_post_styles' );
+
+		if ( method_exists( $elementor->frontend, 'enqueue_styles' ) ) {
+			$elementor->frontend->enqueue_styles();
+		}
+
+		// Elementor only runs its style finalizer once. Run it for popup
+		// documents added after the main page styles were already finalized.
+		if ( did_action( 'elementor/frontend/after_enqueue_post_styles' ) === $styles_enqueued ) {
+			do_action( 'elementor/frontend/after_enqueue_post_styles' );
+		}
+
+		if ( method_exists( $elementor->frontend, 'enqueue_scripts' ) ) {
+			$elementor->frontend->enqueue_scripts();
+		}
+
+		return $builder_content;
 	}
 
 	/**
@@ -52,7 +160,13 @@ class Elementor extends Preview {
 	 * @return int Popup ID, or 0 when the request is not a valid match.
 	 */
 	protected function get_popup_id_from_request() {
-		// Elementor preview requests do not include a WordPress nonce. Access is
+		$standalone_id = $this->get_standalone_popup_id_from_request( 'elementor' );
+
+		if ( $standalone_id ) {
+			return $standalone_id;
+		}
+
+		// Elementor iframe requests do not include a WordPress nonce. Access is
 		// restricted by the per-popup capability check in the calling method.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if (

--- a/classes/Controllers/Compatibility/Builder/Preview.php
+++ b/classes/Controllers/Compatibility/Builder/Preview.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Page Builder Preview Compatibility Controller.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Controllers\Compatibility\Builder;
+
+use PopupMaker\Plugin\Controller;
+use Popup_Maker;
+use function PopupMaker\plugin;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Provides a secure, isolated popup canvas for front-end page builders.
+ *
+ * Builder-specific controllers only need to identify the popup ID represented
+ * by the current request. This base controller handles authorization, query
+ * restoration, assets, template selection, and suppression of other popups.
+ */
+abstract class Preview extends Controller {
+
+	/**
+	 * Initialize shared builder preview hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_filter( 'request', [ $this, 'allow_popup_preview_request' ] );
+		add_action( 'wp_enqueue_scripts', [ $this, 'preload_popup_preview' ], 10 );
+		add_filter( 'template_include', [ $this, 'use_popup_preview_template' ], 9999 );
+		add_filter( 'pum_popup_is_loadable', [ $this, 'limit_popups_in_preview' ], 9999, 2 );
+		add_filter( 'popup_maker/is_builder_preview', [ $this, 'is_builder_preview' ] );
+	}
+
+	/**
+	 * Restore the popup post type for an authorized builder preview request.
+	 *
+	 * WordPress removes non-publicly-queryable post types before applying the
+	 * `request` filter. Adding it back here lets a builder resolve its preview
+	 * without exposing popups to ordinary front-end requests.
+	 *
+	 * @param mixed $query_vars Parsed WordPress query variables.
+	 *
+	 * @return mixed Filtered query variables.
+	 */
+	public function allow_popup_preview_request( $query_vars ) {
+		if ( ! is_array( $query_vars ) ) {
+			return $query_vars;
+		}
+
+		$post_id = $this->get_authorized_popup_id_from_request();
+
+		if ( ! $post_id ) {
+			return $query_vars;
+		}
+
+		$query_vars['p']         = $post_id;
+		$query_vars['post_type'] = 'popup';
+
+		return $query_vars;
+	}
+
+	/**
+	 * Preload the edited popup so its theme and builder assets are available.
+	 *
+	 * This intentionally calls preload_popup() directly because builders can
+	 * edit draft popups, while the ordinary front-end query excludes drafts.
+	 *
+	 * @return void
+	 */
+	public function preload_popup_preview() {
+		$post_id = $this->get_current_popup_preview_id();
+
+		if ( ! $post_id ) {
+			return;
+		}
+
+		$popup = pum_get_popup( $post_id );
+
+		if ( pum_is_popup( $popup ) ) {
+			plugin()->get_controller( 'Frontend\Popups' )->preload_popup( $popup );
+		}
+	}
+
+	/**
+	 * Use Popup Maker's isolated page-builder canvas for the preview.
+	 *
+	 * @param string $template Selected WordPress template path.
+	 *
+	 * @return string Filtered template path.
+	 */
+	public function use_popup_preview_template( $template ) {
+		if ( ! $this->get_current_popup_preview_id() ) {
+			return $template;
+		}
+
+		$popup_template = Popup_Maker::$DIR . 'templates/single-popup.php';
+
+		if ( ! file_exists( $popup_template ) ) {
+			return $template;
+		}
+
+		$popups = plugin()->get_controller( 'Frontend\Popups' );
+		remove_action( 'wp_footer', [ $popups, 'render_popups' ] );
+
+		return $popup_template;
+	}
+
+	/**
+	 * Load only the popup being edited during a builder preview.
+	 *
+	 * @param bool $loadable Whether the popup is loadable.
+	 * @param int  $popup_id Popup ID being checked.
+	 *
+	 * @return bool Whether the popup is loadable.
+	 */
+	public function limit_popups_in_preview( $loadable, $popup_id ) {
+		$preview_id = $this->get_authorized_popup_id_from_request();
+
+		if ( ! $preview_id ) {
+			return $loadable;
+		}
+
+		return absint( $popup_id ) === $preview_id;
+	}
+
+	/**
+	 * Identify an active builder preview for the shared popup template.
+	 *
+	 * @param bool $is_preview Whether another builder identified the request.
+	 *
+	 * @return bool Whether this is an active popup builder preview.
+	 */
+	public function is_builder_preview( $is_preview ) {
+		return $is_preview || (bool) $this->get_current_popup_preview_id();
+	}
+
+	/**
+	 * Get the current queried popup when it matches the authorized preview.
+	 *
+	 * @return int Popup ID, or 0 when the main query is not the preview popup.
+	 */
+	private function get_current_popup_preview_id() {
+		$post_id = $this->get_authorized_popup_id_from_request();
+
+		if (
+			! $post_id ||
+			! is_singular( 'popup' ) ||
+			absint( get_queried_object_id() ) !== $post_id
+		) {
+			return 0;
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * Get a builder preview popup the current user can edit.
+	 *
+	 * @return int Popup ID, or 0 when the request is not authorized.
+	 */
+	private function get_authorized_popup_id_from_request() {
+		$post_id = $this->get_popup_id_from_request();
+
+		if (
+			! $post_id ||
+			'popup' !== get_post_type( $post_id ) ||
+			! is_user_logged_in() ||
+			! current_user_can( 'edit_post', $post_id )
+		) {
+			return 0;
+		}
+
+		return $post_id;
+	}
+
+	/**
+	 * Get the popup ID represented by the builder-specific request.
+	 *
+	 * @return int Popup ID, or 0 when the request is not a valid builder preview.
+	 */
+	abstract protected function get_popup_id_from_request();
+}

--- a/classes/Controllers/Compatibility/Builder/Preview.php
+++ b/classes/Controllers/Compatibility/Builder/Preview.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Page Builder Preview Compatibility Controller.
+ * Page builder preview adapter base.
  *
  * @package   PopupMaker
  * @copyright Copyright (c) 2026, Code Atlantic LLC
@@ -13,12 +13,10 @@ use PopupMaker\Plugin\Controller;
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Provides a secure, isolated popup canvas for front-end page builders.
+ * Shares builder request registration, preview URLs, and asset batching.
  *
- * Builder-specific controllers identify the popup represented by the current
- * request and supply any builder-owned asset finalizer. This base controller
- * handles authorization, query restoration, batch boundaries, template
- * selection, and suppression of other popups.
+ * The main Previews controller owns authorization, query restoration, popup
+ * loading, and template selection for every editor.
  */
 abstract class Preview extends Controller {
 
@@ -30,127 +28,27 @@ abstract class Preview extends Controller {
 	private $builder_assets_pending = false;
 
 	/**
-	 * Initialize shared builder preview hooks.
+	 * Initialize shared builder adapter hooks.
 	 *
 	 * @return void
 	 */
 	public function init() {
-		add_filter( 'request', [ $this, 'allow_popup_preview_request' ] );
-		add_action( 'wp_enqueue_scripts', [ $this, 'preload_popup_preview' ], 11 );
+		add_filter( 'popup_maker/builder_preview_id', [ $this, 'filter_builder_preview_id' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'flush_pending_builder_assets' ], 12 );
 		add_action( 'wp_footer', [ $this, 'flush_pending_builder_assets' ], 0 );
-		add_filter( 'template_include', [ $this, 'use_popup_preview_template' ], 9999 );
-		add_filter( 'pum_popup_is_loadable', [ $this, 'limit_popups_in_preview' ], 9999, 2 );
-		add_filter( 'popup_maker/is_builder_preview', [ $this, 'is_builder_preview' ] );
 	}
 
 	/**
-	 * Restore the popup post type for an authorized builder preview request.
+	 * Supply this adapter's popup ID when no earlier builder matched.
 	 *
-	 * WordPress removes non-publicly-queryable post types before applying the
-	 * `request` filter. Adding it back here lets a builder resolve its preview
-	 * without exposing popups to ordinary front-end requests.
+	 * @param mixed $popup_id Popup ID supplied by another builder.
 	 *
-	 * @param mixed $query_vars Parsed WordPress query variables.
-	 *
-	 * @return mixed Filtered query variables.
+	 * @return int Popup ID, or 0 when no builder matches.
 	 */
-	public function allow_popup_preview_request( $query_vars ) {
-		if ( ! is_array( $query_vars ) ) {
-			return $query_vars;
-		}
+	public function filter_builder_preview_id( $popup_id ) {
+		$popup_id = absint( $popup_id );
 
-		$post_id = $this->get_authorized_popup_id_from_request();
-
-		if ( ! $post_id ) {
-			return $query_vars;
-		}
-
-		$query_vars['p']         = $post_id;
-		$query_vars['post_type'] = 'popup';
-
-		return $query_vars;
-	}
-
-	/**
-	 * Preload the edited popup so its theme and builder assets are available.
-	 *
-	 * This intentionally calls preload_popup() directly because builders can
-	 * edit draft popups, while the ordinary front-end query excludes drafts.
-	 *
-	 * @return void
-	 */
-	public function preload_popup_preview() {
-		$post_id = $this->get_current_popup_preview_id();
-
-		if ( ! $post_id ) {
-			return;
-		}
-
-		$popup  = $this->container->get( 'popups' )->get_by_id( $post_id );
-		$popups = $this->container->get_controller( 'Frontend\Popups' );
-
-		if ( pum_is_popup( $popup ) && $popups instanceof \PopupMaker\Controllers\Frontend\Popups ) {
-			$popups->preload_popup( $popup );
-		}
-	}
-
-	/**
-	 * Use Popup Maker's isolated page-builder canvas for the preview.
-	 *
-	 * @param string $template Selected WordPress template path.
-	 *
-	 * @return string Filtered template path.
-	 */
-	public function use_popup_preview_template( $template ) {
-		if ( ! $this->get_current_popup_preview_id() ) {
-			return $template;
-		}
-
-		$popup_template = $this->container->get_path( 'templates/single-popup.php' );
-
-		if ( ! file_exists( $popup_template ) ) {
-			return $template;
-		}
-
-		$popups = $this->container->get_controller( 'Frontend\Popups' );
-
-		if ( ! $popups instanceof \PopupMaker\Controllers\Frontend\Popups ) {
-			return $template;
-		}
-
-		remove_action( 'wp_footer', [ $popups, 'render_popups' ] );
-
-		return $popup_template;
-	}
-
-	/**
-	 * Load only the popup being edited during a builder preview.
-	 *
-	 * @param bool $loadable Whether the popup is loadable.
-	 * @param int  $popup_id Popup ID being checked.
-	 *
-	 * @return bool Whether the popup is loadable.
-	 */
-	public function limit_popups_in_preview( $loadable, $popup_id ) {
-		$preview_id = $this->get_authorized_popup_id_from_request();
-
-		if ( ! $preview_id ) {
-			return $loadable;
-		}
-
-		return absint( $popup_id ) === $preview_id;
-	}
-
-	/**
-	 * Identify an active builder preview for the shared popup template.
-	 *
-	 * @param bool $is_preview Whether another builder identified the request.
-	 *
-	 * @return bool Whether this is an active popup builder preview.
-	 */
-	public function is_builder_preview( $is_preview ) {
-		return $is_preview || (bool) $this->get_current_popup_preview_id();
+		return $popup_id ?: absint( $this->get_popup_id_from_request() );
 	}
 
 	/**
@@ -187,22 +85,18 @@ abstract class Preview extends Controller {
 	}
 
 	/**
-	 * Get the current queried popup when it matches the authorized preview.
+	 * Get the current popup builder preview.
 	 *
 	 * @return int Popup ID, or 0 when the main query is not the preview popup.
 	 */
 	protected function get_current_popup_preview_id() {
-		$post_id = $this->get_authorized_popup_id_from_request();
+		$previews = $this->container->get_controller( 'Previews' );
 
-		if (
-			! $post_id ||
-			! is_singular( 'popup' ) ||
-			absint( get_queried_object_id() ) !== $post_id
-		) {
+		if ( ! $previews instanceof \PopupMaker\Controllers\Previews ) {
 			return 0;
 		}
 
-		return $post_id;
+		return $previews->get_current_builder_preview();
 	}
 
 	/**
@@ -254,26 +148,6 @@ abstract class Preview extends Controller {
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		if ( $builder !== $request_builder || ! $post_id || ! wp_verify_nonce( $wp_nonce, $nonce_key ) ) {
-			return 0;
-		}
-
-		return $post_id;
-	}
-
-	/**
-	 * Get a builder preview popup the current user can edit.
-	 *
-	 * @return int Popup ID, or 0 when the request is not authorized.
-	 */
-	private function get_authorized_popup_id_from_request() {
-		$post_id = $this->get_popup_id_from_request();
-
-		if (
-			! $post_id ||
-			'popup' !== get_post_type( $post_id ) ||
-			! is_user_logged_in() ||
-			! current_user_can( 'edit_post', $post_id )
-		) {
 			return 0;
 		}
 

--- a/classes/Controllers/Compatibility/Builder/Preview.php
+++ b/classes/Controllers/Compatibility/Builder/Preview.php
@@ -9,8 +9,6 @@
 namespace PopupMaker\Controllers\Compatibility\Builder;
 
 use PopupMaker\Plugin\Controller;
-use Popup_Maker;
-use function PopupMaker\plugin;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -30,7 +28,7 @@ abstract class Preview extends Controller {
 	 */
 	public function init() {
 		add_filter( 'request', [ $this, 'allow_popup_preview_request' ] );
-		add_action( 'wp_enqueue_scripts', [ $this, 'preload_popup_preview' ], 10 );
+		add_action( 'wp_enqueue_scripts', [ $this, 'preload_popup_preview' ], 11 );
 		add_filter( 'template_include', [ $this, 'use_popup_preview_template' ], 9999 );
 		add_filter( 'pum_popup_is_loadable', [ $this, 'limit_popups_in_preview' ], 9999, 2 );
 		add_filter( 'popup_maker/is_builder_preview', [ $this, 'is_builder_preview' ] );
@@ -79,10 +77,11 @@ abstract class Preview extends Controller {
 			return;
 		}
 
-		$popup = pum_get_popup( $post_id );
+		$popup  = $this->container->get( 'popups' )->get_by_id( $post_id );
+		$popups = $this->container->get_controller( 'Frontend\Popups' );
 
-		if ( pum_is_popup( $popup ) ) {
-			plugin()->get_controller( 'Frontend\Popups' )->preload_popup( $popup );
+		if ( pum_is_popup( $popup ) && $popups instanceof \PopupMaker\Controllers\Frontend\Popups ) {
+			$popups->preload_popup( $popup );
 		}
 	}
 
@@ -98,13 +97,18 @@ abstract class Preview extends Controller {
 			return $template;
 		}
 
-		$popup_template = Popup_Maker::$DIR . 'templates/single-popup.php';
+		$popup_template = $this->container->get_path( 'templates/single-popup.php' );
 
 		if ( ! file_exists( $popup_template ) ) {
 			return $template;
 		}
 
-		$popups = plugin()->get_controller( 'Frontend\Popups' );
+		$popups = $this->container->get_controller( 'Frontend\Popups' );
+
+		if ( ! $popups instanceof \PopupMaker\Controllers\Frontend\Popups ) {
+			return $template;
+		}
+
 		remove_action( 'wp_footer', [ $popups, 'render_popups' ] );
 
 		return $popup_template;

--- a/classes/Controllers/Compatibility/Builder/Preview.php
+++ b/classes/Controllers/Compatibility/Builder/Preview.php
@@ -144,7 +144,7 @@ abstract class Preview extends Controller {
 	 *
 	 * @return int Popup ID, or 0 when the main query is not the preview popup.
 	 */
-	private function get_current_popup_preview_id() {
+	protected function get_current_popup_preview_id() {
 		$post_id = $this->get_authorized_popup_id_from_request();
 
 		if (

--- a/classes/Controllers/Compatibility/Builder/Preview.php
+++ b/classes/Controllers/Compatibility/Builder/Preview.php
@@ -15,11 +15,19 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Provides a secure, isolated popup canvas for front-end page builders.
  *
- * Builder-specific controllers only need to identify the popup ID represented
- * by the current request. This base controller handles authorization, query
- * restoration, assets, template selection, and suppression of other popups.
+ * Builder-specific controllers identify the popup represented by the current
+ * request and supply any builder-owned asset finalizer. This base controller
+ * handles authorization, query restoration, batch boundaries, template
+ * selection, and suppression of other popups.
  */
 abstract class Preview extends Controller {
+
+	/**
+	 * Whether this builder has assets waiting to be finalized.
+	 *
+	 * @var bool
+	 */
+	private $builder_assets_pending = false;
 
 	/**
 	 * Initialize shared builder preview hooks.
@@ -29,6 +37,8 @@ abstract class Preview extends Controller {
 	public function init() {
 		add_filter( 'request', [ $this, 'allow_popup_preview_request' ] );
 		add_action( 'wp_enqueue_scripts', [ $this, 'preload_popup_preview' ], 11 );
+		add_action( 'wp_enqueue_scripts', [ $this, 'flush_pending_builder_assets' ], 12 );
+		add_action( 'wp_footer', [ $this, 'flush_pending_builder_assets' ], 0 );
 		add_filter( 'template_include', [ $this, 'use_popup_preview_template' ], 9999 );
 		add_filter( 'pum_popup_is_loadable', [ $this, 'limit_popups_in_preview' ], 9999, 2 );
 		add_filter( 'popup_maker/is_builder_preview', [ $this, 'is_builder_preview' ] );
@@ -141,6 +151,39 @@ abstract class Preview extends Controller {
 	 */
 	public function is_builder_preview( $is_preview ) {
 		return $is_preview || (bool) $this->get_current_popup_preview_id();
+	}
+
+	/**
+	 * Mark this builder's collected assets for the next batch finalization.
+	 *
+	 * @return void
+	 */
+	protected function mark_builder_assets_pending() {
+		$this->builder_assets_pending = true;
+	}
+
+	/**
+	 * Finalize one batch of builder assets when work is pending.
+	 *
+	 * @return void
+	 */
+	public function flush_pending_builder_assets() {
+		if ( ! $this->builder_assets_pending ) {
+			return;
+		}
+
+		if ( $this->finalize_builder_assets() ) {
+			$this->builder_assets_pending = false;
+		}
+	}
+
+	/**
+	 * Finalize assets registered by the builder adapter.
+	 *
+	 * @return bool Whether the pending batch was finalized.
+	 */
+	protected function finalize_builder_assets() {
+		return true;
 	}
 
 	/**

--- a/classes/Controllers/Compatibility/Builder/Preview.php
+++ b/classes/Controllers/Compatibility/Builder/Preview.php
@@ -159,6 +159,61 @@ abstract class Preview extends Controller {
 	}
 
 	/**
+	 * Create an authenticated standalone preview URL for a builder.
+	 *
+	 * @param int    $post_id Popup ID.
+	 * @param string $builder Page builder key.
+	 *
+	 * @return string Preview URL.
+	 */
+	protected function get_standalone_preview_url( $post_id, $builder ) {
+		$post_id = absint( $post_id );
+		$builder = sanitize_key( $builder );
+
+		return add_query_arg(
+			[
+				'post_type'           => 'popup',
+				'p'                   => $post_id,
+				'pum-builder-preview' => $builder,
+				'_wpnonce'            => wp_create_nonce( 'pum_builder_preview_' . $builder . '_' . $post_id ),
+			],
+			home_url( '/' )
+		);
+	}
+
+	/**
+	 * Read an authenticated standalone preview request for a builder.
+	 *
+	 * @param string $builder Page builder key.
+	 *
+	 * @return int Popup ID, or 0 when the request is invalid.
+	 */
+	protected function get_standalone_popup_id_from_request( $builder ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if (
+			! isset( $_GET['pum-builder-preview'], $_GET['p'], $_GET['_wpnonce'] ) ||
+			! is_scalar( $_GET['pum-builder-preview'] ) ||
+			! is_scalar( $_GET['p'] ) ||
+			! is_scalar( $_GET['_wpnonce'] )
+		) {
+			return 0;
+		}
+
+		$builder         = sanitize_key( $builder );
+		$request_builder = sanitize_key( wp_unslash( $_GET['pum-builder-preview'] ) );
+		$post_id         = absint( wp_unslash( $_GET['p'] ) );
+		$wp_nonce        = sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) );
+		$nonce_key       = 'pum_builder_preview_' . $builder . '_' . $post_id;
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ( $builder !== $request_builder || ! $post_id || ! wp_verify_nonce( $wp_nonce, $nonce_key ) ) {
+			return 0;
+		}
+
+		return $post_id;
+	}
+
+	/**
 	 * Get a builder preview popup the current user can edit.
 	 *
 	 * @return int Popup ID, or 0 when the request is not authorized.

--- a/classes/Controllers/Previews.php
+++ b/classes/Controllers/Previews.php
@@ -253,6 +253,12 @@ class Previews extends Controller {
 	 * @return mixed
 	 */
 	public function data_attr( $data_attr, $popup_id ) {
+		if ( absint( $popup_id ) === $this->get_builder_preview() ) {
+			$data_attr['triggers'] = [];
+
+			return $data_attr;
+		}
+
 		if ( ! $this->is_previewing_popup( $popup_id ) ) {
 			return $data_attr;
 		}
@@ -275,6 +281,12 @@ class Previews extends Controller {
 	 * @return array
 	 */
 	public function get_public_settings( $settings, $popup ) {
+		if ( absint( $popup->ID ) === $this->get_builder_preview() ) {
+			$settings['triggers'] = [];
+
+			return $settings;
+		}
+
 		if ( ! $this->is_previewing_popup( $popup->ID ) ) {
 			return $settings;
 		}

--- a/classes/Controllers/Previews.php
+++ b/classes/Controllers/Previews.php
@@ -1,0 +1,307 @@
+<?php
+/**
+ * Popup preview controller.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Controllers;
+
+use PopupMaker\Plugin\Controller;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages popup previews for core editors and page builders.
+ */
+class Previews extends Controller {
+
+	/**
+	 * Whether the controller hooks have been registered.
+	 *
+	 * @var bool
+	 */
+	private $initialized = false;
+
+	/**
+	 * Initialize preview hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		if ( $this->initialized ) {
+			return;
+		}
+
+		$this->initialized = true;
+
+		add_filter( 'request', [ $this, 'allow_builder_preview_request' ] );
+		add_action( 'template_redirect', [ $this, 'force_load_preview' ] );
+		add_action( 'wp_enqueue_scripts', [ $this, 'preload_builder_preview' ], 11 );
+		add_filter( 'template_include', [ $this, 'use_builder_preview_template' ], 9999 );
+		add_filter( 'pum_popup_is_loadable', [ $this, 'is_loadable' ], 1000, 2 );
+		add_filter( 'pum_popup_data_attr', [ $this, 'data_attr' ], 1000, 2 );
+		add_filter( 'pum_popup_get_public_settings', [ $this, 'get_public_settings' ], 1000, 2 );
+		add_filter( 'popup_maker/is_builder_preview', [ $this, 'is_builder_preview' ] );
+	}
+
+	/**
+	 * Get the popup ID from a core editor preview request.
+	 *
+	 * @return false|int
+	 */
+	public function get_popup_preview() {
+		if (
+			! isset( $_GET['popup_preview'], $_GET['popup'] ) ||
+			! is_scalar( $_GET['popup_preview'] ) ||
+			! is_scalar( $_GET['popup'] )
+		) {
+			return false;
+		}
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$nonce    = sanitize_text_field( wp_unslash( $_GET['popup_preview'] ) );
+		$popup_id = sanitize_text_field( wp_unslash( $_GET['popup'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ( ! wp_verify_nonce( $nonce, 'popup-preview' ) ) {
+			return false;
+		}
+
+		if ( is_numeric( $popup_id ) && absint( $popup_id ) > 0 ) {
+			return absint( $popup_id );
+		}
+
+		$post = get_page_by_path( $popup_id, OBJECT, 'popup' );
+
+		return $post instanceof \WP_Post ? $post->ID : false;
+	}
+
+	/**
+	 * Get the authorized popup ID supplied by a builder adapter.
+	 *
+	 * @return int Popup ID, or 0 when the request is not authorized.
+	 */
+	public function get_builder_preview() {
+		$popup_id = absint( apply_filters( 'popup_maker/builder_preview_id', 0 ) );
+
+		if (
+			! $popup_id ||
+			'popup' !== get_post_type( $popup_id ) ||
+			! is_user_logged_in() ||
+			! current_user_can( 'edit_post', $popup_id )
+		) {
+			return 0;
+		}
+
+		return $popup_id;
+	}
+
+	/**
+	 * Get the current queried popup when it matches the builder preview.
+	 *
+	 * @return int Popup ID, or 0 when the main query is not the preview popup.
+	 */
+	public function get_current_builder_preview() {
+		$popup_id = $this->get_builder_preview();
+
+		if (
+			! $popup_id ||
+			! is_singular( 'popup' ) ||
+			absint( get_queried_object_id() ) !== $popup_id
+		) {
+			return 0;
+		}
+
+		return $popup_id;
+	}
+
+	/**
+	 * Restore the popup query for an authorized builder preview.
+	 *
+	 * @param mixed $query_vars Parsed WordPress query variables.
+	 *
+	 * @return mixed Filtered query variables.
+	 */
+	public function allow_builder_preview_request( $query_vars ) {
+		if ( ! is_array( $query_vars ) ) {
+			return $query_vars;
+		}
+
+		$popup_id = $this->get_builder_preview();
+
+		if ( $popup_id ) {
+			$query_vars['p']         = $popup_id;
+			$query_vars['post_type'] = 'popup';
+		}
+
+		return $query_vars;
+	}
+
+	/**
+	 * Preload the builder preview popup and its assets.
+	 *
+	 * @return void
+	 */
+	public function preload_builder_preview() {
+		$popup_id = $this->get_current_builder_preview();
+
+		if ( ! $popup_id ) {
+			return;
+		}
+
+		$popup  = $this->container->get( 'popups' )->get_by_id( $popup_id );
+		$popups = $this->container->get_controller( 'Frontend\Popups' );
+
+		if ( pum_is_popup( $popup ) && $popups instanceof \PopupMaker\Controllers\Frontend\Popups ) {
+			$popups->preload_popup( $popup );
+		}
+	}
+
+	/**
+	 * Select the isolated popup canvas for a builder preview.
+	 *
+	 * @param string $template Selected WordPress template path.
+	 *
+	 * @return string Filtered template path.
+	 */
+	public function use_builder_preview_template( $template ) {
+		if ( ! $this->get_current_builder_preview() ) {
+			return $template;
+		}
+
+		$popup_template = $this->container->get_path( 'templates/single-popup.php' );
+
+		if ( ! file_exists( $popup_template ) ) {
+			return $template;
+		}
+
+		$popups = $this->container->get_controller( 'Frontend\Popups' );
+
+		if ( ! $popups instanceof \PopupMaker\Controllers\Frontend\Popups ) {
+			return $template;
+		}
+
+		remove_action( 'wp_footer', [ $popups, 'render_popups' ] );
+
+		return $popup_template;
+	}
+
+	/**
+	 * Identify an active builder preview for the shared popup template.
+	 *
+	 * @param bool $is_preview Whether another integration identified the request.
+	 *
+	 * @return bool Whether this is an active popup builder preview.
+	 */
+	public function is_builder_preview( $is_preview ) {
+		return $is_preview || (bool) $this->get_current_builder_preview();
+	}
+
+	/**
+	 * Force a core editor preview popup to load regardless of post status.
+	 *
+	 * @return void
+	 */
+	public function force_load_preview() {
+		$popup_id = $this->get_popup_preview();
+
+		if ( ! $popup_id || ! current_user_can( 'edit_post', $popup_id ) ) {
+			return;
+		}
+
+		$popup = $this->container->get( 'popups' )->get_by_id( $popup_id );
+
+		if ( ! pum_is_popup( $popup ) || $popup_id !== $popup->ID ) {
+			return;
+		}
+
+		$popups = $this->container->get_controller( 'Frontend\Popups' );
+
+		if ( $popups instanceof \PopupMaker\Controllers\Frontend\Popups ) {
+			$popups->preload_popup( $popup );
+		}
+	}
+
+	/**
+	 * Force the target popup to load and isolate builder previews to that popup.
+	 *
+	 * @param bool $loadable Whether the popup is loadable.
+	 * @param int  $popup_id Popup ID.
+	 *
+	 * @return bool Whether the popup is loadable.
+	 */
+	public function is_loadable( $loadable, $popup_id ) {
+		$builder_preview_id = $this->get_builder_preview();
+
+		if ( $builder_preview_id ) {
+			return absint( $popup_id ) === $builder_preview_id;
+		}
+
+		return $this->is_previewing_popup( $popup_id ) ? true : $loadable;
+	}
+
+	/**
+	 * Add an admin debug trigger to core editor previews.
+	 *
+	 * @deprecated 1.16.10 Use get_public_settings instead.
+	 *
+	 * @param array $data_attr Popup data attributes.
+	 * @param int   $popup_id Popup ID.
+	 *
+	 * @return mixed
+	 */
+	public function data_attr( $data_attr, $popup_id ) {
+		if ( ! $this->is_previewing_popup( $popup_id ) ) {
+			return $data_attr;
+		}
+
+		$data_attr['triggers'] = [
+			[
+				'type' => 'admin_debug',
+			],
+		];
+
+		return $data_attr;
+	}
+
+	/**
+	 * Add an admin debug trigger to core editor previews.
+	 *
+	 * @param array           $settings Popup public settings.
+	 * @param PUM_Model_Popup $popup Popup model.
+	 *
+	 * @return array
+	 */
+	public function get_public_settings( $settings, $popup ) {
+		if ( ! $this->is_previewing_popup( $popup->ID ) ) {
+			return $settings;
+		}
+
+		$settings['triggers'] = [
+			[
+				'type' => 'admin_debug',
+			],
+		];
+
+		return $settings;
+	}
+
+	/**
+	 * Whether a popup is the authorized core editor preview.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return bool
+	 */
+	private function is_previewing_popup( $popup_id = 0 ) {
+		if ( wp_doing_ajax() ) {
+			return false;
+		}
+
+		$preview_id = $this->get_popup_preview();
+
+		return $popup_id === $preview_id && current_user_can( 'edit_post', $preview_id );
+	}
+}

--- a/classes/Plugin/Core.php
+++ b/classes/Plugin/Core.php
@@ -43,6 +43,7 @@ final class Core extends \PopupMaker\Plugin\Container {
 			'Admin'         => new \PopupMaker\Controllers\Admin( $this ),
 			'Assets'        => new \PopupMaker\Controllers\Assets( $this ),
 			'CallToActions' => new \PopupMaker\Controllers\CallToActions( $this ),
+			'Previews'      => new \PopupMaker\Controllers\Previews( $this ),
 			'Compatibility' => new \PopupMaker\Controllers\Compatibility( $this ),
 			'Debug'         => new \PopupMaker\Controllers\Debug( $this ),
 			'PostTypes'     => new \PopupMaker\Controllers\PostTypes( $this ),

--- a/classes/Previews.php
+++ b/classes/Previews.php
@@ -1,160 +1,130 @@
 <?php
 /**
- * Manage popup prevews.
+ * Legacy popup preview API.
  *
  * @package PopupMaker
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
- * Class PUM_Previews
+ * Backward-compatible facade for the popup preview controller.
  *
- * This class sets up the necessary changes to allow admins & editors to preview popups on the front end.
+ * @deprecated 1.25.0 Use the Previews controller from PopupMaker\plugin().
  */
 class PUM_Previews {
 
 	/**
-	 * Initiator method.
+	 * Initialize preview hooks.
+	 *
+	 * @deprecated 1.25.0 Preview hooks are initialized by the plugin container.
+	 *
+	 * @return void
 	 */
 	public static function init() {
-		add_action( 'template_redirect', [ __CLASS__, 'force_load_preview' ] );
-		add_filter( 'pum_popup_is_loadable', [ __CLASS__, 'is_loadable' ], 1000, 2 );
-		add_filter( 'pum_popup_data_attr', [ __CLASS__, 'data_attr' ], 1000, 2 );
-		add_filter( 'pum_popup_get_public_settings', [ __CLASS__, 'get_public_settings' ], 1000, 2 );
+		_deprecated_function( __METHOD__, '1.25.0', 'PopupMaker\Controllers\Previews::init()' );
+
+		$controller = static::controller();
+
+		if ( $controller ) {
+			$controller->init();
+		}
 	}
 
 	/**
-	 * Get popup id for previewing.
+	 * Get the popup ID for a core editor preview.
+	 *
+	 * @deprecated 1.25.0 Use PopupMaker\Controllers\Previews::get_popup_preview().
 	 *
 	 * @return false|int
 	 */
 	public static function get_popup_preview() {
-		static $preview_id;
+		_deprecated_function( __METHOD__, '1.25.0', 'PopupMaker\Controllers\Previews::get_popup_preview()' );
 
-		if ( isset( $preview_id ) ) {
-			return $preview_id;
-		}
+		$controller = static::controller();
 
-		$preview_id = false;
-
-		if (
-			! isset( $_GET['popup_preview'] ) ||
-			! isset( $_GET['popup'] ) ||
-			// Overridden as wp_verify_nonce is already safe: https://github.com/WordPress/WordPress-Coding-Standards/issues/869#issuecomment-611782416.
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			! wp_verify_nonce( $_GET['popup_preview'], 'popup-preview' )
-		) {
-			return false;
-		}
-
-		$popup_id = sanitize_text_field( wp_unslash( $_GET['popup'] ) );
-
-		if ( is_numeric( $_GET['popup'] ) && absint( $_GET['popup'] ) > 0 ) {
-			$preview_id = absint( $_GET['popup'] );
-		} else {
-			$post       = get_page_by_path( $popup_id, OBJECT, 'popup' );
-			$preview_id = $post->ID;
-		}
-
-		return $preview_id;
+		return $controller ? $controller->get_popup_preview() : false;
 	}
 
 	/**
-	 * Sets the Popup Post Type public arg to true for content editors.
+	 * Force the current core editor preview popup to load.
 	 *
-	 * This enables them to use the built in preview links.
+	 * @deprecated 1.25.0 Use PopupMaker\Controllers\Previews::force_load_preview().
 	 *
-	 * @param int $popup_id Popup ID.
-	 *
-	 * @return bool
-	 */
-	private static function is_previewing_popup( $popup_id = 0 ) {
-		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
-			return false;
-		}
-
-		$preview_id = static::get_popup_preview();
-
-		return $popup_id === $preview_id && current_user_can( 'edit_post', $preview_id );
-	}
-
-	/**
-	 * Force popup to load no matter its status if its supposed to be previewed.
+	 * @return void
 	 */
 	public static function force_load_preview() {
-		$preview_id = static::get_popup_preview();
+		_deprecated_function( __METHOD__, '1.25.0', 'PopupMaker\Controllers\Previews::force_load_preview()' );
 
-		// The preview nonce is shared across block-editor screens; require edit
-		// access to this specific popup before force-loading draft/private content.
-		if ( ! $preview_id || ! current_user_can( 'edit_post', $preview_id ) ) {
-			return;
-		}
+		$controller = static::controller();
 
-		$popup = pum_get_popup( $preview_id );
-
-		if ( $popup->is_valid() && $preview_id === $popup->ID ) {
-			PUM_Site_Popups::preload_popup( $popup );
+		if ( $controller ) {
+			$controller->force_load_preview();
 		}
 	}
 
 	/**
-	 * For popup previews this will force only the correct popup to load.
+	 * Filter popup loadability during a preview.
 	 *
-	 * @param bool $loadable Is popup loadable.
+	 * @deprecated 1.25.0 Use PopupMaker\Controllers\Previews::is_loadable().
+	 *
+	 * @param bool $loadable Whether the popup is loadable.
 	 * @param int  $popup_id Popup ID.
 	 *
 	 * @return bool
 	 */
 	public static function is_loadable( $loadable, $popup_id ) {
-		return self::is_previewing_popup( $popup_id ) ? true : $loadable;
+		_deprecated_function( __METHOD__, '1.25.0', 'PopupMaker\Controllers\Previews::is_loadable()' );
+
+		$controller = static::controller();
+
+		return $controller ? $controller->is_loadable( $loadable, $popup_id ) : $loadable;
 	}
 
 	/**
-	 * On popup previews add an admin debug trigger.
+	 * Filter legacy popup data attributes during a preview.
 	 *
-	 * @deprecated 1.16.10 Use get_public_settings instead.
+	 * @deprecated 1.25.0 Use PopupMaker\Controllers\Previews::data_attr().
 	 *
-	 * @param array $data_attr Array of popup data attributes.
+	 * @param array $data_attr Popup data attributes.
 	 * @param int   $popup_id Popup ID.
 	 *
 	 * @return mixed
 	 */
 	public static function data_attr( $data_attr, $popup_id ) {
-		if ( ! self::is_previewing_popup( $popup_id ) ) {
-			return $data_attr;
-		}
+		_deprecated_function( __METHOD__, '1.25.0', 'PopupMaker\Controllers\Previews::data_attr()' );
 
-		$data_attr['triggers'] = [
-			[
-				'type' => 'admin_debug',
-			],
-		];
+		$controller = static::controller();
 
-		return $data_attr;
+		return $controller ? $controller->data_attr( $data_attr, $popup_id ) : $data_attr;
 	}
 
 	/**
-	 * On popup previews add an admin debug trigger.
+	 * Filter popup public settings during a preview.
 	 *
-	 * @param array           $settings Array of settigs.
-	 * @param PUM_Model_Popup $popup Popup model object.
+	 * @deprecated 1.25.0 Use PopupMaker\Controllers\Previews::get_public_settings().
+	 *
+	 * @param array           $settings Popup public settings.
+	 * @param PUM_Model_Popup $popup Popup model.
 	 *
 	 * @return array
 	 */
 	public static function get_public_settings( $settings, $popup ) {
-		if ( ! self::is_previewing_popup( $popup->ID ) ) {
-			return $settings;
-		}
+		_deprecated_function( __METHOD__, '1.25.0', 'PopupMaker\Controllers\Previews::get_public_settings()' );
 
-		$settings['triggers'] = [
-			[
-				'type' => 'admin_debug',
-			],
-		];
+		$controller = static::controller();
 
-		return $settings;
+		return $controller ? $controller->get_public_settings( $settings, $popup ) : $settings;
+	}
+
+	/**
+	 * Get the modern preview controller.
+	 *
+	 * @return PopupMaker\Controllers\Previews|null
+	 */
+	private static function controller() {
+		$controller = PopupMaker\plugin()->get_controller( 'Previews' );
+
+		return $controller instanceof PopupMaker\Controllers\Previews ? $controller : null;
 	}
 }

--- a/docs/frontend-rendering-analysis.md
+++ b/docs/frontend-rendering-analysis.md
@@ -1,5 +1,11 @@
 # Popup Maker Frontend Rendering Analysis
 
+> This is a historical analysis of the v1.21.0 regression. The authoritative
+> integration contract is now documented in
+> [`page-builder-integration.md`](page-builder-integration.md). Current code uses
+> `wp_enqueue_scripts:11`, after builder initialization, as the proven preload
+> boundary.
+
 ## Executive Summary
 
 Critical timing change identified: Popup preloading moved from `wp_enqueue_scripts:11` to `wp_head:0`, causing Beaver Builder CSS conflicts when popups contain BB templates.
@@ -22,10 +28,13 @@ NEW: wp_head:0 → Popup shortcodes process → BB NOT initialized → CSS leaks
 4. BB shortcodes in popups execute without proper CSS context
 5. Result: BB styles leak into main page instead of being isolated
 
-### Working Solution
-Both of these work (any lower priority breaks BB):
+### Historical Working Threshold
+Historical testing found both of these avoided the original breakage:
 - `add_action( 'wp_head', [ $this, 'preload_popups' ], 1 );`
 - `add_action( 'wp_enqueue_scripts', [ $this, 'preload_popups' ], 10 );`
+
+The production integration uses `wp_enqueue_scripts:11` so builder callbacks at
+priority 10 always finish first, regardless of plugin registration order.
 
 ## Complete Frontend Process Comparison
 
@@ -122,7 +131,7 @@ Both of these work (any lower priority breaks BB):
 ```php
 // Move popup preloading back to safe timing
 // FROM: add_action( 'wp_head', [ $this, 'preload_popups' ], 0 );
-// TO:   add_action( 'wp_enqueue_scripts', [ $this, 'preload_popups' ], 10 );
+// TO:   add_action( 'wp_enqueue_scripts', [ $this, 'preload_popups' ], 11 );
 ```
 
 ### Conditional Loading

--- a/docs/page-builder-integration.md
+++ b/docs/page-builder-integration.md
@@ -1,0 +1,497 @@
+# Page Builder Integration Guide
+
+## Purpose
+
+This guide defines how Popup Maker should integrate page builders with popup
+editing, previewing, frontend rendering, asset loading, and widget
+initialization. It uses the Elementor integration as the reference
+implementation, but separates reusable Popup Maker lifecycle concerns from
+builder-specific APIs.
+
+The goal is to make the next builder integration small and predictable:
+
+1. Identify the popup represented by the builder request.
+2. Let Popup Maker authorize and restore that otherwise non-public query.
+3. Render the popup in Popup Maker's isolated builder canvas.
+4. Ask the builder to render its document during Popup Maker's normal preload.
+5. Batch the builder's asset finalization after all popup documents are known.
+6. Refresh interactive widgets when a hidden popup becomes visible.
+
+## Reference implementation
+
+The current implementation is split across these files:
+
+| Responsibility | Location | Ownership |
+| --- | --- | --- |
+| Secure preview request, isolated query, popup preload, template selection, asset batch boundaries | `classes/Controllers/Compatibility/Builder/Preview.php` | Shared |
+| Bare popup preview document and Popup Maker chrome | `templates/single-popup.php` | Shared |
+| Builder detection, document rendering, standalone preview URL, style finalization | `classes/Controllers/Compatibility/Builder/Elementor.php` | Elementor |
+| Widget refresh after popup visibility changes | `assets/js/src/integration/elementor.js` | Elementor |
+| Controller registration | `classes/Controllers/Compatibility.php` | Shared registry |
+| Asset batch coordinator coverage | `tests/php/tests/Page_Builder_Preview_Test.php` | Shared |
+| Request and authorization coverage | `tests/php/tests/Elementor_Compatibility_Test.php` | Elementor reference tests |
+
+## Architecture rule: abstract the lifecycle, not third-party internals
+
+Popup Maker should own behavior that is stable across builders. An adapter
+should own every call into a builder's API.
+
+### Shared Popup Maker responsibilities
+
+- Authenticate preview routes.
+- Require `edit_post` capability for the exact popup.
+- Restore the non-public `popup` post type only for the authorized request.
+- Preload draft or published popup content at the builder-safe time.
+- Select the isolated popup template.
+- Render only the target popup in a preview request.
+- Preserve Popup Maker theme, container, title, close button, and data
+  attributes.
+- Keep the preview close button visible but inert.
+- Reposition the preview after size changes.
+- Suppress the ordinary footer popup loop in an isolated preview.
+- Provide reusable nonce-backed standalone preview URLs.
+- Track pending builder assets and flush one batch after head-phase preload or
+  one late batch before footer rendering.
+
+### Builder adapter responsibilities
+
+- Recognize the builder's native iframe or preview request.
+- Determine whether a popup was built with that builder.
+- Render the builder document instead of raw `post_content`.
+- Register each rendered document with the builder's asset system.
+- Finalize builder styles and other assets through guarded builder APIs.
+- Supply a standalone preview URL when the builder's editor-only iframe cannot
+  be opened on its own.
+- Refresh legacy and modern widget runtimes after a popup becomes visible.
+- Add narrowly scoped editor-canvas CSS fixes when the builder assumes a page
+  layout rather than a popup container.
+
+### What must remain out of shared code
+
+- Builder globals and singleton access.
+- Builder hook names.
+- Builder document models.
+- Builder-generated CSS file names.
+- Builder widget initialization APIs.
+- Version-specific workarounds.
+
+Do not create a shared abstraction merely because two builders both have a
+method named `render()`. Extract a shared lifecycle only when the ordering,
+security, and state transition are the same.
+
+## Rendering phases
+
+Page-builder popup support spans several WordPress phases. Treat them as one
+pipeline rather than independent compatibility fixes.
+
+### Phase 1: builder editor iframe
+
+Some builders load the edited document through a frontend iframe. Popup posts
+are intentionally not publicly queryable, so WordPress normally strips the
+popup post type and produces a 404.
+
+The builder adapter implements `get_popup_id_from_request()`. The shared
+`Preview` controller then:
+
+1. Validates the target popup.
+2. Requires an authenticated user with `edit_post` capability.
+3. Restores `p` and `post_type=popup` through the `request` filter.
+4. Limits Popup Maker loading to that popup.
+5. Selects `templates/single-popup.php`.
+
+Builder-native iframe requests may not contain a WordPress nonce. They are only
+acceptable when the builder already requires authentication and the shared
+controller still checks the exact popup capability. A Popup Maker-owned route
+must always use the shared nonce-backed URL helpers.
+
+### Phase 2: standalone editor preview
+
+A builder's editor iframe URL is not necessarily a usable standalone preview.
+For example, Elementor's iframe intentionally returns an empty document wrapper
+and expects the parent editor to inject live data.
+
+When the editor's Preview button needs a normal browser page:
+
+1. Filter the builder's WordPress preview URL.
+2. Return `get_standalone_preview_url( $post_id, $builder_key )`.
+3. Recognize it with
+   `get_standalone_popup_id_from_request( $builder_key )`.
+4. Render the saved builder document through the isolated popup canvas.
+
+Do not point a standalone Preview button at an editor-only iframe URL unless it
+has been tested outside the parent editor.
+
+### Phase 3: normal frontend preload
+
+Popup Maker intentionally renders popup content before the main loop and caches
+the result:
+
+```text
+wp_enqueue_scripts:10   Page builders initialize CSS isolation and registries.
+wp_enqueue_scripts:11   Popup Maker queries and renders configured popups.
+wp_enqueue_scripts:12   Builder adapters finalize the collected popup styles.
+wp_enqueue_scripts:20   Builder/default style callbacks may run; one-shot calls no-op.
+main loop               The page's builder document renders normally.
+wp_footer:0             Finalize one batch of popups discovered in main-loop content.
+wp_footer:10            Popup Maker prints cached popup markup.
+wp_footer               Builder runtime enqueues/prints its normal scripts.
+```
+
+Priority 11 is a compatibility boundary, not an arbitrary number. Processing
+builder content before priority 11 can run before builder CSS isolation exists
+and cause popup styles to leak into the page.
+
+The footer does not normally execute the builder document again. It prints the
+content cached by `Frontend\Popups::preload_popup()`.
+
+### Phase 4: popup visibility
+
+Many builder widgets initialize while Popup Maker markup is hidden. Layout- or
+visibility-sensitive widgets may need a refresh after `pumAfterOpen`.
+
+The adapter should support both generations of a builder runtime when they
+coexist. The Elementor adapter, for example, refreshes its atomic Alpine tree
+and invokes the legacy element-ready trigger when those APIs exist.
+
+Always:
+
+- Scope refreshes to the opened popup's builder root.
+- Gate every third-party global and method.
+- Use the builder's lifecycle API instead of widget-specific click handlers.
+- Avoid reinitializing the whole document.
+- Also initialize the isolated builder canvas, which is already visible and
+  does not open through Popup Maker's normal lifecycle.
+
+## Asset finalization and batching
+
+Rendering each builder document is unavoidable. Re-running a builder's global
+asset handler for every popup is avoidable.
+
+### Required batching behavior
+
+Each builder adapter should:
+
+1. Render every configured builder popup during Popup Maker's priority-11
+   preload.
+2. Register each document with the builder's asset collector.
+3. Call `mark_builder_assets_pending()` after the builder registers a document.
+4. Run the builder's guarded style finalizer once at priority 12.
+5. Clear the pending marker.
+6. Use one `wp_footer:0` pass for popups discovered while rendering main-loop
+   content.
+
+This changes cumulative work from repeated passes over an expanding document
+set toward one pass over the complete set.
+
+For the Elementor reference case, an instrumented request containing one
+Elementor main page and six Elementor popups produced:
+
+- Seven builder documents in the DOM.
+- Six popup-specific generated CSS files.
+- One Elementor style-finalizer call.
+- One Elementor script lifecycle call.
+
+The remaining per-popup cost is the builder document render and its own
+generated CSS. Popup Maker should not try to combine or rewrite builder-owned
+CSS.
+
+### One-shot handlers
+
+Calling a builder's asset handler manually is appropriate when that is the
+builder's supported lifecycle boundary. The call must be:
+
+- Guarded by class, object, method, and hook existence as applicable.
+- Batched once per rendering phase.
+- Idempotent or protected by the builder's own one-shot behavior.
+- Repeated only when new documents were registered after the original
+  finalization pass.
+
+Elementor's `enqueue_styles()` is one-shot. The adapter records whether
+`elementor/frontend/after_enqueue_post_styles` advanced during the call. If it
+did not, and a finalizer is registered, it fires that finalizer hook once for
+the newly collected batch.
+
+Do not manually invoke Elementor's script enqueue method. Rendering builder
+content marks Elementor as present, and Elementor's normal footer lifecycle
+enqueues its scripts once.
+
+## Shared preview template contract
+
+`templates/single-popup.php` is a minimal WordPress document. It intentionally
+contains only:
+
+- A valid HTML document.
+- `wp_head()`, `wp_body_open()`, and `wp_footer()`.
+- The selected Popup Maker popup theme and container.
+- Optional popup title and an accessible dialog name.
+- The builder-rendered popup content.
+- The configured close button, visually present but disabled.
+- Preview-only positioning and resize behavior.
+
+It intentionally omits the active theme header, footer, navigation, page
+content, and unrelated popups. This prevents theme layout rules from becoming
+part of the editor canvas while retaining the same Popup Maker chrome used on
+the frontend.
+
+The template currently preserves the legacy Bricks fallback until Bricks is
+migrated to the shared `Preview` controller.
+
+## Builder adapter template
+
+The smallest PHP adapter extends `Preview` and implements builder request
+recognition. Add frontend rendering and override `finalize_builder_assets()`
+only if the builder does not already process `pum_popup_content` and its assets
+correctly.
+
+```php
+namespace PopupMaker\Controllers\Compatibility\Builder;
+
+class ExampleBuilder extends Preview {
+
+	/**
+	 * Initialize builder-specific hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		parent::init();
+
+		add_filter( 'pum_popup_content', [ $this, 'render_popup_content' ], 1000, 2 );
+	}
+
+	/**
+	 * Identify a native builder preview request.
+	 *
+	 * @return int Popup ID, or 0 when the request does not match.
+	 */
+	protected function get_popup_id_from_request() {
+		// Validate scalar request values and return only the matching popup ID.
+		return 0;
+	}
+
+	/**
+	 * Render a popup document through the builder.
+	 *
+	 * Third-party hook callbacks must remain defensively untyped.
+	 *
+	 * @param mixed $content  Original popup content.
+	 * @param mixed $popup_id Popup ID.
+	 *
+	 * @return mixed Builder markup or original content.
+	 */
+	public function render_popup_content( $content, $popup_id = 0 ) {
+		// Validate the builder, popup ID, document, and supported render method.
+		// Register the document, then call mark_builder_assets_pending().
+		return $content;
+	}
+
+	/**
+	 * Finalize one collected builder-asset batch.
+	 *
+	 * @return bool Whether the batch was finalized.
+	 */
+	protected function finalize_builder_assets() {
+		// Gate the builder's asset API and invoke it once for the batch.
+		return true;
+	}
+}
+```
+
+Register the adapter in `classes/Controllers/Compatibility.php`. Keep the
+adapter enabled and cheap when the builder is absent, or implement a reliable
+`controller_enabled()` check if loading it has measurable cost.
+
+## JavaScript adapter template
+
+Place builder runtime integration with the other frontend integrations. Do not
+add a new standalone bundle unless the dependency or payload justifies one.
+
+```javascript
+{
+	const $ = window.jQuery;
+
+	const refreshWidgets = ( popup ) => {
+		const builderRoot = popup.querySelector( '.example-builder' );
+
+		if ( ! builderRoot || ! window.exampleBuilder ) {
+			return;
+		}
+
+		if ( typeof window.exampleBuilder.refresh === 'function' ) {
+			window.exampleBuilder.refresh( builderRoot );
+		}
+	};
+
+	$( document ).on( 'pumAfterOpen', '.pum', function () {
+		refreshWidgets( this );
+	} );
+
+	$( function () {
+		$( '.pum-builder-preview-popup' ).each( function () {
+			refreshWidgets( this );
+		} );
+	} );
+}
+```
+
+## Security requirements
+
+Every preview integration must preserve the non-public popup boundary.
+
+- Never make `popup` publicly queryable to satisfy a builder.
+- Never restore `post_type=popup` for a generic `p` request.
+- Match all builder-specific IDs included in the request.
+- Require an authenticated user and `edit_post` for the exact popup.
+- Use a builder-specific nonce for Popup Maker-owned standalone routes.
+- Treat native builder iframe routes without nonces as exceptions and retain
+  the exact capability check.
+- Reject arrays and objects in query parameters before sanitizing them.
+- Do not load other popups in an isolated preview.
+- Preserve draft support only inside the authorized preview path.
+
+Required negative tests include mismatched IDs, logged-out requests, users
+without popup capability, invalid standalone nonces, and unrelated popup IDs.
+
+## Main-page builder coexistence
+
+Always test a builder popup on a page built with the same builder. This catches
+document-manager corruption, duplicate asset finalization, and CSS leakage that
+a classic WordPress page cannot expose.
+
+The Elementor reference test used two distinct documents:
+
+- Main-loop Elementor page with its own generated `post-{id}.css`.
+- Elementor popup with its own generated popup CSS.
+
+Both builder roots and CSS files must coexist. Rendering the popup must not
+replace the builder's current main document, and opening it must not remove or
+restyle the main page.
+
+Also test a classic page with a builder popup. A builder may only schedule its
+base assets when the main queried object uses that builder, so the popup adapter
+must cover this case without requiring a builder page.
+
+## Test matrix
+
+### Request and authorization
+
+- Native builder iframe with an authorized administrator.
+- Draft popup in the builder iframe.
+- Mismatched builder and WordPress post IDs.
+- Logged-out iframe request.
+- Logged-in user without `edit_post` capability.
+- Valid standalone preview nonce.
+- Invalid or different-popup standalone nonce.
+
+### Editor canvas
+
+- Popup theme, size, position, title, and close button are visible.
+- Theme header, footer, and navigation are absent.
+- Close attempts do not remove the editing canvas.
+- Container repositions after content or setting changes.
+- Empty builder sections do not inherit page-canvas spacing.
+- The editor's Preview button opens a usable standalone page.
+
+### Frontend rendering
+
+- Classic main page plus one builder popup.
+- Same-builder main page plus one builder popup.
+- Same-builder main page plus at least six builder popups.
+- Multiple popup documents receive their individual generated CSS.
+- Global style and script finalizers run once per batch.
+- A popup discovered in main-loop content receives the footer asset pass.
+- Non-builder popups retain their original content path.
+- Tabs, accordions, forms, sliders, and other interactive widgets initialize
+  after opening.
+- Reopening a popup does not duplicate handlers.
+
+### Quality and compatibility
+
+- PHP 7.4 syntax.
+- Defensive, untyped third-party hook callbacks.
+- PHPCS and PHPStan.
+- Focused PHPUnit request tests.
+- Frontend asset build and ESLint when JavaScript changes.
+- Browser verification with generated CSS and script URLs recorded.
+
+## Adding another builder
+
+1. Capture the builder's editor iframe request and standalone Preview behavior.
+2. Confirm whether the builder supports non-public post types directly.
+3. Add a small adapter extending `Preview`.
+4. Implement strict request matching in `get_popup_id_from_request()`.
+5. Reuse the shared standalone URL helpers when needed.
+6. Determine whether the builder already filters popup content.
+7. If not, render only documents positively identified as builder documents.
+8. Identify how document rendering registers generated CSS and widget assets.
+9. Batch the builder's finalizer after priority-11 popup preload.
+10. Add a footer batch only for content discovered after the head phase.
+11. Use the builder's normal script lifecycle whenever possible.
+12. Add a scoped widget refresh on `pumAfterOpen` when required.
+13. Add only builder-specific canvas CSS to the adapter.
+14. Register the controller and add the full authorization test set.
+15. Test classic-page, same-builder-page, and six-popup scenarios.
+
+## Shared utilities and future extraction
+
+The shared `Preview` controller and template cover routing, security, query
+restoration, isolated rendering, popup chrome, and the two-phase asset batching
+state machine. Its contract is:
+
+```text
+mark_pending()       Called whenever a builder document registers assets.
+flush_head_batch()   Runs after priority-11 popup preload.
+flush_footer_batch() Runs before normal footer rendering for late discoveries.
+finalize()           Supplied by the builder adapter and invoked once per batch.
+```
+
+Builder asset APIs remain in their adapter because their hooks and one-shot
+behavior are builder-specific. Do not move a builder hook name or singleton
+into the shared coordinator. It knows only whether work is pending and when a
+batch boundary has been reached.
+
+Likewise, extract a shared JavaScript visibility coordinator only after another
+builder needs the same open/canvas callbacks. The builder adapter should still
+supply the scoped refresh function.
+
+## Common failure modes
+
+| Symptom | Likely cause |
+| --- | --- |
+| Builder editor returns 404 | Popup query was not restored for the exact authorized request. |
+| Editor shows the WordPress popup settings UI | The request opened the normal post editor rather than the builder iframe. |
+| Preview button opens an empty document | An editor-only iframe URL was reused as a standalone preview. |
+| Popup contains raw headings or shortcodes | Popup content bypassed the builder document renderer. |
+| Popup is unstyled | Builder document CSS was not registered or finalized before output. |
+| Main page styles change after enabling a popup | Popup content rendered before builder CSS isolation initialized. |
+| Six popups cause repeated asset work | The builder finalizer is called inside the per-popup render method instead of once per batch. |
+| Widgets look correct but do not respond | Builder scripts or visibility-time widget initialization are missing. |
+| Preview closes and disappears | Builder canvas close behavior was not made inert. |
+| Popup position ignores editor changes | Popup Maker repositioning was not triggered after resize or content mutation. |
+
+## Elementor-specific notes
+
+- `elementor-preview` is the native editor iframe route.
+- The native iframe is an editor shell; use the shared standalone route for the
+  editor's Preview button.
+- `get_builder_content_for_display()` is preferred outside the current preview
+  document.
+- Elementor rejects rendering the current document through that display helper,
+  so the isolated preview uses its internal current-document render method.
+- `elementor/post/render` registers the popup document with Elementor's asset
+  collectors.
+- Elementor atomic styles finalize through
+  `elementor/frontend/after_enqueue_post_styles`.
+- Elementor enqueues scripts through its own footer lifecycle after rendered
+  content marks Elementor as present.
+- Atomic widgets use `elementorV2.alpinejs.refreshTree()`.
+- Legacy widgets use `elementorFrontend.elementsHandler.runReadyTrigger()`.
+- A widget defect that also reproduces on a normal Elementor page is upstream;
+  do not hide it behind a Popup Maker-wide widget workaround.
+
+## Related documentation
+
+- `docs/frontend-rendering-analysis.md` explains why page-builder popup content
+  must not be processed before the builder-safe preload window.
+- `classes/Controllers/Frontend/Popups.php` contains the authoritative timing
+  history and priority-11 compatibility notes.

--- a/docs/page-builder-integration.md
+++ b/docs/page-builder-integration.md
@@ -24,7 +24,8 @@ The current implementation is split across these files:
 | Responsibility | Location | Ownership |
 | --- | --- | --- |
 | Preview authorization, isolated query, popup preload, and template selection | `classes/Controllers/Previews.php` | Shared |
-| Builder request registration, preview URL helpers, and asset batch boundaries | `classes/Controllers/Compatibility/Builder/Preview.php` | Shared |
+| Builder request registration and preview URL helpers | `classes/Controllers/Compatibility/Builder/Concerns/BuilderPreview.php` | Shared concern |
+| Builder asset batch boundaries | `classes/Controllers/Compatibility/Builder/Concerns/AssetBatching.php` | Shared concern |
 | Deprecated static preview API | `classes/Previews.php` | Backward compatibility |
 | Bare popup preview document and Popup Maker chrome | `templates/single-popup.php` | Shared |
 | Builder detection, document rendering, standalone preview URL, style finalization | `classes/Controllers/Compatibility/Builder/Elementor.php` | Elementor |
@@ -242,15 +243,21 @@ migrated to the shared `Previews` controller lifecycle.
 
 ## Builder adapter template
 
-The smallest PHP adapter extends `Preview` and implements builder request
-recognition. Add frontend rendering and override `finalize_builder_assets()`
-only if the builder does not already process `pum_popup_content` and its assets
-correctly.
+The smallest PHP adapter extends Popup Maker's normal `Controller` and composes
+only the concerns it needs. Add `BuilderPreview` for editor request handling,
+and add `AssetBatching` only when the builder needs explicit asset finalization.
 
 ```php
 namespace PopupMaker\Controllers\Compatibility\Builder;
 
-class ExampleBuilder extends Preview {
+use PopupMaker\Controllers\Compatibility\Builder\Concerns\AssetBatching;
+use PopupMaker\Controllers\Compatibility\Builder\Concerns\BuilderPreview;
+use PopupMaker\Plugin\Controller;
+
+class ExampleBuilder extends Controller {
+
+	use AssetBatching;
+	use BuilderPreview;
 
 	/**
 	 * Initialize builder-specific hooks.
@@ -258,7 +265,8 @@ class ExampleBuilder extends Preview {
 	 * @return void
 	 */
 	public function init() {
-		parent::init();
+		$this->register_builder_preview();
+		$this->register_builder_asset_batching();
 
 		add_filter( 'pum_popup_content', [ $this, 'render_popup_content' ], 1000, 2 );
 	}
@@ -422,13 +430,15 @@ must cover this case without requiring a builder page.
 
 1. Capture the builder's editor iframe request and standalone Preview behavior.
 2. Confirm whether the builder supports non-public post types directly.
-3. Add a small adapter extending `Preview`.
-4. Implement strict request matching in `get_popup_id_from_request()`.
+3. Add a small adapter extending Popup Maker's normal `Controller`.
+4. Compose `BuilderPreview` when the builder needs custom editor routing, then
+   implement strict request matching in `get_popup_id_from_request()`.
 5. Reuse the shared standalone URL helpers when needed.
 6. Determine whether the builder already filters popup content.
 7. If not, render only documents positively identified as builder documents.
 8. Identify how document rendering registers generated CSS and widget assets.
-9. Batch the builder's finalizer after priority-11 popup preload.
+9. Compose `AssetBatching` when needed and finalize after priority-11 popup
+   preload.
 10. Add a footer batch only for content discovered after the head phase.
 11. Use the builder's normal script lifecycle whenever possible.
 12. Add a scoped widget refresh on `pumAfterOpen` when required.
@@ -438,9 +448,9 @@ must cover this case without requiring a builder page.
 
 ## Shared utilities and future extraction
 
-The shared `Preview` controller and template cover routing, security, query
-restoration, isolated rendering, popup chrome, and the two-phase asset batching
-state machine. Its contract is:
+The `Previews` controller and shared template cover routing, security, query
+restoration, isolated rendering, and popup chrome. Optional builder concerns
+then add only the primitives an adapter needs. The `AssetBatching` contract is:
 
 ```text
 mark_pending()       Called whenever a builder document registers assets.

--- a/docs/page-builder-integration.md
+++ b/docs/page-builder-integration.md
@@ -23,7 +23,9 @@ The current implementation is split across these files:
 
 | Responsibility | Location | Ownership |
 | --- | --- | --- |
-| Secure preview request, isolated query, popup preload, template selection, asset batch boundaries | `classes/Controllers/Compatibility/Builder/Preview.php` | Shared |
+| Preview authorization, isolated query, popup preload, and template selection | `classes/Controllers/Previews.php` | Shared |
+| Builder request registration, preview URL helpers, and asset batch boundaries | `classes/Controllers/Compatibility/Builder/Preview.php` | Shared |
+| Deprecated static preview API | `classes/Previews.php` | Backward compatibility |
 | Bare popup preview document and Popup Maker chrome | `templates/single-popup.php` | Shared |
 | Builder detection, document rendering, standalone preview URL, style finalization | `classes/Controllers/Compatibility/Builder/Elementor.php` | Elementor |
 | Widget refresh after popup visibility changes | `assets/js/src/integration/elementor.js` | Elementor |
@@ -49,7 +51,9 @@ should own every call into a builder's API.
 - Keep the preview close button visible but inert.
 - Reposition the preview after size changes.
 - Suppress the ordinary footer popup loop in an isolated preview.
-- Provide reusable nonce-backed standalone preview URLs.
+- Authorize the popup ID supplied by a builder through
+  `popup_maker/builder_preview_id`.
+- Provide reusable nonce-backed standalone preview URL helpers.
 - Track pending builder assets and flush one batch after head-phase preload or
   one late batch before footer rendering.
 
@@ -90,8 +94,8 @@ Some builders load the edited document through a frontend iframe. Popup posts
 are intentionally not publicly queryable, so WordPress normally strips the
 popup post type and produces a 404.
 
-The builder adapter implements `get_popup_id_from_request()`. The shared
-`Preview` controller then:
+The builder adapter supplies its request through the shared builder adapter
+base. The `Previews` controller then:
 
 1. Validates the target popup.
 2. Requires an authenticated user with `edit_post` capability.
@@ -100,9 +104,9 @@ The builder adapter implements `get_popup_id_from_request()`. The shared
 5. Selects `templates/single-popup.php`.
 
 Builder-native iframe requests may not contain a WordPress nonce. They are only
-acceptable when the builder already requires authentication and the shared
+acceptable when the builder already requires authentication and the preview
 controller still checks the exact popup capability. A Popup Maker-owned route
-must always use the shared nonce-backed URL helpers.
+must always use a nonce-backed URL.
 
 ### Phase 2: standalone editor preview
 
@@ -234,7 +238,7 @@ part of the editor canvas while retaining the same Popup Maker chrome used on
 the frontend.
 
 The template currently preserves the legacy Bricks fallback until Bricks is
-migrated to the shared `Preview` controller.
+migrated to the shared `Previews` controller lifecycle.
 
 ## Builder adapter template
 

--- a/includes/legacy/class-popup-maker.php
+++ b/includes/legacy/class-popup-maker.php
@@ -168,7 +168,6 @@ class Popup_Maker {
 		PUM_Admin::init();
 		PUM_Utils_Upgrades::instance();
 		PUM_Newsletters::init();
-		PUM_Previews::init();
 		PUM_Integrations::init();
 		PUM_Privacy::init();
 

--- a/templates/single-popup.php
+++ b/templates/single-popup.php
@@ -8,8 +8,8 @@
 
 $is_builder_preview = (bool) apply_filters( 'popup_maker/is_builder_preview', false );
 
-// Preserve the legacy Bricks template behavior until it adopts the shared
-// builder preview controller.
+// Preserve the legacy Bricks template behavior.
+// Keep it until Bricks adopts the shared builder preview controller.
 if ( ! $is_builder_preview ) {
 	get_header();
 	get_footer();
@@ -76,6 +76,8 @@ $previous_popup = \PopupMaker\get_current_popup();
 				aria-modal="false"
 				<?php if ( $has_title ) : ?>
 					aria-labelledby="pum_popup_title_<?php pum_popup_ID(); ?>"
+				<?php else : ?>
+					aria-label="<?php esc_attr_e( 'Popup preview', 'popup-maker' ); ?>"
 				<?php endif; ?>
 				class="<?php pum_popup_classes(); ?> pum-builder-preview-popup"
 				<?php pum_popup_data_attr(); ?>

--- a/templates/single-popup.php
+++ b/templates/single-popup.php
@@ -44,28 +44,20 @@ $previous_popup = \PopupMaker\get_current_popup();
 		}
 
 		body.pum-builder-preview > .pum-builder-preview-popup {
-			display: flex !important;
-			align-items: flex-start;
-			justify-content: center;
-			position: relative !important;
-			inset: auto !important;
-			min-height: 100vh;
-			width: 100% !important;
-			padding: 100px 2.5vw 3em;
+			display: block !important;
 			opacity: 1 !important;
 			visibility: visible !important;
-			overflow: visible;
 		}
 
 		body.pum-builder-preview .pum-container {
 			display: block !important;
-			position: relative !important;
-			top: auto !important;
-			left: auto !important;
-			margin-left: 0 !important;
-			margin-bottom: 0;
 			opacity: 1 !important;
 			visibility: visible !important;
+		}
+
+		body.pum-builder-preview .pum-close[aria-disabled="true"] {
+			display: block !important;
+			pointer-events: none !important;
 		}
 	</style>
 </head>
@@ -106,7 +98,7 @@ $previous_popup = \PopupMaker\get_current_popup();
 					<?php do_action( 'popmake_popup_after_inner' ); // Backward compatibility. ?>
 
 					<?php if ( pum_show_close_button() ) : ?>
-						<button type="button" class="<?php pum_popup_classes( null, 'close' ); ?>" aria-label="<?php esc_attr_e( 'Close', 'popup-maker' ); ?>">
+						<button type="button" class="<?php pum_popup_classes( null, 'close' ); ?>" aria-label="<?php esc_attr_e( 'Close', 'popup-maker' ); ?>" aria-disabled="true" tabindex="-1">
 							<?php pum_popup_close_text(); ?>
 						</button>
 					<?php endif; ?>
@@ -119,5 +111,40 @@ $previous_popup = \PopupMaker\get_current_popup();
 	\PopupMaker\set_current_popup( $previous_popup );
 	wp_footer();
 	?>
+	<script id="pum-builder-preview-script">
+		( function ( $, PUM ) {
+			'use strict';
+
+			var popupId = <?php echo absint( $popup_id ); ?>,
+				$popup = PUM.getPopup( popupId ),
+				resizeObserver;
+
+			function repositionPopup() {
+				$popup.popmake( 'reposition' );
+				$popup.find( '.pum-close' ).attr( {
+					'aria-disabled': 'true',
+					tabindex: '-1'
+				} );
+			}
+
+			$popup.on( 'pumBeforeClose.pumBuilderPreview', function () {
+				$popup.addClass( 'preventClose' );
+			} );
+			$popup.on( 'pumAfterOpen.pumBuilderPreview', repositionPopup );
+
+			if ( PUM.initialized ) {
+				repositionPopup();
+			} else {
+				$( document ).one( 'pumInitialized.pumBuilderPreview', repositionPopup );
+			}
+
+			$( window ).on( 'resize.pumBuilderPreview', repositionPopup );
+
+			if ( 'ResizeObserver' in window ) {
+				resizeObserver = new ResizeObserver( repositionPopup );
+				resizeObserver.observe( $popup.find( '.pum-container' )[ 0 ] );
+			}
+		} )( jQuery, window.PUM );
+	</script>
 </body>
 </html>

--- a/templates/single-popup.php
+++ b/templates/single-popup.php
@@ -1,11 +1,123 @@
 <?php
 /**
- * Single-Popup Templates
+ * Single Popup Template.
  *
  * @package   PopupMaker
  * @copyright Copyright (c) 2024, Code Atlantic LLC
  */
 
-get_header();
+$is_builder_preview = (bool) apply_filters( 'popup_maker/is_builder_preview', false );
 
-get_footer();
+// Preserve the legacy Bricks template behavior until it adopts the shared
+// builder preview controller.
+if ( ! $is_builder_preview ) {
+	get_header();
+	get_footer();
+	return;
+}
+
+$popup_id = absint( get_queried_object_id() );
+$popup    = pum_get_popup( $popup_id );
+
+if ( ! pum_is_popup( $popup ) ) {
+	return;
+}
+
+$previous_popup = \PopupMaker\get_current_popup();
+
+?><!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<?php wp_head(); ?>
+	<style id="pum-builder-preview-styles">
+		html,
+		body.pum-builder-preview {
+			min-height: 100%;
+		}
+
+		body.pum-builder-preview {
+			margin: 0;
+			min-height: 100vh;
+			overflow: auto;
+		}
+
+		body.pum-builder-preview > .pum-builder-preview-popup {
+			display: flex !important;
+			align-items: flex-start;
+			justify-content: center;
+			position: relative !important;
+			inset: auto !important;
+			min-height: 100vh;
+			width: 100% !important;
+			padding: 100px 2.5vw 3em;
+			opacity: 1 !important;
+			visibility: visible !important;
+			overflow: visible;
+		}
+
+		body.pum-builder-preview .pum-container {
+			display: block !important;
+			position: relative !important;
+			top: auto !important;
+			left: auto !important;
+			margin-left: 0 !important;
+			margin-bottom: 0;
+			opacity: 1 !important;
+			visibility: visible !important;
+		}
+	</style>
+</head>
+<body <?php body_class( 'pum-builder-preview' ); ?>>
+	<?php wp_body_open(); ?>
+	<?php if ( have_posts() ) : ?>
+		<?php while ( have_posts() ) : ?>
+			<?php
+			the_post();
+			\PopupMaker\set_current_popup( $popup );
+			$has_title = pum_get_popup_title() !== '';
+			?>
+			<div
+				id="pum-<?php pum_popup_ID(); ?>"
+				role="dialog"
+				aria-modal="false"
+				<?php if ( $has_title ) : ?>
+					aria-labelledby="pum_popup_title_<?php pum_popup_ID(); ?>"
+				<?php endif; ?>
+				class="<?php pum_popup_classes(); ?> pum-builder-preview-popup"
+				<?php pum_popup_data_attr(); ?>
+			>
+				<div id="popmake-<?php pum_popup_ID(); ?>" class="<?php pum_popup_classes( null, 'container' ); ?>">
+					<?php do_action( 'pum_popup_before_title' ); ?>
+					<?php do_action( 'popmake_popup_before_inner' ); // Backward compatibility. ?>
+
+					<?php if ( $has_title ) : ?>
+						<div id="pum_popup_title_<?php pum_popup_ID(); ?>" class="<?php pum_popup_classes( null, 'title' ); ?>">
+							<?php pum_popup_title(); ?>
+						</div>
+					<?php endif; ?>
+
+					<?php do_action( 'pum_popup_before_content' ); ?>
+					<div class="<?php pum_popup_classes( null, 'content' ); ?>" <?php pum_popup_content_tabindex_attr(); ?>>
+						<?php the_content(); ?>
+					</div>
+					<?php do_action( 'pum_popup_after_content' ); ?>
+					<?php do_action( 'popmake_popup_after_inner' ); // Backward compatibility. ?>
+
+					<?php if ( pum_show_close_button() ) : ?>
+						<button type="button" class="<?php pum_popup_classes( null, 'close' ); ?>" aria-label="<?php esc_attr_e( 'Close', 'popup-maker' ); ?>">
+							<?php pum_popup_close_text(); ?>
+						</button>
+					<?php endif; ?>
+				</div>
+			</div>
+		<?php endwhile; ?>
+	<?php endif; ?>
+
+	<?php
+	\PopupMaker\set_current_popup( $previous_popup );
+	wp_footer();
+	?>
+</body>
+</html>

--- a/templates/single-popup.php
+++ b/templates/single-popup.php
@@ -94,7 +94,7 @@ $previous_popup = \PopupMaker\get_current_popup();
 
 					<?php do_action( 'pum_popup_before_content' ); ?>
 					<div class="<?php pum_popup_classes( null, 'content' ); ?>" <?php pum_popup_content_tabindex_attr(); ?>>
-						<?php the_content(); ?>
+						<?php pum_popup_content(); ?>
 					</div>
 					<?php do_action( 'pum_popup_after_content' ); ?>
 					<?php do_action( 'popmake_popup_after_inner' ); // Backward compatibility. ?>

--- a/tests/php/tests/Elementor_Compatibility_Test.php
+++ b/tests/php/tests/Elementor_Compatibility_Test.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * Elementor builder compatibility tests.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Test Elementor popup preview requests.
+ */
+class Elementor_Compatibility_Test extends WP_UnitTestCase {
+
+	/**
+	 * Original query parameters.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private $original_get;
+
+	/**
+	 * Preserve query parameters before each test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test fixture preserves request globals.
+		$this->original_get = $_GET;
+	}
+
+	/**
+	 * Restore global state after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		$_GET = $this->original_get;
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * An authorized Elementor preview can query its popup.
+	 *
+	 * @return void
+	 */
+	public function test_authorized_elementor_preview_restores_popup_post_type() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+		$_GET = [
+			'elementor-preview' => (string) $popup_id,
+			'p'                 => (string) $popup_id,
+			'post_type'         => 'popup',
+		];
+
+		$query_vars = apply_filters( 'request', [ 'p' => (string) $popup_id ] );
+
+		$this->assertSame( $popup_id, $query_vars['p'] );
+		$this->assertSame( 'popup', $query_vars['post_type'] );
+		$this->assertFalse( apply_filters( 'pum_popup_is_loadable', true, $popup_id ) );
+	}
+
+	/**
+	 * A mismatched preview ID must not expose a popup query.
+	 *
+	 * @return void
+	 */
+	public function test_mismatched_elementor_preview_does_not_restore_popup_post_type() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+		$_GET = [
+			'elementor-preview' => (string) $popup_id,
+			'p'                 => (string) ( $popup_id + 1 ),
+			'post_type'         => 'popup',
+		];
+
+		$query_vars = apply_filters( 'request', [ 'p' => (string) ( $popup_id + 1 ) ] );
+
+		$this->assertArrayNotHasKey( 'post_type', $query_vars );
+	}
+
+	/**
+	 * Logged-out preview requests must remain non-queryable.
+	 *
+	 * @return void
+	 */
+	public function test_logged_out_elementor_preview_does_not_restore_popup_post_type() {
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		$_GET = [
+			'elementor-preview' => (string) $popup_id,
+			'p'                 => (string) $popup_id,
+			'post_type'         => 'popup',
+		];
+
+		$query_vars = apply_filters( 'request', [ 'p' => (string) $popup_id ] );
+
+		$this->assertArrayNotHasKey( 'post_type', $query_vars );
+		$this->assertTrue( apply_filters( 'pum_popup_is_loadable', true, $popup_id ) );
+	}
+
+	/**
+	 * A logged-in user without popup permissions must remain blocked.
+	 *
+	 * @return void
+	 */
+	public function test_user_without_popup_permission_does_not_restore_popup_post_type() {
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		$popup_id      = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		wp_set_current_user( $subscriber_id );
+		$_GET = [
+			'elementor-preview' => (string) $popup_id,
+			'p'                 => (string) $popup_id,
+			'post_type'         => 'popup',
+		];
+
+		$query_vars = apply_filters( 'request', [ 'p' => (string) $popup_id ] );
+
+		$this->assertArrayNotHasKey( 'post_type', $query_vars );
+		$this->assertTrue( apply_filters( 'pum_popup_is_loadable', true, $popup_id ) );
+	}
+}

--- a/tests/php/tests/Elementor_Compatibility_Test.php
+++ b/tests/php/tests/Elementor_Compatibility_Test.php
@@ -200,6 +200,32 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An invalid standalone nonce must not expose a popup query.
+	 *
+	 * @return void
+	 */
+	public function test_invalid_standalone_nonce_does_not_restore_popup_post_type() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+		$_GET = [
+			'pum-builder-preview' => 'elementor',
+			'p'                   => (string) $popup_id,
+			'_wpnonce'            => wp_create_nonce( 'pum_builder_preview_elementor_' . ( $popup_id + 1 ) ),
+		];
+
+		$query_vars = apply_filters( 'request', [ 'p' => (string) $popup_id ] );
+
+		$this->assertArrayNotHasKey( 'post_type', $query_vars );
+	}
+
+	/**
 	 * A mismatched preview ID must not expose a popup query.
 	 *
 	 * @return void

--- a/tests/php/tests/Elementor_Compatibility_Test.php
+++ b/tests/php/tests/Elementor_Compatibility_Test.php
@@ -120,6 +120,86 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Elementor's standalone preview uses the authenticated popup canvas.
+	 *
+	 * @return void
+	 */
+	public function test_elementor_wp_preview_url_uses_popup_canvas() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+
+		$document = new class( $popup_id ) {
+			/**
+			 * Popup ID.
+			 *
+			 * @var int
+			 */
+			private $popup_id;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param int $popup_id Popup ID.
+			 */
+			public function __construct( $popup_id ) {
+				$this->popup_id = $popup_id;
+			}
+
+			/**
+			 * Get the document ID.
+			 *
+			 * @return int Popup ID.
+			 */
+			public function get_main_id() {
+				return $this->popup_id;
+			}
+		};
+
+		$preview_url = apply_filters( 'elementor/document/urls/wp_preview', '', $document );
+		$query       = [];
+		parse_str( (string) wp_parse_url( $preview_url, PHP_URL_QUERY ), $query );
+
+		$this->assertSame( 'popup', $query['post_type'] );
+		$this->assertSame( (string) $popup_id, $query['p'] );
+		$this->assertSame( 'elementor', $query['pum-builder-preview'] );
+		$this->assertNotFalse( wp_verify_nonce( $query['_wpnonce'], 'pum_builder_preview_elementor_' . $popup_id ) );
+	}
+
+	/**
+	 * A valid standalone Elementor preview can query its popup.
+	 *
+	 * @return void
+	 */
+	public function test_authorized_standalone_elementor_preview_restores_popup_post_type() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+		$_GET = [
+			'pum-builder-preview' => 'elementor',
+			'p'                   => (string) $popup_id,
+			'_wpnonce'            => wp_create_nonce( 'pum_builder_preview_elementor_' . $popup_id ),
+		];
+
+		$query_vars = apply_filters( 'request', [ 'p' => (string) $popup_id ] );
+
+		$this->assertSame( $popup_id, $query_vars['p'] );
+		$this->assertSame( 'popup', $query_vars['post_type'] );
+	}
+
+	/**
 	 * A mismatched preview ID must not expose a popup query.
 	 *
 	 * @return void

--- a/tests/php/tests/Elementor_Compatibility_Test.php
+++ b/tests/php/tests/Elementor_Compatibility_Test.php
@@ -66,7 +66,57 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 
 		$this->assertSame( $popup_id, $query_vars['p'] );
 		$this->assertSame( 'popup', $query_vars['post_type'] );
-		$this->assertFalse( apply_filters( 'pum_popup_is_loadable', true, $popup_id ) );
+		$this->assertTrue( apply_filters( 'pum_popup_is_loadable', false, $popup_id ) );
+		$this->assertFalse( apply_filters( 'pum_popup_is_loadable', true, $popup_id + 1 ) );
+	}
+
+	/**
+	 * An authorized preview uses the shared popup builder canvas.
+	 *
+	 * @return void
+	 */
+	public function test_authorized_elementor_preview_uses_builder_canvas_template() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+		$_GET = [
+			'elementor-preview' => (string) $popup_id,
+			'p'                 => (string) $popup_id,
+			'post_type'         => 'popup',
+		];
+
+		$original_query  = $GLOBALS['wp_query'];
+		$popups          = \PopupMaker\plugin()->get_controller( 'Frontend\Popups' );
+		$footer_priority = has_action( 'wp_footer', [ $popups, 'render_popups' ] );
+
+		$GLOBALS['wp_query'] = new WP_Query(
+			[
+				'p'           => $popup_id,
+				'post_type'   => 'popup',
+				'post_status' => 'any',
+			]
+		);
+
+		try {
+			$this->assertTrue( apply_filters( 'popup_maker/is_builder_preview', false ) );
+			$this->assertSame(
+				Popup_Maker::$DIR . 'templates/single-popup.php',
+				apply_filters( 'template_include', 'theme-single.php' )
+			);
+			$this->assertFalse( has_action( 'wp_footer', [ $popups, 'render_popups' ] ) );
+		} finally {
+			$GLOBALS['wp_query'] = $original_query;
+
+			if ( false !== $footer_priority && false === has_action( 'wp_footer', [ $popups, 'render_popups' ] ) ) {
+				add_action( 'wp_footer', [ $popups, 'render_popups' ], $footer_priority );
+			}
+		}
 	}
 
 	/**

--- a/tests/php/tests/Page_Builder_Preview_Test.php
+++ b/tests/php/tests/Page_Builder_Preview_Test.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Shared page-builder preview tests.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Test the shared page-builder preview lifecycle.
+ */
+class Page_Builder_Preview_Test extends WP_UnitTestCase {
+
+	/**
+	 * Multiple documents are finalized once per successful batch.
+	 *
+	 * @return void
+	 */
+	public function test_builder_assets_are_finalized_once_per_batch() {
+		$preview = $this->get_preview_double();
+
+		$preview->mark_assets_pending();
+		$preview->mark_assets_pending();
+		$preview->flush_pending_builder_assets();
+		$preview->flush_pending_builder_assets();
+
+		$this->assertSame( 1, $preview->finalization_count );
+
+		$preview->mark_assets_pending();
+		$preview->flush_pending_builder_assets();
+
+		$this->assertSame( 2, $preview->finalization_count );
+	}
+
+	/**
+	 * A failed finalization remains pending for the next batch boundary.
+	 *
+	 * @return void
+	 */
+	public function test_failed_builder_asset_finalization_is_retried() {
+		$preview                        = $this->get_preview_double();
+		$preview->finalization_succeeds = false;
+
+		$preview->mark_assets_pending();
+		$preview->flush_pending_builder_assets();
+
+		$preview->finalization_succeeds = true;
+		$preview->flush_pending_builder_assets();
+		$preview->flush_pending_builder_assets();
+
+		$this->assertSame( 2, $preview->finalization_count );
+	}
+
+	/**
+	 * Create a builder preview test double.
+	 *
+	 * @return \PopupMaker\Controllers\Compatibility\Builder\Preview
+	 */
+	private function get_preview_double() {
+		return new class( \PopupMaker\plugin() ) extends \PopupMaker\Controllers\Compatibility\Builder\Preview {
+
+			/**
+			 * Number of finalization attempts.
+			 *
+			 * @var int
+			 */
+			public $finalization_count = 0;
+
+			/**
+			 * Whether finalization should succeed.
+			 *
+			 * @var bool
+			 */
+			public $finalization_succeeds = true;
+
+			/**
+			 * Mark builder assets as pending.
+			 *
+			 * @return void
+			 */
+			public function mark_assets_pending() {
+				$this->mark_builder_assets_pending();
+			}
+
+			/**
+			 * Count a builder asset finalization attempt.
+			 *
+			 * @return bool Whether the batch was finalized.
+			 */
+			protected function finalize_builder_assets() {
+				++$this->finalization_count;
+
+				return $this->finalization_succeeds;
+			}
+
+			/**
+			 * This test double does not represent a request.
+			 *
+			 * @return int
+			 */
+			protected function get_popup_id_from_request() {
+				return 0;
+			}
+		};
+	}
+}

--- a/tests/php/tests/Page_Builder_Preview_Test.php
+++ b/tests/php/tests/Page_Builder_Preview_Test.php
@@ -1,12 +1,12 @@
 <?php
 /**
- * Shared page-builder preview tests.
+ * Shared page-builder asset batching tests.
  *
  * @package Popup_Maker
  */
 
 /**
- * Test the shared page-builder preview lifecycle.
+ * Test the shared page-builder asset batching concern.
  */
 class Page_Builder_Preview_Test extends WP_UnitTestCase {
 
@@ -53,10 +53,12 @@ class Page_Builder_Preview_Test extends WP_UnitTestCase {
 	/**
 	 * Create a builder preview test double.
 	 *
-	 * @return \PopupMaker\Controllers\Compatibility\Builder\Preview
+	 * @return \PopupMaker\Plugin\Controller
 	 */
 	private function get_preview_double() {
-		return new class( \PopupMaker\plugin() ) extends \PopupMaker\Controllers\Compatibility\Builder\Preview {
+		return new class( \PopupMaker\plugin() ) extends \PopupMaker\Plugin\Controller {
+
+			use \PopupMaker\Controllers\Compatibility\Builder\Concerns\AssetBatching;
 
 			/**
 			 * Number of finalization attempts.
@@ -71,6 +73,14 @@ class Page_Builder_Preview_Test extends WP_UnitTestCase {
 			 * @var bool
 			 */
 			public $finalization_succeeds = true;
+
+			/**
+			 * This test double does not register WordPress hooks.
+			 *
+			 * @return void
+			 */
+			public function init() {
+			}
 
 			/**
 			 * Mark builder assets as pending.
@@ -90,15 +100,6 @@ class Page_Builder_Preview_Test extends WP_UnitTestCase {
 				++$this->finalization_count;
 
 				return $this->finalization_succeeds;
-			}
-
-			/**
-			 * This test double does not represent a request.
-			 *
-			 * @return int
-			 */
-			protected function get_popup_id_from_request() {
-				return 0;
 			}
 		};
 	}

--- a/tests/php/tests/Previews_Test.php
+++ b/tests/php/tests/Previews_Test.php
@@ -95,4 +95,37 @@ class Previews_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( $previews->get_popup_preview() );
 	}
+
+	/**
+	 * Builder previews do not register the popup's live triggers.
+	 *
+	 * @return void
+	 */
+	public function test_builder_preview_strips_live_triggers() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+		$_GET = [
+			'elementor-preview' => (string) $popup_id,
+			'p'                 => (string) $popup_id,
+			'post_type'         => 'popup',
+		];
+
+		$triggers  = [ [ 'type' => 'auto_open' ] ];
+		$data_attr = apply_filters( 'pum_popup_data_attr', [ 'triggers' => $triggers ], $popup_id );
+		$settings  = apply_filters(
+			'pum_popup_get_public_settings',
+			[ 'triggers' => $triggers ],
+			pum_get_popup( $popup_id )
+		);
+
+		$this->assertSame( [], $data_attr['triggers'] );
+		$this->assertSame( [], $settings['triggers'] );
+	}
 }

--- a/tests/php/tests/Previews_Test.php
+++ b/tests/php/tests/Previews_Test.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Popup preview controller tests.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Test core editor preview behavior after the controller migration.
+ */
+class Previews_Test extends WP_UnitTestCase {
+
+	/**
+	 * Original query parameters.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private $original_get;
+
+	/**
+	 * Preserve query parameters before each test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test fixture preserves request globals.
+		$this->original_get = $_GET;
+	}
+
+	/**
+	 * Restore global state after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		$_GET = $this->original_get;
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The modern controller owns the preview hooks.
+	 *
+	 * @return void
+	 */
+	public function test_modern_controller_owns_preview_hooks() {
+		$previews = \PopupMaker\plugin()->get_controller( 'Previews' );
+
+		$this->assertInstanceOf( \PopupMaker\Controllers\Previews::class, $previews );
+		$this->assertNotFalse( has_filter( 'pum_popup_is_loadable', [ $previews, 'is_loadable' ] ) );
+		$this->assertFalse( has_filter( 'pum_popup_is_loadable', [ PUM_Previews::class, 'is_loadable' ] ) );
+	}
+
+	/**
+	 * Core editor previews retain their load and debug-trigger behavior.
+	 *
+	 * @return void
+	 */
+	public function test_core_editor_preview_behavior_is_preserved() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+		$_GET = [
+			'popup_preview' => wp_create_nonce( 'popup-preview' ),
+			'popup'         => (string) $popup_id,
+		];
+
+		$settings = apply_filters( 'pum_popup_get_public_settings', [], pum_get_popup( $popup_id ) );
+
+		$this->assertTrue( apply_filters( 'pum_popup_is_loadable', false, $popup_id ) );
+		$this->assertSame( 'admin_debug', $settings['triggers'][0]['type'] );
+	}
+
+	/**
+	 * An unknown popup slug fails safely.
+	 *
+	 * @return void
+	 */
+	public function test_unknown_popup_preview_slug_returns_false() {
+		$_GET = [
+			'popup_preview' => wp_create_nonce( 'popup-preview' ),
+			'popup'         => 'missing-popup',
+		];
+
+		$previews = \PopupMaker\plugin()->get_controller( 'Previews' );
+
+		$this->assertFalse( $previews->get_popup_preview() );
+	}
+}


### PR DESCRIPTION
## Issue

Elementor's editor could not load Popup Maker popup documents directly. The editor shell opened, but its preview iframe returned a 404. Users had to fall back to creating an Elementor template and embedding its shortcode, despite Popup Maker exposing popups as an Elementor-supported post type.

## Root cause

Popup posts are intentionally registered as non-publicly-queryable. WordPress removes the `post_type=popup` query variable from Elementor's front-end preview request before resolving the main query, so the requested popup cannot be found. Once that query is restored, Elementor falls back to the active theme's full single-post template rather than a popup-shaped editing canvas.

## Fix

- Add a reusable page-builder preview controller that handles per-popup authorization, query restoration, target-only asset loading, isolated template selection, and suppression of duplicate footer popups.
- Keep Elementor-specific code limited to recognizing `elementor-preview`, `p`, and `post_type` request parameters.
- Expand `templates/single-popup.php` into a minimal `wp_head()`/`wp_footer()` builder canvas that renders the popup theme, container, optional title, close button, and hooks around the builder-provided `the_content()` output.
- Preserve the template's existing header/footer fallback for the legacy Bricks integration until it adopts the shared preview controller.
- Keep ordinary and unauthorized front-end popup queries non-public.

## Validation

- Browser-tested published and draft popups with WordPress 7.0.2, Elementor 4.1.3, and Popup Maker 1.24.0.
- Confirmed the Elementor iframe contains one correctly identified popup, live editable content, popup theme styles, and no active-theme site shell.
- Confirmed anonymous preview requests still return 404.
- PHPUnit: 14 tests, 33 assertions.
- PHPCS passed for all changed PHP files and the template.
- PHPStan passed for the shared preview and Elementor controllers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed 404 errors when previewing Popup Maker popups in the Elementor editor.
  - Popup previews now render in an isolated canvas without unrelated overlays.
  - Restricted preview access to authenticated users authorized to edit the popup.
  - Invalid, mismatched, logged-out, or unauthorized preview requests are rejected.
  - Improved preview pages to include popup styling, content, controls, and correct positioning.
  - Added reliable popup repositioning during initialization, opening, and window or container resizing.
  - Elementor widgets now reinitialize correctly when preview popups open.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
