### PR TITLE
fix(i18n): make automatic gate repository-aware

### DIFF
--- a/.github/workflows/translate.yml
+++ b/.github/workflows/translate.yml
@@ -74,8 +74,8 @@ jobs:
                   fi
 
                   if [[ "$GITHUB_EVENT_NAME" == "push" || "$DRY_RUN" != "true" ]]; then
-                    OPEN_PR_COUNT=$(gh pr list --state open --head "$AUTOMATION_BRANCH" --json number --jq 'length')
-                    BLOCKER_COUNT=$(gh issue list --state open --label "$BLOCKER_LABEL" --json number --jq 'length')
+                    OPEN_PR_COUNT=$(gh pr list --repo "$GITHUB_REPOSITORY" --state open --head "$AUTOMATION_BRANCH" --json number --jq 'length')
+                    BLOCKER_COUNT=$(gh issue list --repo "$GITHUB_REPOSITORY" --state open --label "$BLOCKER_LABEL" --json number --jq 'length')
 
                     if (( OPEN_PR_COUNT > 0 || BLOCKER_COUNT > 0 )); then
                       if [[ "$GITHUB_EVENT_NAME" == "push" ]]; then

--- a/bin/verify-translation-guardrails.js
+++ b/bin/verify-translation-guardrails.js
@@ -91,6 +91,14 @@ requirePattern(
 	'Automatic translation must honor a persistent blocker issue.'
 );
 requirePattern(
+	/gh pr list --repo "\$GITHUB_REPOSITORY"/,
+	'The checkout-free safety gate must explicitly target its repository.'
+);
+requirePattern(
+	/gh issue list --repo "\$GITHUB_REPOSITORY"/,
+	'The checkout-free blocker gate must explicitly target its repository.'
+);
+requirePattern(
 	/steps\.preflight\.outputs\.within_limits != 'true'/,
 	'Catalog size limits must be enforced before any provider call.'
 );


### PR DESCRIPTION
Fixes the immediate develop-triggered translation safety gate: the gate runs before checkout, so its PR and issue queries now explicitly target the current repository. Adds a static guardrail check for this requirement.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation safety checks by ensuring pull-request and issue lookups are limited to the current repository.
  * Added validation to prevent improperly scoped command usage in translation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->