### PR TITLE
Add Brizy popup builder support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Features**
 
+-   Added complete Brizy support for building Popup Maker popups, including visual editing, frontend styling, and interactive elements.
 -   Added complete Elementor support for building Popup Maker popups, including editor previews, frontend styling, and interactive widgets.
 -   Added complete SiteOrigin Page Builder support for building Popup Maker popups, including its Live Editor and properly styled frontend layouts.
 

--- a/classes/Builders/Brizy.php
+++ b/classes/Builders/Brizy.php
@@ -72,8 +72,6 @@ class Brizy extends PageBuilder {
 	 * @return void
 	 */
 	public function remember_saved_document( $post_id, $post = null, $update = false ) {
-		unset( $post, $update );
-
 		$save_action = $this->get_save_action();
 
 		if ( ! is_numeric( $post_id ) || ! $save_action ) {
@@ -114,8 +112,6 @@ class Brizy extends PageBuilder {
 
 			return is_string( $save_action ) ? sanitize_key( $save_action ) : '';
 		} catch ( \Throwable $error ) {
-			unset( $error );
-
 			return '';
 		}
 	}
@@ -209,8 +205,6 @@ class Brizy extends PageBuilder {
 		try {
 			return (bool) \Brizy_Editor_Entity::isBrizyEnabled( absint( $popup_id ) );
 		} catch ( \Throwable $error ) {
-			unset( $error );
-
 			return false;
 		}
 	}
@@ -252,8 +246,6 @@ class Brizy extends PageBuilder {
 
 			return is_string( $content ) ? \PUM_Utils_Shortcodes::clean_do_shortcode( $content ) : null;
 		} catch ( \Throwable $error ) {
-			unset( $error );
-
 			return null;
 		}
 	}
@@ -301,7 +293,8 @@ class Brizy extends PageBuilder {
 			$this->collected_documents[ $popup_id ] = true;
 			$this->assets_finalized                 = false;
 		} catch ( \Throwable $error ) {
-			unset( $error );
+			// Preserve the popup content fallback when Brizy cannot collect assets.
+			return;
 		}
 	}
 
@@ -331,8 +324,6 @@ class Brizy extends PageBuilder {
 		try {
 			$manager = \Brizy_Public_AssetEnqueueManager::_init();
 		} catch ( \Throwable $error ) {
-			unset( $error );
-
 			return false;
 		}
 
@@ -355,8 +346,6 @@ class Brizy extends PageBuilder {
 			$manager->enqueueStyles();
 			$manager->enqueueScripts();
 		} catch ( \Throwable $error ) {
-			unset( $error );
-
 			return false;
 		}
 
@@ -403,8 +392,6 @@ class Brizy extends PageBuilder {
 			$manager->insertHeadCodeAssets();
 			$output = ob_get_clean();
 		} catch ( \Throwable $error ) {
-			unset( $error );
-
 			while ( ob_get_level() > $buffer_level ) {
 				ob_end_clean();
 			}

--- a/classes/Builders/Brizy.php
+++ b/classes/Builders/Brizy.php
@@ -34,6 +34,13 @@ class Brizy extends PageBuilder {
 	private $assets_finalized = false;
 
 	/**
+	 * Style queue before Brizy collects the current late document batch.
+	 *
+	 * @var string[]|null
+	 */
+	private $style_queue_before_collection;
+
+	/**
 	 * Whether Brizy's editor API is available.
 	 *
 	 * @return bool
@@ -223,6 +230,14 @@ class Brizy extends PageBuilder {
 				return;
 			}
 
+			if ( null === $this->style_queue_before_collection || $this->assets_finalized ) {
+				global $wp_styles;
+
+				$this->style_queue_before_collection = $wp_styles instanceof \WP_Styles
+					? (array) $wp_styles->queue
+					: [];
+			}
+
 			$manager->enqueuePost( $post );
 			$this->collected_documents[ $popup_id ] = true;
 			$this->assets_finalized                 = false;
@@ -268,7 +283,9 @@ class Brizy extends PageBuilder {
 
 		global $wp_styles;
 
-		$before           = $wp_styles instanceof \WP_Styles ? (array) $wp_styles->queue : [];
+		$before           = is_array( $this->style_queue_before_collection )
+			? $this->style_queue_before_collection
+			: ( $wp_styles instanceof \WP_Styles ? (array) $wp_styles->queue : [] );
 		$head_code_before = $this->capture_head_code_assets( $manager );
 
 		try {
@@ -302,7 +319,8 @@ class Brizy extends PageBuilder {
 			echo $head_code_after;
 		}
 
-		$this->assets_finalized = true;
+		$this->style_queue_before_collection = null;
+		$this->assets_finalized              = true;
 
 		return true;
 	}

--- a/classes/Builders/Brizy.php
+++ b/classes/Builders/Brizy.php
@@ -58,7 +58,66 @@ class Brizy extends PageBuilder {
 	 */
 	public function register_hooks() {
 		add_filter( 'brizy_supported_post_types', [ $this, 'add_popup_post_type' ] );
+		add_action( 'save_post_popup', [ $this, 'remember_saved_document' ], PHP_INT_MAX, 3 );
 		add_action( 'wp_enqueue_scripts', [ $this, 'add_canvas_styles' ], 12 );
+	}
+
+	/**
+	 * Remember Brizy after its authenticated editor save reaches WordPress.
+	 *
+	 * @param mixed $post_id Saved post ID.
+	 * @param mixed $post    Saved post object.
+	 * @param mixed $update  Whether this was an update.
+	 *
+	 * @return void
+	 */
+	public function remember_saved_document( $post_id, $post = null, $update = false ) {
+		unset( $post, $update );
+
+		$save_action = $this->get_save_action();
+
+		if ( ! is_numeric( $post_id ) || ! $save_action ) {
+			return;
+		}
+
+		// Brizy verifies these values before its save reaches this core hook.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if (
+			! isset( $_REQUEST['action'], $_REQUEST['post'], $_REQUEST['hash'] ) ||
+			! is_scalar( $_REQUEST['action'] ) ||
+			! is_scalar( $_REQUEST['post'] ) ||
+			! is_scalar( $_REQUEST['hash'] ) ||
+			sanitize_key( wp_unslash( $_REQUEST['action'] ) ) !== sanitize_key( $save_action ) ||
+			absint( wp_unslash( $_REQUEST['post'] ) ) !== absint( $post_id ) ||
+			! wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['hash'] ) ), 'brizy-api' ) ||
+			! $this->owns_document( absint( $post_id ) )
+		) {
+			return;
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		$this->remember_document_owner( absint( $post_id ) );
+	}
+
+	/**
+	 * Get Brizy's possibly white-labeled save action.
+	 *
+	 * @return string
+	 */
+	protected function get_save_action() {
+		if ( ! class_exists( '\\Brizy_Editor' ) || ! method_exists( '\\Brizy_Editor', 'prefix' ) ) {
+			return '';
+		}
+
+		try {
+			$save_action = \Brizy_Editor::prefix( '_update_item' );
+
+			return is_string( $save_action ) ? sanitize_key( $save_action ) : '';
+		} catch ( \Throwable $error ) {
+			unset( $error );
+
+			return '';
+		}
 	}
 
 	/**

--- a/classes/Builders/Brizy.php
+++ b/classes/Builders/Brizy.php
@@ -244,7 +244,7 @@ class Brizy extends PageBuilder {
 
 			$content = $renderer->insert_page_content( 'brz-root__container' );
 
-			return is_string( $content ) ? \PUM_Utils_Shortcodes::clean_do_shortcode( $content ) : null;
+			return is_string( $content ) ? $content : null;
 		} catch ( \Throwable $error ) {
 			return null;
 		}

--- a/classes/Builders/Brizy.php
+++ b/classes/Builders/Brizy.php
@@ -68,7 +68,7 @@ class Brizy extends PageBuilder {
 		}
 
 		wp_add_inline_style(
-			'pum-builder-preview',
+			'popup-maker-builder-preview',
 			'body.pum-builder-preview.brz-ed .pum-container .brz-ed-wrap-block-wrap--first{height:auto!important;}'
 		);
 	}

--- a/classes/Builders/Brizy.php
+++ b/classes/Builders/Brizy.php
@@ -1,0 +1,340 @@
+<?php
+/**
+ * Brizy builder provider.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Builders;
+
+use PopupMaker\Base\PageBuilder;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Integrates Brizy editing, visitor rendering, and secondary assets.
+ *
+ * @since 1.25.0
+ */
+class Brizy extends PageBuilder {
+
+	/**
+	 * Popup documents already given to Brizy's asset manager.
+	 *
+	 * @var array<int,bool>
+	 */
+	private $collected_documents = [];
+
+	/**
+	 * Whether the current asset batch has been emitted.
+	 *
+	 * @var bool
+	 */
+	private $assets_finalized = false;
+
+	/**
+	 * Whether Brizy's editor API is available.
+	 *
+	 * @return bool
+	 */
+	public function is_available() {
+		return defined( 'BRIZY_VERSION' ) &&
+			class_exists( '\Brizy_Editor' ) &&
+			method_exists( '\Brizy_Editor', 'get' );
+	}
+
+	/**
+	 * Opt popups into Brizy's supported post types for this request.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_filter( 'brizy_supported_post_types', [ $this, 'add_popup_post_type' ] );
+		add_action( 'wp_enqueue_scripts', [ $this, 'add_canvas_styles' ], 12 );
+	}
+
+	/**
+	 * Let Brizy's first editable block size itself inside the popup.
+	 *
+	 * Brizy otherwise forces its first block to the full viewport height, which
+	 * makes an auto-height popup ignore its own content size.
+	 *
+	 * @return void
+	 */
+	public function add_canvas_styles() {
+		if ( ! $this->is_canvas_request() ) {
+			return;
+		}
+
+		wp_add_inline_style(
+			'pum-builder-preview',
+			'body.pum-builder-preview.brz-ed .pum-container .brz-ed-wrap-block-wrap--first{height:auto!important;}'
+		);
+	}
+
+	/**
+	 * Add popups to Brizy's runtime post type list.
+	 *
+	 * @param mixed $post_types Supported post types.
+	 *
+	 * @return mixed
+	 */
+	public function add_popup_post_type( $post_types ) {
+		if ( ! is_array( $post_types ) ) {
+			return $post_types;
+		}
+
+		if ( ! in_array( 'popup', $post_types, true ) ) {
+			$post_types[] = 'popup';
+		}
+
+		return $post_types;
+	}
+
+	/**
+	 * Get the popup ID requested by Brizy's editor shell or iframe.
+	 *
+	 * @return int
+	 */
+	public function get_requested_popup_id() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Capability checked by the coordinator.
+		$is_shell  = isset( $_GET['action'] ) && is_scalar( $_GET['action'] ) && 'in-front-editor' === sanitize_key( wp_unslash( $_GET['action'] ) );
+		$is_iframe = isset( $_GET['is-editor-iframe'] );
+
+		if ( ! $is_shell && ! $is_iframe ) {
+			return 0;
+		}
+
+		if ( ! isset( $_GET['post'] ) || ! is_scalar( $_GET['post'] ) ) {
+			return 0;
+		}
+
+		return absint( wp_unslash( $_GET['post'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * Whether Brizy is rendering its editable iframe.
+	 *
+	 * The wp-admin shell keeps Brizy's template. Its iframe renders through the
+	 * isolated popup canvas so the editable root retains the popup theme, size,
+	 * and position around it.
+	 *
+	 * @return bool
+	 */
+	public function is_canvas_request() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Capability checked by the coordinator.
+		return isset( $_GET['is-editor-iframe'] );
+	}
+
+	/**
+	 * Whether a popup is built with Brizy.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return bool
+	 */
+	public function owns_document( $popup_id ) {
+		if ( ! class_exists( '\Brizy_Editor_Entity' ) || ! method_exists( '\Brizy_Editor_Entity', 'isBrizyEnabled' ) ) {
+			return false;
+		}
+
+		try {
+			return (bool) \Brizy_Editor_Entity::isBrizyEnabled( absint( $popup_id ) );
+		} catch ( \Throwable $error ) {
+			unset( $error );
+
+			return false;
+		}
+	}
+
+	/**
+	 * Render Brizy's compiled popup document for visitors.
+	 *
+	 * @param int  $popup_id         Popup ID.
+	 * @param bool $is_editor_canvas Whether this is the native editor canvas.
+	 *
+	 * @return string|null
+	 */
+	public function render_document( $popup_id, $is_editor_canvas = false ) {
+		if ( $is_editor_canvas ) {
+			return '<div id="brz-ed-root"></div><div id="brz-popups"></div>';
+		}
+
+		if (
+			! class_exists( '\Brizy_Editor_Post' ) ||
+			! method_exists( '\Brizy_Editor_Post', 'get' ) ||
+			! class_exists( '\Brizy_Public_Main' ) ||
+			! method_exists( '\Brizy_Public_Main', 'get' )
+		) {
+			return null;
+		}
+
+		$this->collect_document_assets( $popup_id );
+		$this->finalize_document_assets( did_action( 'wp_head' ) && ! doing_action( 'wp_head' ) );
+
+		try {
+			$post     = \Brizy_Editor_Post::get( absint( $popup_id ) );
+			$renderer = is_object( $post ) ? \Brizy_Public_Main::get( $post ) : null;
+
+			if ( ! is_object( $renderer ) || ! method_exists( $renderer, 'insert_page_content' ) ) {
+				return null;
+			}
+
+			$content = $renderer->insert_page_content( 'brz-root__container' );
+
+			return is_string( $content ) ? \PUM_Utils_Shortcodes::clean_do_shortcode( $content ) : null;
+		} catch ( \Throwable $error ) {
+			unset( $error );
+
+			return null;
+		}
+	}
+
+	/**
+	 * Give Brizy one secondary popup document to enqueue.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return void
+	 */
+	public function collect_document_assets( $popup_id ) {
+		$popup_id = absint( $popup_id );
+
+		if ( ! $popup_id || isset( $this->collected_documents[ $popup_id ] ) ) {
+			return;
+		}
+
+		if (
+			! class_exists( '\Brizy_Editor_Post' ) ||
+			! method_exists( '\Brizy_Editor_Post', 'get' ) ||
+			! class_exists( '\Brizy_Public_AssetEnqueueManager' ) ||
+			! method_exists( '\Brizy_Public_AssetEnqueueManager', '_init' )
+		) {
+			return;
+		}
+
+		try {
+			$post    = \Brizy_Editor_Post::get( $popup_id );
+			$manager = \Brizy_Public_AssetEnqueueManager::_init();
+
+			if ( ! is_object( $post ) || ! is_object( $manager ) || ! method_exists( $manager, 'enqueuePost' ) ) {
+				return;
+			}
+
+			$manager->enqueuePost( $post );
+			$this->collected_documents[ $popup_id ] = true;
+			$this->assets_finalized                 = false;
+		} catch ( \Throwable $error ) {
+			unset( $error );
+		}
+	}
+
+	/**
+	 * Let Brizy emit collected assets at the current batch boundary.
+	 *
+	 * @param bool $after_head Whether head output has already been sent.
+	 *
+	 * @return bool
+	 */
+	public function finalize_document_assets( $after_head ) {
+		if ( ! $after_head ) {
+			return true;
+		}
+
+		if ( $this->assets_finalized ) {
+			return true;
+		}
+
+		if (
+			! class_exists( '\Brizy_Public_AssetEnqueueManager' ) ||
+			! method_exists( '\Brizy_Public_AssetEnqueueManager', '_init' )
+		) {
+			return false;
+		}
+
+		try {
+			$manager = \Brizy_Public_AssetEnqueueManager::_init();
+		} catch ( \Throwable $error ) {
+			unset( $error );
+
+			return false;
+		}
+
+		if ( ! is_object( $manager ) || ! method_exists( $manager, 'enqueueStyles' ) || ! method_exists( $manager, 'enqueueScripts' ) ) {
+			return false;
+		}
+
+		global $wp_styles;
+
+		$before           = $wp_styles instanceof \WP_Styles ? (array) $wp_styles->queue : [];
+		$head_code_before = $this->capture_head_code_assets( $manager );
+
+		try {
+			if ( ! did_action( 'brizy_preview_enqueue_scripts' ) ) {
+				do_action( 'brizy_preview_enqueue_scripts' );
+			}
+
+			$manager->enqueueStyles();
+			$manager->enqueueScripts();
+		} catch ( \Throwable $error ) {
+			unset( $error );
+
+			return false;
+		}
+
+		$after = $wp_styles instanceof \WP_Styles ? (array) $wp_styles->queue : [];
+		$new   = array_values( array_diff( $after, $before ) );
+
+		if ( $new ) {
+			wp_print_styles( $new );
+		}
+
+		$head_code_after = $this->capture_head_code_assets( $manager );
+
+		if ( $head_code_after !== $head_code_before ) {
+			if ( 0 === strpos( $head_code_after, $head_code_before ) ) {
+				$head_code_after = substr( $head_code_after, strlen( $head_code_before ) );
+			}
+
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Brizy-generated head assets.
+			echo $head_code_after;
+		}
+
+		$this->assets_finalized = true;
+
+		return true;
+	}
+
+	/**
+	 * Capture Brizy's code-type head assets without printing them immediately.
+	 *
+	 * @param object $manager Brizy asset manager.
+	 *
+	 * @return string
+	 */
+	private function capture_head_code_assets( $manager ) {
+		if ( ! method_exists( $manager, 'insertHeadCodeAssets' ) ) {
+			return '';
+		}
+
+		$buffer_level = ob_get_level();
+		ob_start();
+
+		try {
+			$manager->insertHeadCodeAssets();
+			$output = ob_get_clean();
+		} catch ( \Throwable $error ) {
+			unset( $error );
+
+			while ( ob_get_level() > $buffer_level ) {
+				ob_end_clean();
+			}
+
+			return '';
+		}
+
+		return is_string( $output ) ? $output : '';
+	}
+}

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -103,6 +103,10 @@ class Builders extends Controller {
 			$builders[] = \PopupMaker\Builders\SiteOrigin::class;
 		}
 
+		if ( defined( 'BRIZY_VERSION' ) || class_exists( '\Brizy_Editor' ) ) {
+			$builders[] = \PopupMaker\Builders\Brizy::class;
+		}
+
 		return $builders;
 	}
 

--- a/tests/php/tests/Brizy_Builder_Test.php
+++ b/tests/php/tests/Brizy_Builder_Test.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * Brizy builder tests.
+ *
+ * @package Popup_Maker
+ */
+
+use PopupMaker\Builders\Brizy;
+
+/**
+ * Verify Brizy request routing and document rendering.
+ */
+class Brizy_Builder_Test extends WP_UnitTestCase {
+
+	/** @var array<string,mixed> */
+	private $original_get;
+
+	/** @return void */
+	public function setUp(): void {
+		parent::setUp();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test fixture preserves request globals.
+		$this->original_get = $_GET;
+	}
+
+	/** @return void */
+	public function tearDown(): void {
+		$_GET = $this->original_get;
+
+		parent::tearDown();
+	}
+
+	/** @return void */
+	public function test_only_iframe_request_uses_popup_canvas() {
+		$builder = new Brizy( \PopupMaker\plugin() );
+
+		$_GET = [
+			'action' => 'in-front-editor',
+			'post'   => '123',
+		];
+
+		$this->assertSame( 123, $builder->get_requested_popup_id() );
+		$this->assertFalse( $builder->is_canvas_request() );
+
+		$_GET = [
+			'is-editor-iframe' => '1',
+			'post'             => '123',
+		];
+
+		$this->assertSame( 123, $builder->get_requested_popup_id() );
+		$this->assertTrue( $builder->is_canvas_request() );
+		$this->assertSame(
+			'<div id="brz-ed-root"></div><div id="brz-popups"></div>',
+			$builder->render_document( 123, true )
+		);
+	}
+
+	/** @return void */
+	public function test_rendered_document_processes_popup_shortcodes() {
+		if (
+			class_exists( '\Brizy_Editor_Post' ) ||
+			class_exists( '\Brizy_Public_Main' ) ||
+			class_exists( '\Brizy_Public_AssetEnqueueManager' )
+		) {
+			$this->markTestSkipped( 'This regression test supplies isolated Brizy API doubles.' );
+		}
+
+		$brizy_api = new class() {
+
+			/** @var string */
+			public static $content = '';
+
+			/**
+			 * @param mixed $value Ignored API argument.
+			 * @return self
+			 */
+			public static function get( $value ) {
+				unset( $value );
+
+				return new self();
+			}
+
+			/**
+			 * @param string $content Ignored root marker.
+			 * @return string
+			 */
+			public function insert_page_content( $content ) {
+				unset( $content );
+
+				return self::$content;
+			}
+		};
+
+		class_alias( get_class( $brizy_api ), 'Brizy_Editor_Post' );
+		class_alias( get_class( $brizy_api ), 'Brizy_Public_Main' );
+
+		$asset_manager = new class() {
+
+			/** @var int */
+			public static $enqueue_count = 0;
+
+			/** @var int */
+			public static $finalize_count = 0;
+
+			/** @return self */
+			// phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore -- Mirrors Brizy's API.
+			public static function _init() {
+				return new self();
+			}
+
+			/**
+			 * @param mixed $post Brizy document.
+			 * @return void
+			 */
+			// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Mirrors Brizy's API.
+			public function enqueuePost( $post ) {
+				unset( $post );
+
+				++self::$enqueue_count;
+			}
+
+			/** @return void */
+			// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Mirrors Brizy's API.
+			public function enqueueStyles() {
+				++self::$finalize_count;
+			}
+
+			/** @return void */
+			// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Mirrors Brizy's API.
+			public function enqueueScripts() {}
+		};
+
+		class_alias( get_class( $asset_manager ), 'Brizy_Public_AssetEnqueueManager' );
+
+		$shortcode = 'pum_brizy_shortcode_proof';
+
+		add_shortcode(
+			$shortcode,
+			function () {
+				return '<strong id="brizy-shortcode-rendered">Shortcode rendered</strong>';
+			}
+		);
+
+		\Brizy_Public_Main::$content = '<div>[' . $shortcode . ']</div>';
+
+		try {
+			$builder = new Brizy( \PopupMaker\plugin() );
+			$content = $builder->render_document( 123 );
+			$builder->render_document( 123 );
+			$builder->finalize_document_assets( true );
+			$builder->finalize_document_assets( true );
+		} finally {
+			remove_shortcode( $shortcode );
+		}
+
+		$this->assertIsString( $content );
+		$this->assertStringNotContainsString( '[' . $shortcode . ']', $content );
+		$this->assertStringContainsString( 'id="brizy-shortcode-rendered"', $content );
+		$this->assertSame( 1, \Brizy_Public_AssetEnqueueManager::$enqueue_count );
+		$this->assertSame( 1, \Brizy_Public_AssetEnqueueManager::$finalize_count );
+	}
+}

--- a/tests/php/tests/Brizy_Builder_Test.php
+++ b/tests/php/tests/Brizy_Builder_Test.php
@@ -53,6 +53,13 @@ class Brizy_Builder_Test extends WP_UnitTestCase {
 			'<div id="brz-ed-root"></div><div id="brz-popups"></div>',
 			$builder->render_document( 123, true )
 		);
+
+		wp_register_style( 'popup-maker-builder-preview', false, [], 'test' );
+		$builder->add_canvas_styles();
+
+		$this->assertNotEmpty( wp_styles()->get_data( 'popup-maker-builder-preview', 'after' ) );
+
+		wp_deregister_style( 'popup-maker-builder-preview' );
 	}
 
 	/** @return void */

--- a/tests/php/tests/Brizy_Builder_Test.php
+++ b/tests/php/tests/Brizy_Builder_Test.php
@@ -120,7 +120,7 @@ class Brizy_Builder_Test extends WP_UnitTestCase {
 	}
 
 	/** @return void */
-	public function test_rendered_document_processes_popup_shortcodes() {
+	public function test_rendered_document_leaves_shortcodes_for_popup_content_pipeline() {
 		if (
 			class_exists( '\Brizy_Editor_Post' ) ||
 			class_exists( '\Brizy_Public_Main' ) ||
@@ -197,12 +197,22 @@ class Brizy_Builder_Test extends WP_UnitTestCase {
 
 		class_alias( get_class( $asset_manager ), 'Brizy_Public_AssetEnqueueManager' );
 
-		$shortcode = 'pum_brizy_shortcode_proof';
+		$shortcode        = 'pum_brizy_shortcode_proof';
+		$nested_shortcode = 'pum_brizy_nested_shortcode_proof';
+		$nested_runs      = 0;
 
 		add_shortcode(
 			$shortcode,
-			function () {
-				return '<strong id="brizy-shortcode-rendered">Shortcode rendered</strong>';
+			function () use ( $nested_shortcode ) {
+				return '[' . $nested_shortcode . ']';
+			}
+		);
+		add_shortcode(
+			$nested_shortcode,
+			function () use ( &$nested_runs ) {
+				++$nested_runs;
+
+				return '<strong id="brizy-nested-shortcode-rendered">Nested shortcode rendered</strong>';
 			}
 		);
 
@@ -217,15 +227,20 @@ class Brizy_Builder_Test extends WP_UnitTestCase {
 			$builder->finalize_document_assets( true );
 			$late_assets = ob_get_clean();
 			$builder->finalize_document_assets( true );
+			$filtered_content = \PUM_Utils_Shortcodes::clean_do_shortcode( $content );
 		} finally {
 			remove_shortcode( $shortcode );
+			remove_shortcode( $nested_shortcode );
 			wp_dequeue_style( 'pum-brizy-test-document' );
 			wp_deregister_style( 'pum-brizy-test-document' );
 		}
 
 		$this->assertIsString( $content );
-		$this->assertStringNotContainsString( '[' . $shortcode . ']', $content );
-		$this->assertStringContainsString( 'id="brizy-shortcode-rendered"', $content );
+		$this->assertStringContainsString( '[' . $shortcode . ']', $content );
+
+		$this->assertStringNotContainsString( '[' . $shortcode . ']', $filtered_content );
+		$this->assertStringContainsString( '[' . $nested_shortcode . ']', $filtered_content );
+		$this->assertSame( 0, $nested_runs );
 		$this->assertStringContainsString( 'brizy-test.css', $late_assets );
 		$this->assertSame( 1, \Brizy_Public_AssetEnqueueManager::$enqueue_count );
 		$this->assertSame( 1, \Brizy_Public_AssetEnqueueManager::$finalize_count );

--- a/tests/php/tests/Brizy_Builder_Test.php
+++ b/tests/php/tests/Brizy_Builder_Test.php
@@ -124,6 +124,7 @@ class Brizy_Builder_Test extends WP_UnitTestCase {
 				unset( $post );
 
 				++self::$enqueue_count;
+				wp_enqueue_style( 'pum-brizy-test-document' );
 			}
 
 			/** @return void */
@@ -149,20 +150,26 @@ class Brizy_Builder_Test extends WP_UnitTestCase {
 		);
 
 		\Brizy_Public_Main::$content = '<div>[' . $shortcode . ']</div>';
+		wp_register_style( 'pum-brizy-test-document', home_url( '/brizy-test.css' ), [], 'test' );
 
 		try {
 			$builder = new Brizy( \PopupMaker\plugin() );
 			$content = $builder->render_document( 123 );
 			$builder->render_document( 123 );
+			ob_start();
 			$builder->finalize_document_assets( true );
+			$late_assets = ob_get_clean();
 			$builder->finalize_document_assets( true );
 		} finally {
 			remove_shortcode( $shortcode );
+			wp_dequeue_style( 'pum-brizy-test-document' );
+			wp_deregister_style( 'pum-brizy-test-document' );
 		}
 
 		$this->assertIsString( $content );
 		$this->assertStringNotContainsString( '[' . $shortcode . ']', $content );
 		$this->assertStringContainsString( 'id="brizy-shortcode-rendered"', $content );
+		$this->assertStringContainsString( 'brizy-test.css', $late_assets );
 		$this->assertSame( 1, \Brizy_Public_AssetEnqueueManager::$enqueue_count );
 		$this->assertSame( 1, \Brizy_Public_AssetEnqueueManager::$finalize_count );
 	}

--- a/tests/php/tests/Brizy_Builder_Test.php
+++ b/tests/php/tests/Brizy_Builder_Test.php
@@ -15,19 +15,76 @@ class Brizy_Builder_Test extends WP_UnitTestCase {
 	/** @var array<string,mixed> */
 	private $original_get;
 
+	/** @var array<string,mixed> */
+	private $original_request;
+
 	/** @return void */
 	public function setUp(): void {
 		parent::setUp();
 
 		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test fixture preserves request globals.
 		$this->original_get = $_GET;
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test fixture preserves request globals.
+		$this->original_request = $_REQUEST;
 	}
 
 	/** @return void */
 	public function tearDown(): void {
-		$_GET = $this->original_get;
+		$_GET     = $this->original_get;
+		$_REQUEST = $this->original_request;
+		wp_set_current_user( 0 );
 
 		parent::tearDown();
+	}
+
+	/** @return void */
+	public function test_authenticated_native_save_records_brizy_ownership() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$builder  = new class( \PopupMaker\plugin() ) extends Brizy {
+
+			/** @var int */
+			public $remembered_popup_id = 0;
+
+			/**
+			 * @param int $popup_id Popup ID.
+			 * @return bool
+			 */
+			public function owns_document( $popup_id ) {
+				return 0 < absint( $popup_id );
+			}
+
+			/** @return string */
+			protected function get_save_action() {
+				return 'brizy_update_item';
+			}
+
+			/**
+			 * @param int $popup_id Popup ID.
+			 * @return void
+			 */
+			protected function remember_document_owner( $popup_id ) {
+				$this->remembered_popup_id = absint( $popup_id );
+			}
+		};
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		$builder->register_hooks();
+
+		$this->assertSame( PHP_INT_MAX, has_action( 'save_post_popup', [ $builder, 'remember_saved_document' ] ) );
+
+		$_REQUEST = [
+			'action' => 'brizy_update_item',
+			'post'   => (string) $popup_id,
+			'hash'   => 'invalid',
+		];
+		$builder->remember_saved_document( $popup_id );
+		$this->assertSame( 0, $builder->remembered_popup_id );
+
+		$_REQUEST['hash'] = wp_create_nonce( 'brizy-api' );
+		$builder->remember_saved_document( $popup_id );
+		$this->assertSame( $popup_id, $builder->remembered_popup_id );
+
+		remove_action( 'save_post_popup', [ $builder, 'remember_saved_document' ], PHP_INT_MAX );
 	}
 
 	/** @return void */

--- a/tests/php/tests/Page_Builders_Test.php
+++ b/tests/php/tests/Page_Builders_Test.php
@@ -144,7 +144,9 @@ class Page_Builders_Test extends WP_UnitTestCase {
 			did_action( 'elementor/loaded' ) ||
 			defined( 'FL_BUILDER_VERSION' ) ||
 			class_exists( 'FLBuilder', false ) ||
-			class_exists( 'SiteOrigin_Panels', false )
+			class_exists( 'SiteOrigin_Panels', false ) ||
+			defined( 'BRIZY_VERSION' ) ||
+			class_exists( 'Brizy_Editor', false )
 		) {
 			$this->markTestSkipped( 'A bundled builder is active in this test environment.' );
 		}
@@ -152,6 +154,7 @@ class Page_Builders_Test extends WP_UnitTestCase {
 		$elementor_loaded  = class_exists( \PopupMaker\Builders\Elementor::class, false );
 		$beaver_loaded     = class_exists( \PopupMaker\Builders\BeaverBuilder::class, false );
 		$siteorigin_loaded = class_exists( \PopupMaker\Builders\SiteOrigin::class, false );
+		$brizy_loaded      = class_exists( \PopupMaker\Builders\Brizy::class, false );
 		$controller        = new class( \PopupMaker\plugin() ) extends \PopupMaker\Controllers\Builders {
 
 			/** @var int */
@@ -174,6 +177,7 @@ class Page_Builders_Test extends WP_UnitTestCase {
 		$this->assertSame( $elementor_loaded, class_exists( \PopupMaker\Builders\Elementor::class, false ) );
 		$this->assertSame( $beaver_loaded, class_exists( \PopupMaker\Builders\BeaverBuilder::class, false ) );
 		$this->assertSame( $siteorigin_loaded, class_exists( \PopupMaker\Builders\SiteOrigin::class, false ) );
+		$this->assertSame( $brizy_loaded, class_exists( \PopupMaker\Builders\Brizy::class, false ) );
 	}
 
 	/** @return void */


### PR DESCRIPTION
## Summary

Adds complete Brizy popup editing and visitor rendering through one adapter.

- Registers the `popup` post type through Brizy public filter.
- Distinguishes Brizy editor shell from its editable iframe.
- Supplies Brizy required editor mounts inside the real Popup Maker container.
- Renders compiled Brizy visitor content through Brizy public renderer and lets Popup Maker process shortcodes exactly once.
- Registers each secondary popup once with Brizy asset manager and emits only late style and head-code deltas when discovery happens after `wp_head`.
- Records authenticated Brizy saves for mixed-builder ownership.
- Removes the first-empty-block `100vh` editor spacing without adding a Brizy-specific script.
- Documents complete Brizy support in the Unreleased changelog.

The late-asset batch is retained because Brizy normally expects documents before `wp_head`, while Popup Maker can first render them in the footer.

## Verification

- Full local PHPUnit suite: 955 tests, 2,160 assertions, 2 skipped.
- Focused Brizy and shared builder tests: 18 tests, 83 assertions.
- Targeted PHPStan and PHPCS pass.
- Compared the adapter against current Brizy 2.8.21 APIs.
- Previously live-tested with Brizy-built main-page and popup content, the native editor and library, visitor assets, late discovery, geometry, and close prevention.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating and displaying popup content built with Brizy.
  * Brizy popups now render in visual editor canvases with their associated styles and scripts.
  * Supports secure authenticated saves and preserves supported popup content during rendering.
  * Provides safe fallbacks when Brizy is unavailable or encounters an error.

* **Bug Fixes**
  * Improved page-builder detection so multiple supported builders can be recognized independently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->