### PR TITLE
Remove iframe-resizer and render support page locally

### DIFF
--- a/assets/js/src/admin/support-page.scss
+++ b/assets/js/src/admin/support-page.scss
@@ -2,32 +2,84 @@
  * Copyright (c) 2019, Code Atlantic LLC
  ******************************************************************************/
 
-$wpblue: #20252b;
+.pum-support-page {
+	max-width: 1100px;
 
-.popmake-support-links {
-	list-style: none;
-
-	li {
-		margin-bottom: 10px;
+	&__intro {
+		font-size: 16px;
+		margin-bottom: 24px;
 	}
 
-	a {
-		color: $wpblue;
-		font-size: 1.25em;
-		text-decoration: none;
-		text-transform: uppercase;
+	&__resources {
+		display: grid;
+		gap: 16px;
+		grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+	}
 
-		span {
-			margin-left: 10px;
+	&__contact {
+		align-items: center;
+		background: #fff;
+		border-left: 4px solid #2271b1;
+		box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+		display: flex;
+		gap: 24px;
+		justify-content: space-between;
+		margin-top: 24px;
+		padding: 24px;
+
+		h2 {
+			margin-top: 0;
 		}
 
-		img {
-			max-height: 24px;
-			max-width: 24px;
-			min-height: 24px;
-			min-width: 24px;
-			position: relative;
-			top: 6px;
+		p {
+			margin-bottom: 0;
 		}
+	}
+}
+
+.pum-support-card {
+	align-items: flex-start;
+	background: #fff;
+	border: 1px solid #c3c4c7;
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.04);
+	color: #1d2327;
+	display: flex;
+	gap: 16px;
+	padding: 20px;
+	text-decoration: none;
+
+	&:focus,
+	&:hover {
+		border-color: #2271b1;
+		box-shadow: 0 0 0 1px #2271b1;
+		color: #135e96;
+	}
+
+	.dashicons {
+		font-size: 32px;
+		height: 32px;
+		width: 32px;
+	}
+
+	strong,
+	strong + span {
+		display: block;
+	}
+
+	strong {
+		font-size: 16px;
+		margin-bottom: 6px;
+	}
+
+	strong + span {
+		color: #50575e;
+		line-height: 1.5;
+	}
+}
+
+@media screen and (max-width: 782px) {
+	.pum-support-page__contact {
+		align-items: stretch;
+		flex-direction: column;
 	}
 }

--- a/classes/Admin/Assets.php
+++ b/classes/Admin/Assets.php
@@ -100,8 +100,6 @@ class PUM_Admin_Assets {
 		wp_register_script( 'pum-admin-theme-editor', self::$js_url . 'admin-theme-editor.js', [ 'pum-admin-general' ], Popup_Maker::$VER, true );
 		wp_register_script( 'pum-admin-settings-page', self::$js_url . 'admin-settings-page.js', [ 'pum-admin-general' ], Popup_Maker::$VER, true );
 		wp_register_script( 'pum-admin-shortcode-ui', self::$js_url . 'admin-shortcode-ui.js', [ 'pum-admin-general' ], Popup_Maker::$VER, true );
-		wp_register_script( 'iframe-resizer', self::$js_url . 'vendor/iframeResizer.min.js', [ 'jquery' ], '4.3.1', false );
-
 		// @deprecated handle. Currently loads empty file and admin-general as dependency.
 		wp_register_script( 'popup-maker-admin', self::$js_url . 'admin-deprecated.js', [ 'pum-admin-general' ], Popup_Maker::$VER, true );
 		wp_localize_script( 'pum-admin-general', 'pum_admin', $admin_vars );
@@ -125,10 +123,6 @@ class PUM_Admin_Assets {
 
 		if ( pum_is_settings_page() ) {
 			wp_enqueue_script( 'pum-admin-settings-page' );
-		}
-
-		if ( pum_is_support_page() ) {
-			wp_enqueue_script( 'iframe-resizer' );
 		}
 	}
 

--- a/classes/Admin/Support.php
+++ b/classes/Admin/Support.php
@@ -21,52 +21,67 @@ class PUM_Admin_Support {
 	 * Renders the support page contents.
 	 */
 	public static function page() {
+		$resources = [
+			[
+				'icon'        => 'welcome-learn-more',
+				'title'       => __( 'Getting Started', 'popup-maker' ),
+				'description' => __( 'Learn the basics and build your first popup.', 'popup-maker' ),
+				'url'         => 'https://wppopupmaker.com/guides/?utm_source=plugin-support&utm_medium=referral&utm_campaign=guides',
+			],
+			[
+				'icon'        => 'book-alt',
+				'title'       => __( 'Documentation', 'popup-maker' ),
+				'description' => __( 'Browse setup guides, common questions, and advanced documentation.', 'popup-maker' ),
+				'url'         => 'https://wppopupmaker.com/docs/',
+			],
+			[
+				'icon'        => 'groups',
+				'title'       => __( 'Community', 'popup-maker' ),
+				'description' => __( 'Ask questions and share solutions with other Popup Maker users.', 'popup-maker' ),
+				'url'         => 'https://wppopupmaker.com/community/',
+			],
+			[
+				'icon'        => 'admin-plugins',
+				'title'       => __( 'Extensions', 'popup-maker' ),
+				'description' => __( 'Find documentation for Popup Maker extensions.', 'popup-maker' ),
+				'url'         => 'https://wppopupmaker.com/docs/category/extensions/',
+			],
+			[
+				'icon'        => 'editor-code',
+				'title'       => __( 'Developer Wiki', 'popup-maker' ),
+				'description' => __( 'Contribute to or extend Popup Maker.', 'popup-maker' ),
+				'url'         => 'https://github.com/PopupMaker/Popup-Maker/wiki',
+			],
+		];
 		?>
-		<style>
-			.pum-secure-notice {
-				position: fixed;
-				top: 32px;
-				left: 160px;
-				right: 0;
-				background: #ebfdeb;
-				padding: 10px 20px;
-				color: green;
-				z-index: 9999;
-				box-shadow: 0 2px 2px rgba(6, 113, 6, 0.3);
-				opacity: 0.95;
-				filter: alpha(opacity=95);
-			}
+		<div class="wrap pum-support-page">
+			<h1><?php esc_html_e( 'Help & Support', 'popup-maker' ); ?></h1>
+			<p class="pum-support-page__intro">
+				<?php esc_html_e( 'Find answers, connect with the community, or contact the Popup Maker support team.', 'popup-maker' ); ?>
+			</p>
 
-			#pum-support-frame {
-				margin: 40px 0 -65px -20px;
-			}
+			<div class="pum-support-page__resources">
+				<?php foreach ( $resources as $resource ) : ?>
+					<a class="pum-support-card" href="<?php echo esc_url( $resource['url'] ); ?>" target="_blank" rel="noopener noreferrer">
+						<span class="dashicons dashicons-<?php echo esc_attr( $resource['icon'] ); ?>" aria-hidden="true"></span>
+						<span>
+							<strong><?php echo esc_html( $resource['title'] ); ?></strong>
+							<span><?php echo esc_html( $resource['description'] ); ?></span>
+						</span>
+					</a>
+				<?php endforeach; ?>
+			</div>
 
-			#pum-support-frame iframe {
-				width: 100%;
-				border: 0;
-				transition: scroll .5s;
-			}
-		</style>
-		<div class="pum-secure-notice">
-			<i class="dashicons dashicons-lock"></i>
-			<span><?php echo wp_kses( __( '<b>Secure HTTPS contact page</b>, running via iframe from external domain', 'popup-maker' ), [ 'b' => [] ] ); ?> </span>
-			<i class="dashicons dashicons-info" title="https://api.wppopupmaker.com/dashboard-support/"></i>
+			<div class="pum-support-page__contact">
+				<div>
+					<h2><?php esc_html_e( 'Still need help?', 'popup-maker' ); ?></h2>
+					<p><?php esc_html_e( 'Open a support request and include the site URL, Popup Maker version, steps to reproduce, and any relevant error messages.', 'popup-maker' ); ?></p>
+				</div>
+				<a class="button button-primary button-hero" href="<?php echo esc_url( 'https://wppopupmaker.com/support/?utm_source=plugin-support&utm_medium=referral&utm_campaign=plugin-support' ); ?>" target="_blank" rel="noopener noreferrer">
+					<?php esc_html_e( 'Contact Support', 'popup-maker' ); ?>
+				</a>
+			</div>
 		</div>
-		<div id="pum-support-frame" class="wrap">
-			<script type="text/javascript">
-				(function ($) {
-					var frame = $('<iframe scrolling="no">')
-						.css({height: '535px'})
-						.attr('src', 'https://api.wppopupmaker.com/dashboard-support/')
-						.appendTo('#pum-support-frame');
-
-					frame.iFrameResize({
-						checkOrigin: false
-					});
-				})(jQuery);
-			</script>
-		</div>
-
 		<?php
 	}
 }

--- a/classes/Site/Assets.php
+++ b/classes/Site/Assets.php
@@ -186,7 +186,6 @@ class PUM_Site_Assets {
 		self::$scripts_registered = true;
 
 		wp_register_script( 'mobile-detect', self::$js_url . 'vendor/mobile-detect.min.js', null, '1.3.3', true );
-		wp_register_script( 'iframe-resizer', self::$js_url . 'vendor/iframeResizer.min.js', [ 'jquery' ], '4.3.1', false );
 
 		if ( PUM_AssetCache::enabled() && false !== self::$cache_url ) {
 			$cached = get_option( 'pum-has-cached-js' );

--- a/docs/build-processes.md
+++ b/docs/build-processes.md
@@ -20,7 +20,7 @@
 ### **Dependency Management** 📦
 - **Frontend**: NPM workspaces with @popup-maker/* internal packages
 - **Backend**: Composer with Strauss vendor prefixing → `vendor-prefixed/`
-- **External Dependencies**: jQuery, iframe-resizer, mobile-detect
+- **External Dependencies**: jQuery, mobile-detect
 - **WordPress Dependencies**: Managed via custom extraction plugin
 
 ---

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
 		"@popup-maker/registry": "workspace:*",
 		"@popup-maker/use-query-params": "workspace:*",
 		"@popup-maker/utils": "workspace:*",
-		"iframe-resizer": "^4.2.10",
 		"mobile-detect": "^1.4.5"
 	},
 	"devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,9 +88,6 @@ importers:
       '@popup-maker/utils':
         specifier: workspace:*
         version: link:packages/utils
-      iframe-resizer:
-        specifier: ^4.2.10
-        version: 4.4.5
       mobile-detect:
         specifier: ^1.4.5
         version: 1.4.5
@@ -154,10 +151,10 @@ importers:
         version: 34.0.0(@playwright/test@1.62.1)(@types/eslint@9.6.1)(@types/node@26.1.2)(@types/react@18.3.31)(@typescript-eslint/eslint-plugin@6.21.0(@typescript-eslint/parser@6.21.0(eslint@10.8.0)(typescript@5.7.3))(eslint@10.8.0)(typescript@5.7.3))(@typescript-eslint/parser@8.66.0(eslint@10.8.0)(typescript@5.7.3))(@wordpress/env@11.12.0(@types/node@26.1.2))(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.12))(esbuild@0.25.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(stylelint-scss@6.14.0(stylelint@16.26.1(typescript@5.7.3)))(ts-node@10.9.1(@types/node@26.1.2)(typescript@5.7.3))(type-fest@4.41.0)(typescript@5.7.3)(webpack-hot-middleware@2.26.1)
       copy-webpack-plugin:
         specifier: ^14.0.0
-        version: 14.0.0(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4))
+        version: 14.0.0(webpack@5.109.2)
       css-loader:
         specifier: ^7.1.4
-        version: 7.1.4(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4))
+        version: 7.1.4(webpack@5.109.2)
       eslint-plugin-storybook:
         specifier: 10.5.6
         version: 10.5.6(eslint@10.8.0)(storybook@10.5.6(@types/react@18.3.31)(react@18.3.1)(wp-prettier@3.0.3))(typescript@5.7.3)
@@ -199,13 +196,13 @@ importers:
         version: 1.102.0
       sass-loader:
         specifier: ^17.0.0
-        version: 17.0.0(sass@1.102.0)(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4))
+        version: 17.0.0(sass@1.102.0)(webpack@5.109.2)
       storybook:
         specifier: 10.5.6
         version: 10.5.6(@types/react@18.3.31)(react@18.3.1)(wp-prettier@3.0.3)
       style-loader:
         specifier: ^4.0.0
-        version: 4.0.0(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4))
+        version: 4.0.0(webpack@5.109.2)
       typescript:
         specifier: 5.7.3
         version: 5.7.3
@@ -7779,10 +7776,6 @@ packages:
 
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
-
-  iframe-resizer@4.4.5:
-    resolution: {integrity: sha512-U8bCywf/Gh07O69RXo6dXAzTtODQrxaHGHRI7Nt4ipXsuq6EMxVsOP/jjaP43YtXz/ibESS0uSVDN3sOGCzSmw==}
-    engines: {node: '>=0.8.0'}
 
   ignore-walk@4.0.1:
     resolution: {integrity: sha512-rzDQLaW4jQbh2YrOFlJdCtX8qgJTehFRYiUB2r1osqTeDzV/3+Jh8fz1oAPzUThf3iku8Ds4IDqawI5d8mUiQw==}
@@ -15941,18 +15934,18 @@ snapshots:
       '@storybook/core-webpack': 10.5.6(storybook@10.5.6(@types/react@18.3.31)(react@18.3.1)(wp-prettier@3.0.3))
       case-sensitive-paths-webpack-plugin: 2.4.0
       cjs-module-lexer: 1.4.3
-      css-loader: 7.1.4(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4))
+      css-loader: 7.1.4(webpack@5.109.2)
       es-module-lexer: 1.7.0
-      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.7.3)(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4))
-      html-webpack-plugin: 5.6.6(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4))
+      fork-ts-checker-webpack-plugin: 9.1.0(typescript@5.7.3)(webpack@5.109.2)
+      html-webpack-plugin: 5.6.6(webpack@5.109.2)
       magic-string: 0.30.21
       semver: 7.8.5
       storybook: 10.5.6(@types/react@18.3.31)(react@18.3.1)(wp-prettier@3.0.3)
-      style-loader: 4.0.0(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4))
+      style-loader: 4.0.0(webpack@5.109.2)
       terser-webpack-plugin: 5.6.1(cssnano@6.1.2(postcss@8.5.25))(esbuild@0.25.12)(postcss@8.5.25)(webpack@5.109.2)
       ts-dedent: 2.2.0
       webpack: 5.109.2(cssnano@6.1.2(postcss@8.5.25))(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4)
-      webpack-dev-middleware: 6.1.3(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4))
+      webpack-dev-middleware: 6.1.3(webpack@5.109.2)
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
     optionalDependencies:
@@ -15995,7 +15988,7 @@ snapshots:
   '@storybook/preset-react-webpack@10.5.6(esbuild@0.25.12)(postcss@8.5.25)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(storybook@10.5.6(@types/react@18.3.31)(react@18.3.1)(wp-prettier@3.0.3))(typescript@5.7.3)(webpack-cli@5.1.4)':
     dependencies:
       '@storybook/core-webpack': 10.5.6(storybook@10.5.6(@types/react@18.3.31)(react@18.3.1)(wp-prettier@3.0.3))
-      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.7.3)(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4))
+      '@storybook/react-docgen-typescript-plugin': 1.0.6--canary.9.0c3f3b7.0(typescript@5.7.3)(webpack@5.109.2)
       '@types/semver': 7.7.1
       magic-string: 0.30.21
       react: 18.3.1
@@ -16024,7 +16017,7 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.7.3)(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4))':
+  '@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.7.3)(webpack@5.109.2)':
     dependencies:
       debug: 4.4.3
       endent: 2.1.0
@@ -21216,7 +21209,7 @@ snapshots:
       serialize-javascript: 7.0.7
       webpack: 5.109.2(cssnano@6.1.2(postcss@8.5.25))(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4)
 
-  copy-webpack-plugin@14.0.0(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4)):
+  copy-webpack-plugin@14.0.0(webpack@5.109.2):
     dependencies:
       glob-parent: 6.0.2
       normalize-path: 3.0.0
@@ -21302,7 +21295,7 @@ snapshots:
     optionalDependencies:
       webpack: 5.109.2(cssnano@6.1.2(postcss@8.5.25))(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4)
 
-  css-loader@7.1.4(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4)):
+  css-loader@7.1.4(webpack@5.109.2):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.25)
       postcss: 8.5.25
@@ -22496,7 +22489,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.7.3)(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4)):
+  fork-ts-checker-webpack-plugin@9.1.0(typescript@5.7.3)(webpack@5.109.2):
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
@@ -22870,7 +22863,7 @@ snapshots:
 
   html-tags@3.3.1: {}
 
-  html-webpack-plugin@5.6.6(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4)):
+  html-webpack-plugin@5.6.6(webpack@5.109.2):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
@@ -22978,8 +22971,6 @@ snapshots:
       postcss: 8.5.25
 
   ieee754@1.2.1: {}
-
-  iframe-resizer@4.4.5: {}
 
   ignore-walk@4.0.1:
     dependencies:
@@ -25850,7 +25841,7 @@ snapshots:
       sass: 1.102.0
       webpack: 5.109.2(cssnano@6.1.2(postcss@8.5.25))(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4)
 
-  sass-loader@17.0.0(sass@1.102.0)(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4)):
+  sass-loader@17.0.0(sass@1.102.0)(webpack@5.109.2):
     optionalDependencies:
       sass: 1.102.0
       webpack: 5.109.2(cssnano@6.1.2(postcss@8.5.25))(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4)
@@ -26370,7 +26361,7 @@ snapshots:
 
   stubborn-utils@1.0.2: {}
 
-  style-loader@4.0.0(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4)):
+  style-loader@4.0.0(webpack@5.109.2):
     dependencies:
       webpack: 5.109.2(cssnano@6.1.2(postcss@8.5.25))(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4)
 
@@ -27087,7 +27078,7 @@ snapshots:
       webpack-bundle-analyzer: 5.3.1
       webpack-dev-server: 5.2.6(webpack-cli@5.1.4)(webpack@5.109.2)
 
-  webpack-dev-middleware@6.1.3(webpack@5.109.2(esbuild@0.25.12)(postcss@8.5.25)(webpack-cli@5.1.4)):
+  webpack-dev-middleware@6.1.3(webpack@5.109.2):
     dependencies:
       colorette: 2.0.20
       memfs: 3.5.3

--- a/readme.md
+++ b/readme.md
@@ -30,7 +30,6 @@ Then, move on to our [Setting up your local environment](https://github.com/Popu
 -   [SASS](https://sass-lang.com) - The CSS pre-processor we use. We use the SCSS syntax.
 -   [jQuery](https://jquery.com) - A fast, small, and feature-rich JavaScript library
 -   [JSON for JS](https://github.com/douglascrockford/JSON-js) - Creates a JSON property in the global object, if there isn't already one
--   [iFrame Resizer](https://github.com/davidjbradshaw/iframe-resizer) - Force cross domain iframes to size to content
 -   [mobile-detect.js](https://github.com/hgoebl/mobile-detect.js) - Detect the device by comparing patterns against a given User-Agent string
 
 ## Developer Tools

--- a/webpack.old.config.js
+++ b/webpack.old.config.js
@@ -125,10 +125,6 @@ const config = {
 					from: './node_modules/mobile-detect/mobile-detect.min.js',
 					to: path.join( distPath, 'vendor', 'mobile-detect.min.js' ),
 				},
-				{
-					from: './node_modules/iframe-resizer/js/iframeResizer.min.js',
-					to: path.join( distPath, 'vendor', 'iframeResizer.min.js' ),
-				},
 			],
 		} ),
 		// new UnminifiedWebpackPlugin(),


### PR DESCRIPTION
## Summary
- replace the externally hosted Help & Support iframe with a native WordPress admin page
- remove iframe-resizer registration, enqueueing, dependency, lockfile entries, and build copying
- retain direct links to guides, documentation, community, extension docs, developer wiki, and support
- coordinate with PopupMaker/Remote-Content#20, which already removed the extension's legacy dependency

## Why
The previous iframe only displayed a resource page and linked users onward to the support site; it did not submit tickets. Rendering those resources locally removes an unnecessary cross-origin iframe and the iframe-resizer dependency.

## Validation
- frozen pnpm install
- production build
- focused Stylelint for the support page
- PHPCS and PHP syntax checks for changed PHP files
- repository search confirms no iframe-resizer references remain
- 

## Follow-up
A direct ticket form can be added separately once the support system endpoint/authentication contract and diagnostic-data consent requirements are defined.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a redesigned admin support page with localized help content.
  - Added five resource cards linking to helpful support materials.
  - Added a dedicated contact-support call to action.

- **Improvements**
  - Improved support-page layout, readability, and visual hierarchy.
  - Added responsive behavior for smaller screens.
  - Added clearer hover and keyboard-focus states for support links.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->