### PR TITLE
Fix Astra Custom Layout query corruption during popup preload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 **Fixes**
 
 -   Added a compatibility safeguard for Jetpack synced forms that pass object-valued field attributes into string escaping.
+-   Prevented Astra Custom Layouts rendered inside popups from corrupting the pending WordPress main loop.
 
 ## v1.24.0 - 2026-08-03
 

--- a/classes/Controllers/Compatibility.php
+++ b/classes/Controllers/Compatibility.php
@@ -28,6 +28,7 @@ class Compatibility extends Controller {
 	public function init() {
 		$this->container->register_controllers( [
 			'Compatibility\Backcompat\Filters'     => new \PopupMaker\Controllers\Compatibility\Backcompat\Filters( $this->container ),
+			'Compatibility\Builder\Astra'          => new \PopupMaker\Controllers\Compatibility\Builder\Astra( $this->container ),
 			'Compatibility\SEO\Yoast'              => new \PopupMaker\Controllers\Compatibility\SEO\Yoast( $this->container ),
 			'Compatibility\Builder\Divi'           => new \PopupMaker\Controllers\Compatibility\Builder\Divi( $this->container ),
 			'Compatibility\Plugin\ACF'             => new \PopupMaker\Controllers\Compatibility\Plugin\ACF( $this->container ),

--- a/classes/Controllers/Compatibility/Builder/Astra.php
+++ b/classes/Controllers/Compatibility/Builder/Astra.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Astra Builder compatibility controller.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Controllers\Compatibility\Builder;
+
+use PopupMaker\Plugin\Controller;
+use PopupMaker\Utils\QueryGlobals;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Protect the pending main loop while Astra Custom Layouts render in popups.
+ *
+ * Astra Custom Layouts can delegate rendering to a page builder. Some archive
+ * widgets alter the main query when the layout is rendered before the theme's
+ * main loop. Scope query isolation to popup content that actually embeds an
+ * Astra Custom Layout so ordinary popup rendering remains untouched.
+ *
+ * @since 1.25.0
+ */
+class Astra extends Controller {
+
+	/**
+	 * Query snapshots for nested popup content filters.
+	 *
+	 * A false entry means that invocation did not contain an Astra layout.
+	 *
+	 * @var array<int, array<string, mixed>|false>
+	 */
+	private $query_snapshots = [];
+
+	/**
+	 * Initialize compatibility hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_filter( 'pum_popup_content', [ $this, 'capture_query_globals' ], 1, 2 );
+		add_filter( 'pum_popup_content', [ $this, 'restore_query_globals' ], PHP_INT_MAX );
+	}
+
+	/**
+	 * Capture query globals when popup content embeds an Astra Custom Layout.
+	 *
+	 * @param mixed $content  Popup content (passed through unchanged).
+	 * @param mixed $popup_id ID of the popup being rendered.
+	 * @return mixed
+	 */
+	public function capture_query_globals( $content, $popup_id = 0 ) {
+		$should_capture = is_string( $content )
+			&& false !== strpos( $content, '[astra_custom_layout' )
+			&& has_shortcode( $content, 'astra_custom_layout' );
+
+		$this->query_snapshots[] = $should_capture ? QueryGlobals::capture() : false;
+
+		return $content;
+	}
+
+	/**
+	 * Restore query globals after popup content has finished rendering.
+	 *
+	 * @param mixed $content Popup content (passed through unchanged).
+	 * @return mixed
+	 */
+	public function restore_query_globals( $content ) {
+		$snapshot = array_pop( $this->query_snapshots );
+
+		if ( is_array( $snapshot ) ) {
+			QueryGlobals::restore( $snapshot );
+		}
+
+		return $content;
+	}
+}

--- a/classes/Utils/QueryGlobals.php
+++ b/classes/Utils/QueryGlobals.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * WordPress query globals utility.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Utils;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Capture and restore WordPress query and loop globals.
+ *
+ * Builders that render a secondary template may alter the pending main query.
+ * Compatibility controllers can use this utility to isolate only the affected
+ * rendering paths.
+ */
+class QueryGlobals {
+
+	/**
+	 * WordPress globals involved in query and loop state.
+	 *
+	 * @var string[]
+	 */
+	private static $global_names = [
+		'wp_query',
+		'wp_the_query',
+		'post',
+		'id',
+		'authordata',
+		'currentday',
+		'currentmonth',
+		'page',
+		'pages',
+		'multipage',
+		'more',
+		'numpages',
+	];
+
+	/**
+	 * Capture the current WordPress query and loop globals.
+	 *
+	 * @return array{
+	 *     globals: array<string, array{exists: bool, value: mixed}>,
+	 *     queries: array<int, array{query: object, state: array<string, mixed>}>
+	 * }
+	 */
+	public static function capture() {
+		$global_state = [];
+		$query_state  = [];
+
+		foreach ( self::$global_names as $global_name ) {
+			$exists = array_key_exists( $global_name, $GLOBALS );
+			$value  = $exists ? $GLOBALS[ $global_name ] : null;
+
+			$global_state[ $global_name ] = [
+				'exists' => $exists,
+				'value'  => $value,
+			];
+
+			if ( in_array( $global_name, [ 'wp_query', 'wp_the_query' ], true ) && is_object( $value ) ) {
+				$object_id = spl_object_id( $value );
+
+				if ( ! isset( $query_state[ $object_id ] ) ) {
+					$query_state[ $object_id ] = [
+						'query' => $value,
+						'state' => self::snapshot_query( $value ),
+					];
+				}
+			}
+		}
+
+		return [
+			'globals' => $global_state,
+			'queries' => $query_state,
+		];
+	}
+
+	/**
+	 * Restore a previously captured WordPress query and loop state.
+	 *
+	 * @param array{globals: array<string, array{exists: bool, value: mixed}>, queries: array<int, array{query: object, state: array<string, mixed>}>} $snapshot Query global snapshot.
+	 * @return void
+	 */
+	public static function restore( $snapshot ) {
+		foreach ( $snapshot['queries'] as $query_state ) {
+			self::restore_query( $query_state['query'], $query_state['state'] );
+		}
+
+		foreach ( $snapshot['globals'] as $global_name => $global_state ) {
+			if ( $global_state['exists'] ) {
+				$GLOBALS[ $global_name ] = $global_state['value'];
+			} else {
+				unset( $GLOBALS[ $global_name ] );
+			}
+		}
+	}
+
+	/**
+	 * Snapshot a query's public state without retaining referenced arrays.
+	 *
+	 * @param object $query Query to snapshot.
+	 * @return array<string, mixed>
+	 */
+	private static function snapshot_query( $query ) {
+		$state = [];
+
+		foreach ( get_object_vars( $query ) as $property => $value ) {
+			$state[ $property ] = is_array( $value ) ? self::copy_array( $value ) : $value;
+		}
+
+		return $state;
+	}
+
+	/**
+	 * Copy an array without retaining element references.
+	 *
+	 * @param array<mixed> $values Values to copy.
+	 * @return array<mixed>
+	 */
+	private static function copy_array( $values ) {
+		$copy = [];
+
+		foreach ( $values as $key => $value ) {
+			$copy[ $key ] = is_array( $value ) ? self::copy_array( $value ) : $value;
+		}
+
+		return $copy;
+	}
+
+	/**
+	 * Restore a query's public properties from a snapshot.
+	 *
+	 * @param object               $query Query to restore.
+	 * @param array<string, mixed> $state Original query state.
+	 * @return void
+	 */
+	private static function restore_query( $query, $state ) {
+		foreach ( get_object_vars( $query ) as $property => $value ) {
+			if ( ! array_key_exists( $property, $state ) ) {
+				unset( $query->{$property} );
+			}
+		}
+
+		foreach ( $state as $property => $value ) {
+			unset( $query->{$property} );
+			$query->{$property} = $value;
+		}
+	}
+}

--- a/tests/php/tests/Astra_Compatibility_Test.php
+++ b/tests/php/tests/Astra_Compatibility_Test.php
@@ -47,6 +47,13 @@ class Astra_Compatibility_Test extends WP_UnitTestCase {
 
 		$this->controller = new Astra( new stdClass() );
 		$this->controller->init();
+
+		add_shortcode(
+			'astra_custom_layout',
+			function () {
+				return 'Astra Custom Layout';
+			}
+		);
 	}
 
 	/**
@@ -61,6 +68,8 @@ class Astra_Compatibility_Test extends WP_UnitTestCase {
 		if ( $this->content_filter ) {
 			remove_filter( 'pum_popup_content', $this->content_filter, 11 );
 		}
+
+		remove_shortcode( 'astra_custom_layout' );
 
 		foreach ( $this->global_state as $global_name => $value ) {
 			$GLOBALS[ $global_name ] = $value;
@@ -81,7 +90,7 @@ class Astra_Compatibility_Test extends WP_UnitTestCase {
 
 		$content = apply_filters( 'pum_popup_content', '[astra_custom_layout id="123"]', 456 );
 
-		$this->assertStringContainsString( 'astra_custom_layout', $content );
+		$this->assertStringContainsString( 'Astra Custom Layout', $content );
 		$this->assertSame( $query, $GLOBALS['wp_query'] );
 		$this->assertSame( $query, $GLOBALS['wp_the_query'] );
 		$this->assertSame( $original_posts, $query->posts );

--- a/tests/php/tests/Astra_Compatibility_Test.php
+++ b/tests/php/tests/Astra_Compatibility_Test.php
@@ -81,7 +81,7 @@ class Astra_Compatibility_Test extends WP_UnitTestCase {
 
 		$content = apply_filters( 'pum_popup_content', '[astra_custom_layout id="123"]', 456 );
 
-		$this->assertSame( '[astra_custom_layout id="123"]', $content );
+		$this->assertStringContainsString( 'astra_custom_layout', $content );
 		$this->assertSame( $query, $GLOBALS['wp_query'] );
 		$this->assertSame( $query, $GLOBALS['wp_the_query'] );
 		$this->assertSame( $original_posts, $query->posts );

--- a/tests/php/tests/Astra_Compatibility_Test.php
+++ b/tests/php/tests/Astra_Compatibility_Test.php
@@ -1,0 +1,151 @@
+<?php
+/**
+ * Astra compatibility controller tests.
+ *
+ * @package Popup_Maker
+ */
+
+use PopupMaker\Controllers\Compatibility\Builder\Astra;
+
+/**
+ * Test Astra Custom Layout rendering compatibility.
+ */
+class Astra_Compatibility_Test extends WP_UnitTestCase {
+
+	/**
+	 * Controller under test.
+	 *
+	 * @var Astra
+	 */
+	private $controller;
+
+	/**
+	 * Preserve globals changed by the test fixture.
+	 *
+	 * @var array<string, mixed>
+	 */
+	private $global_state = [];
+
+	/**
+	 * Temporary popup content filter.
+	 *
+	 * @var callable|null
+	 */
+	private $content_filter;
+
+	/**
+	 * Set up test fixtures.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		foreach ( [ 'wp_query', 'wp_the_query', 'post' ] as $global_name ) {
+			$this->global_state[ $global_name ] = $GLOBALS[ $global_name ] ?? null;
+		}
+
+		$this->controller = new Astra( new stdClass() );
+		$this->controller->init();
+	}
+
+	/**
+	 * Restore test hooks and globals.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		remove_filter( 'pum_popup_content', [ $this->controller, 'capture_query_globals' ], 1 );
+		remove_filter( 'pum_popup_content', [ $this->controller, 'restore_query_globals' ], PHP_INT_MAX );
+
+		if ( $this->content_filter ) {
+			remove_filter( 'pum_popup_content', $this->content_filter, 11 );
+		}
+
+		foreach ( $this->global_state as $global_name => $value ) {
+			$GLOBALS[ $global_name ] = $value;
+		}
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Astra Custom Layout rendering must not mutate the pending main query.
+	 */
+	public function test_astra_custom_layout_preserves_main_query_and_post_globals() {
+		$query          = $this->set_main_query_fixture();
+		$original_posts = $query->posts;
+		$original_post  = $GLOBALS['post'];
+
+		$this->add_query_mutation_filter( $query );
+
+		$content = apply_filters( 'pum_popup_content', '[astra_custom_layout id="123"]', 456 );
+
+		$this->assertSame( '[astra_custom_layout id="123"]', $content );
+		$this->assertSame( $query, $GLOBALS['wp_query'] );
+		$this->assertSame( $query, $GLOBALS['wp_the_query'] );
+		$this->assertSame( $original_posts, $query->posts );
+		$this->assertSame( -1, $query->current_post );
+		$this->assertFalse( $query->in_the_loop );
+		$this->assertSame( $original_post, $GLOBALS['post'] );
+	}
+
+	/**
+	 * Ordinary popup content must not invoke the query isolation helper.
+	 */
+	public function test_ordinary_popup_content_is_not_isolated() {
+		$query = $this->set_main_query_fixture();
+
+		$this->add_query_mutation_filter( $query );
+
+		apply_filters( 'pum_popup_content', 'Ordinary popup content', 456 );
+
+		$this->assertSame( [ $query->post->ID ], $query->posts );
+		$this->assertSame( 1, $query->current_post );
+		$this->assertTrue( $query->in_the_loop );
+		$this->assertSame( $query->post, $GLOBALS['post'] );
+	}
+
+	/**
+	 * Create a main query fixture with two posts.
+	 *
+	 * @return WP_Query
+	 */
+	private function set_main_query_fixture() {
+		$post_ids = self::factory()->post->create_many( 2 );
+		$query    = new WP_Query(
+			[
+				'post__in'       => $post_ids,
+				'orderby'        => 'post__in',
+				'posts_per_page' => 2,
+			]
+		);
+
+		$GLOBALS['wp_query']     = $query;
+		$GLOBALS['wp_the_query'] = $query;
+		$GLOBALS['post']         = $query->posts[0];
+
+		return $query;
+	}
+
+	/**
+	 * Add a builder-like filter that mutates the main query.
+	 *
+	 * @param WP_Query $query Query fixture.
+	 * @return void
+	 */
+	private function add_query_mutation_filter( $query ) {
+		$this->content_filter = function ( $content ) use ( $query ) {
+			$rendered_post       = $query->posts[1];
+			$query->posts        = [ $rendered_post->ID ];
+			$query->current_post = 1;
+			$query->post         = $rendered_post;
+			$query->in_the_loop  = true;
+			$GLOBALS['post']     = $rendered_post;
+
+			return $content;
+		};
+
+		add_filter( 'pum_popup_content', $this->content_filter, 11 );
+	}
+}


### PR DESCRIPTION
## Summary

- add a reusable query-global snapshot/restore utility for builder compatibility cases
- add an Astra compatibility controller that isolates query state only when popup content contains an `astra_custom_layout` shortcode
- add regression coverage proving Astra layouts are isolated while ordinary popup content remains untouched

## Root cause

Popup Maker preloads popup content before the theme renders its main loop so third-party builders can discover their assets. When an Astra Custom Layout delegates rendering to Elementor Pro's WooCommerce archive-products widget, the widget changes the pending main query's `posts` from `WP_Post` objects to IDs. Astra then receives that corrupted query when it renders the page's main product loop.

The safeguard is intentionally not applied to every popup. The Astra compatibility controller brackets only popup-content filter passes that actually contain an Astra Custom Layout, and delegates the reusable state handling to `QueryGlobals`.

Reported in: https://wordpress.org/support/topic/popup-maker-affecting-woocommerce/

## Validation

- `vendor/bin/phpcs --standard=.phpcs.xml.dist CHANGELOG.md classes/Controllers/Compatibility.php classes/Controllers/Compatibility/Builder/Astra.php classes/Utils/QueryGlobals.php tests/php/tests/Astra_Compatibility_Test.php`
- `vendor/bin/phpstan analyse classes/Controllers/Compatibility.php classes/Controllers/Compatibility/Builder/Astra.php classes/Utils/QueryGlobals.php --memory-limit=2048M --no-progress`
- isolated WordPress Playground reproduction with WordPress 7.0.2, Astra 4.13.4, WooCommerce 10.9.1, Elementor 4.0.7, and Elementor Pro 3.32.1; confirmed the query becomes IDs inside the nested template and is restored to `WP_Post` objects before Astra's main loop

The PHPUnit regression test is included, but the local PHPUnit runner could not execute because the WordPress PHPUnit test library is not installed in this checkout.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where Astra Custom Layouts rendered in popups could corrupt the WordPress main loop.
  * Preserved page and post context while rendering Astra Custom Layout popup content.
  * Ensured standard popup content continues to render normally, without unnecessary query isolation.
  * Improved compatibility when multiple popup layouts are rendered in sequence or nested.

* **Documentation**
  * Added a changelog entry describing the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->