### PR TITLE
Make changelog release notes user-facing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,16 @@
 
 **Improvements**
 
--   Improved PHP 8.3, 8.4, and 8.5 compatibility by safely handling extension-added post and metadata fields without deprecated dynamic properties, with expanded automated and release-package runtime coverage through PHP 8.5.
+-   Improved compatibility with PHP 8.3, 8.4, and 8.5.
 
 **Fixes**
 
 -   Added a compatibility safeguard for Jetpack synced forms that pass object-valued field attributes into string escaping.
 -   Prevented Astra Custom Layouts rendered inside popups from corrupting the pending WordPress main loop.
+
+**Developers**
+
+-   Updated extension-added post and metadata field handling to avoid deprecated dynamic properties, and expanded automated and release-package runtime coverage through PHP 8.5.
 
 ## v1.24.0 - 2026-08-03
 

--- a/bin/changelog-utils.js
+++ b/bin/changelog-utils.js
@@ -12,20 +12,31 @@ function stripDeveloperSections( content ) {
 	const lines = content.split( /\r?\n/ );
 	const filteredLines = [];
 	let isDeveloperSection = false;
+	let developerHeadingDepth = 0;
 
 	for ( const line of lines ) {
-		if (
-			/^\s*(?:\*\*Developers\*\*|#{3,6}\s+Developers)\s*$/i.test( line )
-		) {
+		const developerHeading = line.match(
+			/^\s*(?:\*\*Developers\*\*|(#{2,6})\s+Developers)\s*$/i
+		);
+
+		if ( developerHeading ) {
 			isDeveloperSection = true;
+			developerHeadingDepth = developerHeading[ 1 ]
+				? developerHeading[ 1 ].length
+				: 0;
 			continue;
 		}
 
-		if (
-			isDeveloperSection &&
-			/^\s*(?:\*\*[^*]+\*\*|#{2,6}\s+\S)/.test( line )
-		) {
-			isDeveloperSection = false;
+		if ( isDeveloperSection ) {
+			const markdownHeading = line.match( /^\s*(#{2,6})\s+\S/ );
+			const isBoldSectionHeading = /^\s*\*\*[^*]+\*\*\s*$/.test( line );
+			const isPeerMarkdownHeading =
+				markdownHeading &&
+				markdownHeading[ 1 ].length <= ( developerHeadingDepth || 2 );
+
+			if ( isBoldSectionHeading || isPeerMarkdownHeading ) {
+				isDeveloperSection = false;
+			}
 		}
 
 		if ( ! isDeveloperSection ) {

--- a/bin/changelog-utils.js
+++ b/bin/changelog-utils.js
@@ -1,0 +1,42 @@
+/**
+ * Remove developer-only sections from changelog content.
+ *
+ * Developer sections remain in CHANGELOG.md for maintainers, but are omitted
+ * from user-facing release notes and the WordPress.org readme.
+ *
+ * @param {string} content Changelog content.
+ * @return {string} Changelog content without developer-only sections.
+ */
+function stripDeveloperSections( content ) {
+	const newline = content.includes( '\r\n' ) ? '\r\n' : '\n';
+	const lines = content.split( /\r?\n/ );
+	const filteredLines = [];
+	let isDeveloperSection = false;
+
+	for ( const line of lines ) {
+		if (
+			/^\s*(?:\*\*Developers\*\*|#{3,6}\s+Developers)\s*$/i.test( line )
+		) {
+			isDeveloperSection = true;
+			continue;
+		}
+
+		if (
+			isDeveloperSection &&
+			/^\s*(?:\*\*[^*]+\*\*|#{2,6}\s+\S)/.test( line )
+		) {
+			isDeveloperSection = false;
+		}
+
+		if ( ! isDeveloperSection ) {
+			filteredLines.push( line );
+		}
+	}
+
+	return filteredLines
+		.join( newline )
+		.replace( /(?:\r?\n){3,}/g, `${ newline }${ newline }` )
+		.trim();
+}
+
+module.exports = { stripDeveloperSections };

--- a/bin/extract-changelog.js
+++ b/bin/extract-changelog.js
@@ -13,6 +13,7 @@
 
 const fs = require( 'fs' );
 const path = require( 'path' );
+const { stripDeveloperSections } = require( './changelog-utils' );
 
 // Parse command line arguments
 const args = process.argv.slice( 2 );
@@ -80,7 +81,7 @@ function extractVersionContent( content, version ) {
 function extractUnreleasedContent( content ) {
 	// Handles both LF and CRLF line endings
 	const unreleasedPattern =
-		/^## Unreleased\s*([\s\S]*?)(?=\r?\n## |\r?\n?$)/m;
+		/^## Unreleased[^\S\r\n]*\r?\n([\s\S]*?)(?=\r?\n## |$(?![\s\S]))/m;
 	const match = content.match( unreleasedPattern );
 
 	if ( ! match || ! match[ 1 ].trim() ) {
@@ -111,7 +112,7 @@ function extractLatestVersion( content ) {
 
 	// Find first semver version in the search content
 	const versionPattern =
-		/^## (?:v)?(\d+\.\d+\.\d+)(?:\s*-\s*[0-9]{4}-[0-9]{2}-[0-9]{2})?\s*\r?\n([\s\S]*?)(?=\r?\n## |\r?\n?$)/m;
+		/^## (?:v)?(\d+\.\d+\.\d+)(?:\s*-\s*[0-9]{4}-[0-9]{2}-[0-9]{2})?\s*\r?\n([\s\S]*?)(?=\r?\n## |$(?![\s\S]))/m;
 	const matches = searchContent.match( versionPattern );
 
 	if ( ! matches ) {
@@ -138,7 +139,7 @@ function formatForGitHubRelease( content, version ) {
 		return `## ${ version }\n\nNo changelog content available.`;
 	}
 
-	let formatted = content;
+	let formatted = stripDeveloperSections( content );
 
 	// Ensure proper formatting for GitHub markdown
 	formatted = formatted

--- a/bin/extract-changelog.js
+++ b/bin/extract-changelog.js
@@ -141,6 +141,10 @@ function formatForGitHubRelease( content, version ) {
 
 	let formatted = stripDeveloperSections( content );
 
+	if ( ! formatted ) {
+		return `## ${ version }\n\nNo user-facing changes.`;
+	}
+
 	// Ensure proper formatting for GitHub markdown
 	formatted = formatted
 		.replace( /^\s*[-*]\s+/gm, '- ' ) // Normalize bullet points

--- a/bin/update-changelog.js
+++ b/bin/update-changelog.js
@@ -63,7 +63,9 @@ if ( isVerbose ) {
 
 // Use the original formatting for files (preserve structure)
 const formattedFileChanges = unreleasedChangesText;
-const formattedUserChanges = stripDeveloperSections( unreleasedChangesText );
+const formattedUserChanges =
+	stripDeveloperSections( unreleasedChangesText ) ||
+	'-   No user-facing changes.';
 
 // Update CHANGELOG.md with new version using string manipulation
 const beforeUnreleased = changelogContent.substring( 0, unreleasedStart );

--- a/bin/update-changelog.js
+++ b/bin/update-changelog.js
@@ -1,3 +1,5 @@
+/* eslint-disable no-console */
+
 const fs = require( 'fs' );
 const { stripDeveloperSections } = require( './changelog-utils' );
 
@@ -18,7 +20,7 @@ const isVerbose =
 const changelogFilePath = 'CHANGELOG.md';
 const readmeFilePath = 'readme.txt';
 
-let changelogContent = fs.readFileSync( changelogFilePath, 'utf8' );
+const changelogContent = fs.readFileSync( changelogFilePath, 'utf8' );
 
 // Extract unreleased changes using string manipulation for reliability
 const unreleasedStart = changelogContent.indexOf( '## Unreleased' );
@@ -111,3 +113,5 @@ fs.writeFileSync( readmeFilePath, newChangelog.trim(), 'utf8' );
 console.log(
 	`Changelog updated successfully with ${ changeCount } change(s).`
 );
+
+/* eslint-enable no-console */

--- a/bin/update-changelog.js
+++ b/bin/update-changelog.js
@@ -1,4 +1,5 @@
 const fs = require( 'fs' );
+const { stripDeveloperSections } = require( './changelog-utils' );
 
 // Read the current version number from package.json
 const newVersion = process.argv[ 2 ];
@@ -60,6 +61,7 @@ if ( isVerbose ) {
 
 // Use the original formatting for files (preserve structure)
 const formattedFileChanges = unreleasedChangesText;
+const formattedUserChanges = stripDeveloperSections( unreleasedChangesText );
 
 // Update CHANGELOG.md with new version using string manipulation
 const beforeUnreleased = changelogContent.substring( 0, unreleasedStart );
@@ -90,7 +92,7 @@ const usesVPrefix = firstVersionEntry.includes( '= v' );
 const versionPrefix = usesVPrefix ? 'v' : '';
 
 // Create the new version entry
-const newVersionEntry = `= ${ versionPrefix }${ newVersion } - ${ releaseDate } =\n\n${ formattedFileChanges }\n\n`;
+const newVersionEntry = `= ${ versionPrefix }${ newVersion } - ${ releaseDate } =\n\n${ formattedUserChanges }\n\n`;
 
 // Insert the new version entry before the first existing version
 const newChangelog = readmeContent.replace(

--- a/tests/unit/bin/changelog-release-output.test.js
+++ b/tests/unit/bin/changelog-release-output.test.js
@@ -60,6 +60,31 @@ describe( 'user-facing changelog release output', () => {
 		expect( output ).not.toContain( 'Added PHP runtime coverage.' );
 	} );
 
+	test( 'returns a user-facing placeholder when only developer notes exist', () => {
+		fs.writeFileSync(
+			path.join( temporaryRoot, 'CHANGELOG.md' ),
+			`# Popup Maker Changelog
+
+## Unreleased
+
+**Developers**
+
+-   Added PHP runtime coverage.
+
+## v1.0.0 - 2026-01-01
+`
+		);
+
+		const output = execFileSync(
+			process.execPath,
+			[ extractScript, '--unreleased' ],
+			{ cwd: temporaryRoot, encoding: 'utf8' }
+		);
+
+		expect( output ).toContain( 'No user-facing changes.' );
+		expect( output ).not.toContain( 'Added PHP runtime coverage.' );
+	} );
+
 	test( 'retains developer notes in CHANGELOG.md but omits them from readme.txt', () => {
 		fs.writeFileSync(
 			path.join( temporaryRoot, 'readme.txt' ),
@@ -93,6 +118,48 @@ For the latest updates and release information: https://example.com/changelog
 		expect( updatedReadme ).toContain( 'Improved PHP compatibility.' );
 		expect( updatedReadme ).toContain( 'Fixed popup rendering.' );
 		expect( updatedReadme ).not.toContain( 'Developers' );
+		expect( updatedReadme ).not.toContain( 'Added PHP runtime coverage.' );
+	} );
+
+	test( 'adds a readme placeholder when only developer notes exist', () => {
+		fs.writeFileSync(
+			path.join( temporaryRoot, 'CHANGELOG.md' ),
+			`# Popup Maker Changelog
+
+## Unreleased
+
+**Developers**
+
+-   Added PHP runtime coverage.
+
+## v1.0.0 - 2026-01-01
+`
+		);
+		fs.writeFileSync(
+			path.join( temporaryRoot, 'readme.txt' ),
+			`=== Popup Maker ===
+
+== Changelog ==
+
+For the latest updates and release information: https://example.com/changelog
+
+= v1.0.0 - 2026-01-01 =
+
+**Fixes**
+
+-   Fixed an older issue.`
+		);
+
+		execFileSync( process.execPath, [ updateScript, '1.1.0' ], {
+			cwd: temporaryRoot,
+		} );
+
+		const updatedReadme = fs.readFileSync(
+			path.join( temporaryRoot, 'readme.txt' ),
+			'utf8'
+		);
+
+		expect( updatedReadme ).toContain( 'No user-facing changes.' );
 		expect( updatedReadme ).not.toContain( 'Added PHP runtime coverage.' );
 	} );
 } );

--- a/tests/unit/bin/changelog-release-output.test.js
+++ b/tests/unit/bin/changelog-release-output.test.js
@@ -1,0 +1,98 @@
+const { execFileSync } = require( 'child_process' );
+const fs = require( 'fs' );
+const os = require( 'os' );
+const path = require( 'path' );
+
+const pluginRoot = path.resolve( __dirname, '../../..' );
+const extractScript = path.join( pluginRoot, 'bin/extract-changelog.js' );
+const updateScript = path.join( pluginRoot, 'bin/update-changelog.js' );
+
+const changelog = `# Popup Maker Changelog
+
+## Unreleased
+
+**Improvements**
+
+-   Improved PHP compatibility.
+
+**Developers**
+
+-   Added PHP runtime coverage.
+
+**Fixes**
+
+-   Fixed popup rendering.
+
+## v1.0.0 - 2026-01-01
+
+**Fixes**
+
+-   Fixed an older issue.
+`;
+
+describe( 'user-facing changelog release output', () => {
+	let temporaryRoot;
+
+	beforeEach( () => {
+		temporaryRoot = fs.mkdtempSync(
+			path.join( os.tmpdir(), 'popup-maker-changelog-' )
+		);
+		fs.writeFileSync(
+			path.join( temporaryRoot, 'CHANGELOG.md' ),
+			changelog
+		);
+	} );
+
+	afterEach( () => {
+		fs.rmSync( temporaryRoot, { recursive: true, force: true } );
+	} );
+
+	test( 'excludes developer notes from extracted release notes', () => {
+		const output = execFileSync(
+			process.execPath,
+			[ extractScript, '--unreleased' ],
+			{ cwd: temporaryRoot, encoding: 'utf8' }
+		);
+
+		expect( output ).toContain( 'Improved PHP compatibility.' );
+		expect( output ).toContain( 'Fixed popup rendering.' );
+		expect( output ).not.toContain( 'Developers' );
+		expect( output ).not.toContain( 'Added PHP runtime coverage.' );
+	} );
+
+	test( 'retains developer notes in CHANGELOG.md but omits them from readme.txt', () => {
+		fs.writeFileSync(
+			path.join( temporaryRoot, 'readme.txt' ),
+			`=== Popup Maker ===
+
+== Changelog ==
+
+For the latest updates and release information: https://example.com/changelog
+
+= v1.0.0 - 2026-01-01 =
+
+**Fixes**
+
+-   Fixed an older issue.`
+		);
+
+		execFileSync( process.execPath, [ updateScript, '1.1.0' ], {
+			cwd: temporaryRoot,
+		} );
+
+		const updatedChangelog = fs.readFileSync(
+			path.join( temporaryRoot, 'CHANGELOG.md' ),
+			'utf8'
+		);
+		const updatedReadme = fs.readFileSync(
+			path.join( temporaryRoot, 'readme.txt' ),
+			'utf8'
+		);
+
+		expect( updatedChangelog ).toContain( 'Added PHP runtime coverage.' );
+		expect( updatedReadme ).toContain( 'Improved PHP compatibility.' );
+		expect( updatedReadme ).toContain( 'Fixed popup rendering.' );
+		expect( updatedReadme ).not.toContain( 'Developers' );
+		expect( updatedReadme ).not.toContain( 'Added PHP runtime coverage.' );
+	} );
+} );

--- a/tests/unit/bin/changelog-utils.test.js
+++ b/tests/unit/bin/changelog-utils.test.js
@@ -1,0 +1,47 @@
+const { stripDeveloperSections } = require( '../../../bin/changelog-utils' );
+
+describe( 'changelog utilities', () => {
+	test( 'removes developer sections while preserving user-facing sections', () => {
+		const changelog = `**Improvements**
+
+- Improved PHP compatibility.
+
+**Developers**
+
+- Added PHP 8.5 runtime coverage.
+
+**Fixes**
+
+- Fixed popup rendering.`;
+
+		expect( stripDeveloperSections( changelog ) ).toBe( `**Improvements**
+
+- Improved PHP compatibility.
+
+**Fixes**
+
+- Fixed popup rendering.` );
+	} );
+
+	test( 'removes a trailing developer section', () => {
+		const changelog = `**Fixes**
+
+- Fixed popup rendering.
+
+### Developers
+
+- Added regression coverage.`;
+
+		expect( stripDeveloperSections( changelog ) ).toBe( `**Fixes**
+
+- Fixed popup rendering.` );
+	} );
+
+	test( 'leaves changelog content without developer sections unchanged', () => {
+		const changelog = `**Improvements**
+
+- Improved PHP compatibility.`;
+
+		expect( stripDeveloperSections( changelog ) ).toBe( changelog );
+	} );
+} );

--- a/tests/unit/bin/changelog-utils.test.js
+++ b/tests/unit/bin/changelog-utils.test.js
@@ -23,18 +23,31 @@ describe( 'changelog utilities', () => {
 - Fixed popup rendering.` );
 	} );
 
-	test( 'removes a trailing developer section', () => {
+	test( 'removes nested headings from a developer section', () => {
 		const changelog = `**Fixes**
 
 - Fixed popup rendering.
 
 ### Developers
 
-- Added regression coverage.`;
+#### Runtime coverage
+
+- Added regression coverage.
+
+### Security
+
+- Hardened popup rendering.`;
 
 		expect( stripDeveloperSections( changelog ) ).toBe( `**Fixes**
 
-- Fixed popup rendering.` );
+- Fixed popup rendering.
+
+### Security
+
+- Hardened popup rendering.` );
+		expect( stripDeveloperSections( changelog ) ).not.toContain(
+			'Runtime coverage'
+		);
 	} );
 
 	test( 'leaves changelog content without developer sections unchanged', () => {


### PR DESCRIPTION
## Summary

- simplify the PHP compatibility changelog entry for WordPress users
- retain implementation and test details under a developer-only section
- omit developer sections from generated `readme.txt` entries and GitHub release notes
- keep developer-only releases non-empty with a user-facing placeholder
- fix unreleased/latest changelog extraction so it returns the complete section

Follow-up to #1269.

## Validation

- `jest --config tests/unit/jest.config.js --runInBand tests/unit/bin/changelog-utils.test.js tests/unit/bin/changelog-release-output.test.js` (7 tests passed)
- changed-file JavaScript lint and Prettier checks
- WordPress Plugin Check Delta
- `git diff --check`
- manual `node bin/extract-changelog.js --unreleased` verification
- CodeRabbit completed with no unresolved findings
- Codex P2 finding fixed and its thread resolved; a follow-up Codex pass is currently blocked by account review quota