### PR TITLE
Introduce page-builder infrastructure with Elementor support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,13 @@
 
 ## Unreleased
 
+**Features**
+
+-   Expanded Elementor support with direct popup editing, previews, and correctly styled frontend rendering.
+
 **Improvements**
 
+-   Improved page builder compatibility with more efficient asset loading and an easier path to supporting additional builders.
 -   Improved compatibility with PHP 8.3, 8.4, and 8.5.
 
 **Fixes**

--- a/assets/js/src/integration/builder-preview.js
+++ b/assets/js/src/integration/builder-preview.js
@@ -1,0 +1,122 @@
+import './builder-preview.scss';
+
+( function ( $, PUM ) {
+	'use strict';
+
+	if ( ! $ || ! PUM || 'function' !== typeof PUM.getPopup ) {
+		return;
+	}
+
+	const $popupElement = $( 'body.pum-builder-preview > .pum' ).first();
+	const popupId = parseInt(
+		( $popupElement.attr( 'id' ) || '' ).replace( 'pum-', '' ),
+		10
+	);
+	const $popup = popupId ? PUM.getPopup( popupId ) : null;
+	const $container =
+		$popup && $popup.length ? $popup.find( '.pum-container' ) : null;
+
+	function constrainPopupToVisibleViewport() {
+		const inset = 10;
+		const bounds = {
+			left: inset,
+			top: $( 'body' ).hasClass( 'admin-bar' ) ? 42 : inset,
+			right: window.innerWidth - inset,
+			bottom: window.innerHeight - inset,
+		};
+		let frameRect;
+
+		if ( ! $container || ! $container.length ) {
+			return;
+		}
+
+		if ( window.frameElement && window.parent !== window ) {
+			try {
+				frameRect = window.frameElement.getBoundingClientRect();
+				bounds.left = Math.max( bounds.left, inset - frameRect.left );
+				bounds.top = Math.max( bounds.top, inset - frameRect.top );
+				bounds.right = Math.min(
+					bounds.right,
+					window.parent.innerWidth - frameRect.left - inset
+				);
+				bounds.bottom = Math.min(
+					bounds.bottom,
+					window.parent.innerHeight - frameRect.top - inset
+				);
+			} catch {
+				// Keep the iframe's own viewport bounds across origins.
+			}
+		}
+
+		if ( bounds.right <= bounds.left || bounds.bottom <= bounds.top ) {
+			return;
+		}
+
+		const containerRect = $container[ 0 ].getBoundingClientRect();
+		const offsetLeft =
+			containerRect.width <= bounds.right - bounds.left
+				? Math.max(
+						bounds.left - containerRect.left,
+						Math.min( 0, bounds.right - containerRect.right )
+				  )
+				: Math.max( 0, bounds.left - containerRect.left );
+		const offsetTop =
+			containerRect.height <= bounds.bottom - bounds.top
+				? Math.max(
+						bounds.top - containerRect.top,
+						Math.min( 0, bounds.bottom - containerRect.bottom )
+				  )
+				: Math.max( 0, bounds.top - containerRect.top );
+
+		$container.css( {
+			left: ( parseFloat( $container.css( 'left' ) ) || 0 ) + offsetLeft,
+			top: ( parseFloat( $container.css( 'top' ) ) || 0 ) + offsetTop,
+		} );
+	}
+
+	function repositionPopup() {
+		if (
+			! $popup ||
+			! $popup.length ||
+			! $popup.closest( 'body' ).length
+		) {
+			return;
+		}
+
+		$popup.popmake( 'reposition' );
+		$popup.find( '.pum-close' ).attr( {
+			'aria-disabled': 'true',
+			tabindex: '-1',
+		} );
+
+		$( document ).trigger( 'pumBuilderPreviewReposition', [
+			$popup,
+			popupId,
+		] );
+		constrainPopupToVisibleViewport();
+	}
+
+	if ( $popup && $popup.length ) {
+		$popup.on( 'pumBeforeClose.pumBuilderPreview', function () {
+			$popup.addClass( 'preventClose' );
+		} );
+		$popup.on( 'pumAfterOpen.pumBuilderPreview', repositionPopup );
+
+		if ( 'ResizeObserver' in window && $container.length ) {
+			new window.ResizeObserver( repositionPopup ).observe(
+				$container[ 0 ]
+			);
+		}
+	}
+
+	if ( PUM.initialized ) {
+		repositionPopup();
+	} else {
+		$( document ).one(
+			'pumInitialized.pumBuilderPreview',
+			repositionPopup
+		);
+	}
+
+	$( window ).on( 'resize.pumBuilderPreview', repositionPopup );
+} )( window.jQuery, window.PUM );

--- a/assets/js/src/integration/builder-preview.scss
+++ b/assets/js/src/integration/builder-preview.scss
@@ -1,0 +1,31 @@
+html,
+body.pum-builder-preview {
+	min-height: 100%;
+}
+
+body.pum-builder-preview {
+	margin: 0;
+	min-height: 100vh;
+	overflow: auto;
+
+	&.pum-builder-preview-overlay-disabled {
+		background: transparent !important;
+	}
+
+	> .pum {
+		display: block !important;
+		opacity: 1 !important;
+		visibility: visible !important;
+	}
+
+	.pum-container,
+	.pum-close {
+		display: block !important;
+		opacity: 1 !important;
+		visibility: visible !important;
+	}
+
+	.pum-close {
+		pointer-events: none !important;
+	}
+}

--- a/assets/js/src/integration/elementor.js
+++ b/assets/js/src/integration/elementor.js
@@ -5,24 +5,49 @@
 	const formProvider = 'elementor';
 	const $ = window.jQuery;
 
-	// Elementor Forms success event.
-	$( document ).on(
-		'submit_success',
-		'.elementor-form',
-		function ( event, response ) {
-			const $form = $( this )[ 0 ];
+	const refreshWidgets = ( popup ) => {
+		const elementorRoot = popup.querySelector( '.elementor' );
 
-			// Get element_id from the widget container.
-			// Elementor form widgets are inside a .elementor-element-{id} container.
-			const $widget = $( this ).closest( '[data-id]' );
-			const elementId = $widget.length
-				? $widget.attr( 'data-id' )
-				: 'unknown';
-
-			window.PUM.integrations.formSubmission( $form, {
-				formProvider,
-				formId: elementId,
-			} );
+		if ( ! elementorRoot ) {
+			return;
 		}
-	);
+
+		if (
+			window.elementorFrontend &&
+			window.elementorFrontend.elementsHandler &&
+			typeof window.elementorFrontend.elementsHandler.runReadyTrigger ===
+				'function'
+		) {
+			$( elementorRoot )
+				.find( '[data-element_type]' )
+				.addBack( '[data-element_type]' )
+				.each( function () {
+					window.elementorFrontend.elementsHandler.runReadyTrigger(
+						this
+					);
+				} );
+		}
+	};
+
+	// Elementor Forms success event.
+	$( document ).on( 'submit_success', '.elementor-form', function () {
+		const $form = $( this );
+
+		// Get element_id from the widget container.
+		// Elementor form widgets are inside a .elementor-element-{id} container.
+		const $widget = $( this ).closest( '[data-id]' );
+		const elementId = $widget.length
+			? $widget.attr( 'data-id' )
+			: 'unknown';
+
+		window.PUM.integrations.formSubmission( $form, {
+			formProvider,
+			formId: elementId,
+		} );
+	} );
+
+	// Reinitialize Elementor widgets after their popup becomes visible.
+	$( document ).on( 'pumAfterOpen', '.pum', function () {
+		refreshWidgets( this );
+	} );
 }

--- a/classes/Builders/Elementor.php
+++ b/classes/Builders/Elementor.php
@@ -1,0 +1,252 @@
+<?php
+/**
+ * Elementor builder provider.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Builders;
+
+use PopupMaker\Interfaces\BuilderProvider;
+use PopupMaker\Interfaces\BuilderProvider\EditsPopups;
+use PopupMaker\Interfaces\BuilderProvider\ProvidesPreviewUrl;
+use PopupMaker\Interfaces\BuilderProvider\RendersDocuments;
+use PopupMaker\Services\BuilderPreviewUrl;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Elementor support for popup documents.
+ *
+ * Elementor defaults to supporting posts and pages only, so this provider adds
+ * runtime support for popups. It also restores the popup query for Elementor's
+ * preview iframe and renders popup documents through Elementor's API.
+ *
+ * @since 1.25.0
+ */
+class Elementor implements BuilderProvider, EditsPopups, RendersDocuments, ProvidesPreviewUrl {
+
+	/**
+	 * Plugin container.
+	 *
+	 * @var \PopupMaker\Plugin\Core
+	 */
+	private $container;
+
+	/**
+	 * Construct the provider.
+	 *
+	 * @param \PopupMaker\Plugin\Core $container Plugin container.
+	 */
+	public function __construct( $container ) {
+		$this->container = $container;
+	}
+
+	/**
+	 * Provider key.
+	 *
+	 * @return string
+	 */
+	public function key() {
+		return 'elementor';
+	}
+
+	/**
+	 * Whether Elementor's document and rendering APIs are usable.
+	 *
+	 * @return bool
+	 */
+	public function is_available() {
+		if ( ! did_action( 'elementor/loaded' ) || ! class_exists( '\Elementor\Plugin' ) ) {
+			return false;
+		}
+
+		$elementor = \Elementor\Plugin::$instance;
+
+		return isset( $elementor->documents, $elementor->frontend ) &&
+			method_exists( $elementor->documents, 'get' );
+	}
+
+	/**
+	 * Register Elementor-specific hooks.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_post_type_support( 'popup', 'elementor' );
+	}
+
+	/**
+	 * Point Elementor's preview button at the signed standalone preview.
+	 *
+	 * @return void
+	 */
+	public function register_preview_url() {
+		add_filter( 'elementor/document/urls/wp_preview', [ $this, 'filter_preview_url' ], 10, 2 );
+	}
+
+	/**
+	 * Replace an empty WordPress preview URL for popups.
+	 *
+	 * Popups are not publicly queryable, so WordPress produces no usable
+	 * preview URL and Elementor's preview button does nothing.
+	 *
+	 * @param mixed $url      WordPress preview URL.
+	 * @param mixed $document Elementor document.
+	 *
+	 * @return mixed
+	 */
+	public function filter_preview_url( $url, $document ) {
+		if ( ! is_object( $document ) || ! method_exists( $document, 'get_main_id' ) ) {
+			return $url;
+		}
+
+		$popup_id = absint( $document->get_main_id() );
+
+		if ( ! $popup_id || 'popup' !== get_post_type( $popup_id ) ) {
+			return $url;
+		}
+
+		if ( ! current_user_can( 'edit_post', $popup_id ) ) {
+			return $url;
+		}
+
+		return BuilderPreviewUrl::create( $popup_id, $this->key() );
+	}
+
+	/**
+	 * Get the popup ID Elementor is requesting.
+	 *
+	 * Authorization is intentionally absent; the coordinator performs it.
+	 *
+	 * @return int
+	 */
+	public function get_requested_popup_id() {
+		// Elementor's preview iframe carries no nonce; access rests on the
+		// per-popup capability check the coordinator applies.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if (
+			! isset( $_GET['elementor-preview'], $_GET['p'], $_GET['post_type'] ) ||
+			! is_scalar( $_GET['elementor-preview'] ) ||
+			! is_scalar( $_GET['p'] ) ||
+			! is_scalar( $_GET['post_type'] )
+		) {
+			return 0;
+		}
+
+		$preview_id = absint( wp_unslash( $_GET['elementor-preview'] ) );
+		$post_id    = absint( wp_unslash( $_GET['p'] ) );
+		$post_type  = sanitize_key( wp_unslash( $_GET['post_type'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ( 'popup' !== $post_type || ! $preview_id || $preview_id !== $post_id ) {
+			return 0;
+		}
+
+		return $preview_id;
+	}
+
+	/**
+	 * Whether this request renders the isolated canvas.
+	 *
+	 * Elementor serves its editor shell from wp-admin and requests the document
+	 * itself through the front-end preview iframe, so every front-end request
+	 * this provider claims is already a canvas.
+	 *
+	 * @return bool
+	 */
+	public function is_canvas_request() {
+		return true;
+	}
+
+	/**
+	 * Whether a popup's content is built with Elementor.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return bool
+	 */
+	public function is_builder_document( $popup_id ) {
+		$document = $this->get_document( $popup_id );
+
+		return $document && method_exists( $document, 'is_built_with_elementor' ) &&
+			$document->is_built_with_elementor();
+	}
+
+	/**
+	 * Render a popup's Elementor document.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return string|null
+	 */
+	public function render_document( $popup_id ) {
+		if ( ! $this->is_available() ) {
+			return null;
+		}
+
+		$popup_id = absint( $popup_id );
+		$frontend = \Elementor\Plugin::$instance->frontend;
+
+		/**
+		 * Lets Elementor's atomic widgets, components, and third-party widgets
+		 * register state for this secondary document before it renders.
+		 */
+		do_action( 'elementor/post/render', $popup_id );
+
+		/**
+		 * Inside the builder canvas the document must render unfiltered so edits
+		 * appear live. Elsewhere the display variant is correct, since it applies
+		 * the filters a visitor would see.
+		 */
+		if (
+			$popup_id === $this->get_canvas_popup_id() &&
+			method_exists( $frontend, 'get_builder_content' )
+		) {
+			$rendered = $frontend->get_builder_content( $popup_id );
+		} elseif ( method_exists( $frontend, 'get_builder_content_for_display' ) ) {
+			$rendered = $frontend->get_builder_content_for_display( $popup_id );
+		} else {
+			return null;
+		}
+
+		return is_string( $rendered ) ? $rendered : null;
+	}
+
+	/**
+	 * Get an Elementor document for a popup.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return object|null
+	 */
+	private function get_document( $popup_id ) {
+		if ( ! $this->is_available() ) {
+			return null;
+		}
+
+		$popup_id = absint( $popup_id );
+
+		if ( ! $popup_id || 'popup' !== get_post_type( $popup_id ) ) {
+			return null;
+		}
+
+		$document = \Elementor\Plugin::$instance->documents->get( $popup_id );
+
+		return is_object( $document ) ? $document : null;
+	}
+
+	/**
+	 * Get the popup ID currently rendering in the isolated canvas.
+	 *
+	 * @return int
+	 */
+	private function get_canvas_popup_id() {
+		$builders = $this->container->get_controller( 'Builders' );
+
+		return $builders instanceof \PopupMaker\Controllers\Builders
+			? $builders->get_canvas_popup_id()
+			: 0;
+	}
+}

--- a/classes/Controllers/Admin/Toolbar.php
+++ b/classes/Controllers/Admin/Toolbar.php
@@ -24,9 +24,58 @@ class Toolbar extends Controller {
 	 * Initializes this module.
 	 */
 	public function init() {
+		add_action( 'admin_bar_menu', [ $this, 'add_preview_edit_link' ], 80 );
 		add_action( 'admin_bar_menu', [ $this, 'toolbar_links' ], 999 );
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_files' ] );
 		add_action( 'init', [ $this, 'show_debug_bar' ] );
+	}
+
+	/**
+	 * Add the canonical edit link to authorized popup previews.
+	 *
+	 * Popup post types stay hidden from the admin bar globally so they do not
+	 * appear in WordPress's New menu. Core and builder previews still need the
+	 * same direct edit link WordPress shows for ordinary post previews.
+	 *
+	 * @param mixed $wp_admin_bar WordPress admin bar instance.
+	 *
+	 * @return void
+	 */
+	public function add_preview_edit_link( $wp_admin_bar ) {
+		if ( ! $wp_admin_bar instanceof \WP_Admin_Bar || is_admin() ) {
+			return;
+		}
+
+		$previews = $this->container->get_controller( 'Previews' );
+		$popup_id = $previews instanceof \PopupMaker\Controllers\Previews
+			? absint( $previews->get_popup_preview() )
+			: 0;
+
+		if ( ! $popup_id ) {
+			$builders = $this->container->get_controller( 'Builders' );
+			$popup_id = $builders instanceof \PopupMaker\Controllers\Builders
+				? absint( $builders->get_edit_popup_id() )
+				: 0;
+		}
+
+		if ( ! $popup_id || ! current_user_can( 'edit_post', $popup_id ) ) {
+			return;
+		}
+
+		$edit_url = get_edit_post_link( $popup_id, 'raw' );
+
+		if ( ! is_string( $edit_url ) || '' === $edit_url ) {
+			return;
+		}
+
+		$wp_admin_bar->add_node(
+			[
+				'id'     => 'edit',
+				'title'  => get_post_type_object( 'popup' )->labels->edit_item,
+				'href'   => $edit_url,
+				'parent' => false,
+			]
+		);
 	}
 
 	/**

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -1,0 +1,526 @@
+<?php
+/**
+ * Page builder coordinator.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Controllers;
+
+use PopupMaker\Interfaces\BuilderProvider;
+use PopupMaker\Interfaces\BuilderProvider\EditsPopups;
+use PopupMaker\Interfaces\BuilderProvider\LoadsDocumentAssets;
+use PopupMaker\Interfaces\BuilderProvider\ProvidesPreviewUrl;
+use PopupMaker\Interfaces\BuilderProvider\RendersDocuments;
+use PopupMaker\Plugin\Controller;
+use PopupMaker\Services\BuilderPreviewUrl;
+use PopupMaker\Services\BuilderProviders;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Owns the page builder request lifecycle.
+ *
+ * Providers answer questions and perform one operation each. This controller
+ * decides when those operations happen:
+ *
+ * - authorizing a builder edit/canvas request and restoring the popup query;
+ * - selecting the isolated popup canvas template;
+ * - routing popup content through the owning builder;
+ * - batching secondary-document assets and finalizing each builder at most
+ *   once per boundary.
+ *
+ * Keeping batching here prevents multiple builder popups from repeating
+ * one-time bootstraps: providers accumulate, the coordinator flushes.
+ *
+ * @since 1.25.0
+ */
+class Builders extends Controller {
+
+	/**
+	 * Provider registry.
+	 *
+	 * @var BuilderProviders
+	 */
+	private $providers;
+
+	/**
+	 * Provider keys whose runtime hooks have been registered.
+	 *
+	 * @var array<string,bool>
+	 */
+	private $registered = [];
+
+	/**
+	 * Provider keys with assets awaiting finalization.
+	 *
+	 * @var array<string,bool>
+	 */
+	private $pending = [];
+
+	/**
+	 * Popup IDs whose assets have already been collected this request.
+	 *
+	 * @var array<int,bool>
+	 */
+	private $collected = [];
+
+	/**
+	 * Initialize the coordinator.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		$this->providers = new BuilderProviders();
+
+		foreach ( $this->default_providers() as $provider ) {
+			$this->providers->register( $provider );
+		}
+
+		// Core initializes on `plugins_loaded:11`; Pro and add-ons load at 12/13.
+		// Delay the extension point until their registration callbacks exist.
+		if ( did_action( 'plugins_loaded' ) && ! doing_action( 'plugins_loaded' ) ) {
+			$this->register_providers();
+		} else {
+			add_action( 'plugins_loaded', [ $this, 'register_providers' ], 20 );
+		}
+
+		// Theme builders are available after setup. Some plugin builders construct
+		// their APIs on `init`, so retry there without double-hooking.
+		add_action( 'after_setup_theme', [ $this, 'register_provider_hooks' ], 20 );
+		add_action( 'init', [ $this, 'register_provider_hooks' ], 20 );
+
+		// Restore the popup query for an authorized builder request. The popup
+		// post type is intentionally not publicly queryable.
+		add_filter( 'request', [ $this, 'allow_builder_request' ] );
+		// Select the authorized popup canvas after builders replace the template.
+		add_filter( 'template_include', [ $this, 'use_popup_canvas' ], PHP_INT_MAX );
+		add_filter( 'popup_maker/is_builder_preview', [ $this, 'is_builder_canvas' ] );
+
+		// Route popup content through whichever builder owns the document.
+		add_filter( 'pum_popup_content', [ $this, 'render_popup_content' ], 1000, 2 );
+
+		// Drafts are excluded from the normal preload query, but their canvas still
+		// needs Popup Maker's CSS, JavaScript, and per-document builder assets.
+		add_action( 'wp_enqueue_scripts', [ $this, 'preload_canvas_popup' ], 11 );
+
+		/**
+		 * Asset batch boundaries.
+		 *
+		 * Priority 12 sits after Popup Maker's own preload at 11, so popups
+		 * discovered during preloading finalize before `wp_head()` output. The
+		 * footer pass catches popups discovered later, such as a `popmake-123`
+		 * click trigger found while filtering `the_content`.
+		 */
+		add_action( 'wp_enqueue_scripts', [ $this, 'flush_pending_assets' ], 12 );
+		add_action( 'wp_footer', [ $this, 'flush_pending_assets_late' ], 0 );
+	}
+
+	/**
+	 * Providers bundled with the plugin.
+	 *
+	 * @return BuilderProvider[]
+	 */
+	protected function default_providers() {
+		return [
+			new \PopupMaker\Builders\Elementor( $this->container ),
+		];
+	}
+
+	/**
+	 * Get the provider registry.
+	 *
+	 * @return BuilderProviders
+	 */
+	public function providers() {
+		return $this->providers;
+	}
+
+	/**
+	 * Register providers supplied by add-ons and their preview URL filters.
+	 *
+	 * @return void
+	 */
+	public function register_providers() {
+		/**
+		 * Register additional page builder providers.
+		 *
+		 * Mirrors the `pum_integrations` filter used by form providers.
+		 *
+		 * @param BuilderProviders $providers Provider registry.
+		 */
+		do_action( 'popup_maker/register_builder_providers', $this->providers );
+
+		// Preview URL filters do not depend on a bootstrapped builder runtime.
+		foreach ( $this->providers->all() as $provider ) {
+			if ( $provider instanceof ProvidesPreviewUrl ) {
+				$provider->register_preview_url();
+			}
+		}
+	}
+
+	/**
+	 * Register hooks for every available provider.
+	 *
+	 * @return void
+	 */
+	public function register_provider_hooks() {
+		foreach ( $this->providers->available() as $provider ) {
+			if ( isset( $this->registered[ $provider->key() ] ) ) {
+				continue;
+			}
+
+			$provider->register_hooks();
+
+			$this->registered[ $provider->key() ] = true;
+		}
+	}
+
+	/**
+	 * Get the authorized builder edit request for this page load.
+	 *
+	 * Authorization lives here rather than in providers so every builder is
+	 * held to the same checks: the target must be a popup, the user must be
+	 * logged in, and they must be able to edit that specific popup.
+	 *
+	 * @return array{provider:BuilderProvider,popup_id:int}|null
+	 */
+	protected function get_edit_request() {
+		$edit_request = null;
+
+		/**
+		 * Recognizing a builder request only reads query arguments, so every
+		 * registered provider is asked — not just the available ones. A builder
+		 * can be installed but not yet bootstrapped for the current request, and
+		 * the popup query still has to be restored (and live triggers stripped)
+		 * for the editor to work at all.
+		 */
+		foreach ( $this->providers->all() as $provider ) {
+			$popup_id = absint( BuilderPreviewUrl::read_request( $provider->key() ) );
+
+			if ( ! $popup_id && $provider instanceof EditsPopups ) {
+				$popup_id = absint( $provider->get_requested_popup_id() );
+			}
+
+			if ( ! $popup_id ) {
+				continue;
+			}
+
+			if ( 'popup' !== get_post_type( $popup_id ) ) {
+				continue;
+			}
+
+			if ( ! is_user_logged_in() || ! current_user_can( 'edit_post', $popup_id ) ) {
+				continue;
+			}
+
+			$edit_request = [
+				'provider' => $provider,
+				'popup_id' => $popup_id,
+			];
+
+			break;
+		}
+
+		return $edit_request;
+	}
+
+	/**
+	 * Get the authorized popup ID for this builder request.
+	 *
+	 * @return int Popup ID, or 0 when the request is not an authorized builder request.
+	 */
+	public function get_edit_popup_id() {
+		$request = $this->get_edit_request();
+
+		return $request ? $request['popup_id'] : 0;
+	}
+
+	/**
+	 * Get the popup ID when the isolated canvas should be rendered.
+	 *
+	 * The editor shell is left to the builder; only the canvas — and our own
+	 * signed preview — gets Popup Maker's template.
+	 *
+	 * @return int Popup ID, or 0 when this is not a canvas request.
+	 */
+	public function get_canvas_popup_id() {
+		$request = $this->get_edit_request();
+
+		if ( ! $request ) {
+			return 0;
+		}
+
+		$provider = $request['provider'];
+
+		$is_signed_preview = (bool) BuilderPreviewUrl::read_request( $provider->key() );
+
+		if ( ! $is_signed_preview && $provider instanceof EditsPopups && ! $provider->is_canvas_request() ) {
+			return 0;
+		}
+
+		if ( ! is_singular( 'popup' ) || absint( get_queried_object_id() ) !== $request['popup_id'] ) {
+			return 0;
+		}
+
+		return $request['popup_id'];
+	}
+
+	/**
+	 * Restore the popup query for an authorized builder request.
+	 *
+	 * @param mixed $query_vars Parsed query variables.
+	 *
+	 * @return mixed Filtered query variables.
+	 */
+	public function allow_builder_request( $query_vars ) {
+		if ( ! is_array( $query_vars ) ) {
+			return $query_vars;
+		}
+
+		$popup_id = $this->get_edit_popup_id();
+
+		if ( ! $popup_id ) {
+			return $query_vars;
+		}
+
+		$query_vars['p']         = $popup_id;
+		$query_vars['post_type'] = 'popup';
+
+		/**
+		 * Builders open unsaved popups, which are drafts. A front-end query
+		 * returns only published and private posts, so an authorized editor
+		 * would otherwise get a 404 for a popup they just created.
+		 */
+		$status = get_post_status( $popup_id );
+
+		if ( $status && ! in_array( $status, [ 'publish', 'private' ], true ) ) {
+			$query_vars['post_status'] = $status;
+		}
+
+		return $query_vars;
+	}
+
+	/**
+	 * Select the isolated popup canvas template.
+	 *
+	 * @param string $template Selected template path.
+	 *
+	 * @return string Filtered template path.
+	 */
+	public function use_popup_canvas( $template ) {
+		if ( ! $this->get_edit_popup_id() ) {
+			return $template;
+		}
+
+		/**
+		 * Never render popups through the normal footer pass during a builder
+		 * request.
+		 *
+		 * On the canvas the template renders the popup itself, so the footer pass
+		 * would duplicate it. On the editor shell there is no popup to show at
+		 * all: rendering one covers the entire builder with a fixed, full-screen
+		 * overlay at Popup Maker's stacking order.
+		 */
+		$popups = $this->container->get_controller( 'Frontend\Popups' );
+
+		if ( $popups instanceof \PopupMaker\Controllers\Frontend\Popups ) {
+			remove_action( 'wp_footer', [ $popups, 'render_popups' ] );
+		}
+
+		if ( ! $this->get_canvas_popup_id() ) {
+			return $template;
+		}
+
+		$canvas = $this->container->get_path( 'templates/single-popup.php' );
+
+		return file_exists( $canvas ) ? $canvas : $template;
+	}
+
+	/**
+	 * Whether the current request renders the isolated builder canvas.
+	 *
+	 * @param bool $is_canvas Whether another integration claimed the request.
+	 *
+	 * @return bool
+	 */
+	public function is_builder_canvas( $is_canvas ) {
+		return $is_canvas || (bool) $this->get_canvas_popup_id();
+	}
+
+	/**
+	 * Preload the isolated canvas popup before head assets are printed.
+	 *
+	 * @return void
+	 */
+	public function preload_canvas_popup() {
+		$popup_id = $this->get_canvas_popup_id();
+
+		if ( ! $popup_id ) {
+			return;
+		}
+
+		$popup  = $this->container->get( 'popups' )->get_by_id( $popup_id );
+		$popups = $this->container->get_controller( 'Frontend\Popups' );
+
+		if (
+			pum_is_popup( $popup ) &&
+			$popup_id === $popup->ID &&
+			$popups instanceof \PopupMaker\Controllers\Frontend\Popups
+		) {
+			$popups->preload_popup( $popup );
+		}
+	}
+
+	/**
+	 * Render popup content through the builder that owns the document.
+	 *
+	 * @param mixed $content  Popup post content.
+	 * @param mixed $popup_id Popup ID.
+	 *
+	 * @return mixed Builder markup, or the original content.
+	 */
+	public function render_popup_content( $content, $popup_id = 0 ) {
+		if ( ! is_string( $content ) || ! is_numeric( $popup_id ) ) {
+			return $content;
+		}
+
+		if ( is_admin() && ! wp_doing_ajax() ) {
+			return $content;
+		}
+
+		$popup_id = absint( $popup_id );
+
+		if ( ! $popup_id || 'popup' !== get_post_type( $popup_id ) ) {
+			return $content;
+		}
+
+		$provider = $this->find_document_provider( $popup_id );
+
+		if ( $provider ) {
+			$rendered = $provider->render_document( $popup_id );
+
+			if ( is_string( $rendered ) ) {
+				$content = $rendered;
+			}
+		}
+
+		$asset_provider = $this->find_asset_provider( $popup_id );
+
+		if ( $asset_provider ) {
+			$this->collect_assets( $asset_provider, $popup_id );
+		}
+
+		return $content;
+	}
+
+	/**
+	 * Find the provider whose builder owns a popup's document.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return RendersDocuments|null
+	 */
+	protected function find_document_provider( $popup_id ) {
+		foreach ( $this->providers->supporting( RendersDocuments::class ) as $provider ) {
+			if ( $provider->is_builder_document( $popup_id ) ) {
+				return $provider;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Find the provider whose builder owns a popup's document assets.
+	 *
+	 * Asset ownership is independent from document rendering. Builders that
+	 * render through WordPress' existing content pipeline can still need a
+	 * secondary document's assets collected.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return LoadsDocumentAssets|null
+	 */
+	protected function find_asset_provider( $popup_id ) {
+		foreach ( $this->providers->supporting( LoadsDocumentAssets::class ) as $provider ) {
+			if ( $provider->is_builder_document( $popup_id ) ) {
+				return $provider;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Collect one popup's assets and mark its provider for finalization.
+	 *
+	 * Deduplicated per popup, so a popup rendered more than once in a request
+	 * only collects once.
+	 *
+	 * @param BuilderProvider $provider Provider that owns the document assets.
+	 * @param int             $popup_id Popup ID.
+	 *
+	 * @return void
+	 */
+	protected function collect_assets( BuilderProvider $provider, $popup_id ) {
+		if ( ! $provider instanceof LoadsDocumentAssets ) {
+			return;
+		}
+
+		if ( isset( $this->collected[ $popup_id ] ) ) {
+			return;
+		}
+
+		$this->collected[ $popup_id ] = true;
+
+		$provider->collect_document_assets( $popup_id );
+
+		$this->pending[ $provider->key() ] = true;
+	}
+
+	/**
+	 * Finalize pending assets before head output.
+	 *
+	 * @return void
+	 */
+	public function flush_pending_assets() {
+		$this->flush( false );
+	}
+
+	/**
+	 * Finalize pending assets discovered after head output.
+	 *
+	 * @return void
+	 */
+	public function flush_pending_assets_late() {
+		$this->flush( true );
+	}
+
+	/**
+	 * Finalize each provider with pending assets exactly once.
+	 *
+	 * @param bool $after_head Whether head output has already been sent.
+	 *
+	 * @return void
+	 */
+	protected function flush( $after_head ) {
+		if ( ! $this->pending ) {
+			return;
+		}
+
+		foreach ( array_keys( $this->pending ) as $key ) {
+			$provider = $this->providers->get( $key );
+
+			if ( ! $provider instanceof LoadsDocumentAssets ) {
+				unset( $this->pending[ $key ] );
+				continue;
+			}
+
+			if ( $provider->finalize_document_assets( $after_head ) ) {
+				unset( $this->pending[ $key ] );
+			}
+		}
+	}
+}

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -97,6 +97,7 @@ class Builders extends Controller {
 		// Select the authorized popup canvas after builders replace the template.
 		add_filter( 'template_include', [ $this, 'use_popup_canvas' ], PHP_INT_MAX );
 		add_filter( 'popup_maker/is_builder_preview', [ $this, 'is_builder_canvas' ] );
+		add_filter( 'body_class', [ $this, 'filter_canvas_body_classes' ] );
 
 		// Route popup content through whichever builder owns the document.
 		add_filter( 'pum_popup_content', [ $this, 'render_popup_content' ], 1000, 2 );
@@ -350,6 +351,34 @@ class Builders extends Controller {
 	}
 
 	/**
+	 * Add presentation classes to the isolated builder canvas.
+	 *
+	 * @param mixed $classes Body classes.
+	 *
+	 * @return mixed Filtered body classes.
+	 */
+	public function filter_canvas_body_classes( $classes ) {
+		if ( ! is_array( $classes ) ) {
+			return $classes;
+		}
+
+		$popup_id = $this->get_canvas_popup_id();
+
+		if ( ! $popup_id ) {
+			return $classes;
+		}
+
+		$classes[] = 'pum-builder-preview';
+		$popup     = pum_get_popup( $popup_id );
+
+		if ( pum_is_popup( $popup ) && $popup->get_setting( 'overlay_disabled', false ) ) {
+			$classes[] = 'pum-builder-preview-overlay-disabled';
+		}
+
+		return array_values( array_unique( $classes ) );
+	}
+
+	/**
 	 * Preload the isolated canvas popup before head assets are printed.
 	 *
 	 * @return void
@@ -370,6 +399,20 @@ class Builders extends Controller {
 			$popups instanceof \PopupMaker\Controllers\Frontend\Popups
 		) {
 			$popups->preload_popup( $popup );
+
+			wp_enqueue_style(
+				'pum-builder-preview',
+				\Popup_Maker::$URL . 'dist/assets/builder-preview.css',
+				[ 'popup-maker-site' ],
+				\Popup_Maker::$VER
+			);
+			wp_enqueue_script(
+				'pum-builder-preview',
+				\Popup_Maker::$URL . 'dist/assets/builder-preview.js',
+				[ 'popup-maker-site' ],
+				\Popup_Maker::$VER,
+				true
+			);
 		}
 	}
 

--- a/classes/Controllers/Previews.php
+++ b/classes/Controllers/Previews.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * Popup preview controller.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Controllers;
+
+use PopupMaker\Plugin\Controller;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Manages core editor popup previews.
+ *
+ * Scope is deliberately narrow: the `popup_preview` nonce flow used by the
+ * classic and block editors, which renders a real popup on a real page with a
+ * debug trigger.
+ *
+ * Third-party page builders are *not* handled here. They need query
+ * restoration, an isolated canvas, and secondary-document asset loading, none
+ * of which are preview concerns — those live in
+ * {@see \PopupMaker\Controllers\Builders}. This controller only asks that
+ * controller whether a builder owns the request, so the two never fight over
+ * the same popup.
+ *
+ * @since 1.21.0
+ */
+class Previews extends Controller {
+
+	/**
+	 * Whether the controller hooks have been registered.
+	 *
+	 * @var bool
+	 */
+	private $initialized = false;
+
+	/**
+	 * Initialize preview hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		if ( $this->initialized ) {
+			return;
+		}
+
+		$this->initialized = true;
+
+		add_action( 'template_redirect', [ $this, 'force_load_preview' ] );
+		add_filter( 'pum_popup_is_loadable', [ $this, 'is_loadable' ], 1000, 2 );
+		add_filter( 'pum_popup_data_attr', [ $this, 'data_attr' ], 1000, 2 );
+		add_filter( 'pum_popup_get_public_settings', [ $this, 'get_public_settings' ], 1000, 2 );
+	}
+
+	/**
+	 * Get the popup ID from a core editor preview request.
+	 *
+	 * @return false|int
+	 */
+	public function get_popup_preview() {
+		if (
+			! isset( $_GET['popup_preview'], $_GET['popup'] ) ||
+			! is_scalar( $_GET['popup_preview'] ) ||
+			! is_scalar( $_GET['popup'] )
+		) {
+			return false;
+		}
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Verified below.
+		$nonce    = sanitize_text_field( wp_unslash( $_GET['popup_preview'] ) );
+		$popup_id = sanitize_text_field( wp_unslash( $_GET['popup'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ( ! wp_verify_nonce( $nonce, 'popup-preview' ) ) {
+			return false;
+		}
+
+		if ( is_numeric( $popup_id ) && absint( $popup_id ) > 0 ) {
+			return absint( $popup_id );
+		}
+
+		$post = get_page_by_path( $popup_id, OBJECT, 'popup' );
+
+		return $post instanceof \WP_Post ? $post->ID : false;
+	}
+
+	/**
+	 * Force a core editor preview popup to load regardless of post status.
+	 *
+	 * @return void
+	 */
+	public function force_load_preview() {
+		$popup_id = $this->get_popup_preview();
+
+		if ( ! $popup_id || ! current_user_can( 'edit_post', $popup_id ) ) {
+			return;
+		}
+
+		$popup = $this->container->get( 'popups' )->get_by_id( $popup_id );
+
+		if ( ! pum_is_popup( $popup ) || $popup_id !== $popup->ID ) {
+			return;
+		}
+
+		$popups = $this->container->get_controller( 'Frontend\Popups' );
+
+		if ( $popups instanceof \PopupMaker\Controllers\Frontend\Popups ) {
+			$popups->preload_popup( $popup );
+		}
+	}
+
+	/**
+	 * Force the previewed popup to load.
+	 *
+	 * @param bool $loadable Whether the popup is loadable.
+	 * @param int  $popup_id Popup ID.
+	 *
+	 * @return bool Whether the popup is loadable.
+	 */
+	public function is_loadable( $loadable, $popup_id ) {
+		$builder_popup_id = $this->get_builder_popup_id();
+
+		// A builder request edits exactly one popup; loading any other would
+		// put unrelated popups in the editing canvas.
+		if ( $builder_popup_id ) {
+			return absint( $popup_id ) === $builder_popup_id;
+		}
+
+		return $this->is_previewing_popup( $popup_id ) ? true : $loadable;
+	}
+
+	/**
+	 * Add an admin debug trigger to core editor previews.
+	 *
+	 * @deprecated 1.16.10 Use get_public_settings instead.
+	 *
+	 * @param array $data_attr Popup data attributes.
+	 * @param int   $popup_id Popup ID.
+	 *
+	 * @return mixed
+	 */
+	public function data_attr( $data_attr, $popup_id ) {
+		if ( ! is_array( $data_attr ) ) {
+			return $data_attr;
+		}
+
+		$data_attr['triggers'] = $this->filter_triggers(
+			isset( $data_attr['triggers'] ) ? $data_attr['triggers'] : [],
+			$popup_id
+		);
+
+		return $data_attr;
+	}
+
+	/**
+	 * Adjust triggers for previewed popups.
+	 *
+	 * @param array           $settings Popup public settings.
+	 * @param PUM_Model_Popup $popup Popup model.
+	 *
+	 * @return array
+	 */
+	public function get_public_settings( $settings, $popup ) {
+		if ( ! is_array( $settings ) || ! is_object( $popup ) || ! isset( $popup->ID ) ) {
+			return $settings;
+		}
+
+		$settings['triggers'] = $this->filter_triggers(
+			isset( $settings['triggers'] ) ? $settings['triggers'] : [],
+			$popup->ID
+		);
+
+		return $settings;
+	}
+
+	/**
+	 * Replace a popup's triggers for preview contexts.
+	 *
+	 * Builder canvases get no triggers at all: the canvas is already visible,
+	 * so a time-delay or auto-open trigger would re-open it mid-edit and apply
+	 * animations and focus locks while the user is working.
+	 *
+	 * Core editor previews get a single debug trigger so the popup opens once
+	 * for inspection.
+	 *
+	 * @param array $triggers Existing triggers.
+	 * @param int   $popup_id Popup ID.
+	 *
+	 * @return array
+	 */
+	private function filter_triggers( $triggers, $popup_id ) {
+		if ( ! is_array( $triggers ) ) {
+			$triggers = [];
+		}
+
+		if ( absint( $popup_id ) === $this->get_builder_popup_id() ) {
+			return [];
+		}
+
+		if ( ! $this->is_previewing_popup( $popup_id ) ) {
+			return $triggers;
+		}
+
+		return [
+			[
+				'type' => 'admin_debug',
+			],
+		];
+	}
+
+	/**
+	 * Get the popup ID owned by an authorized builder request.
+	 *
+	 * @return int
+	 */
+	private function get_builder_popup_id() {
+		$builders = $this->container->get_controller( 'Builders' );
+
+		return $builders instanceof \PopupMaker\Controllers\Builders
+			? $builders->get_edit_popup_id()
+			: 0;
+	}
+
+	/**
+	 * Whether a popup is the authorized core editor preview.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return bool
+	 */
+	private function is_previewing_popup( $popup_id = 0 ) {
+		if ( wp_doing_ajax() ) {
+			return false;
+		}
+
+		$preview_id = $this->get_popup_preview();
+
+		return absint( $popup_id ) === $preview_id && current_user_can( 'edit_post', $preview_id );
+	}
+}

--- a/classes/Interfaces/BuilderProvider.php
+++ b/classes/Interfaces/BuilderProvider.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * Page builder provider contract.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Interfaces;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Base contract every page builder provider implements.
+ *
+ * Mirrors the long-standing form provider contract
+ * (`PUM_Interface_Integration`): a stable key and an availability probe.
+ * Everything beyond that is an optional capability, because no two builders
+ * expose the same surface.
+ *
+ * Providers answer questions and perform single operations. They never own
+ * request lifecycle, batching, or finalization — that belongs to
+ * `PopupMaker\Controllers\Builders`.
+ *
+ * @since 1.25.0
+ */
+interface BuilderProvider {
+
+	/**
+	 * Stable provider key.
+	 *
+	 * Used for hook names, signed preview URLs, and registry lookups, so it
+	 * must not change once shipped.
+	 *
+	 * @return string
+	 */
+	public function key();
+
+	/**
+	 * Whether the builder is active and exposes the APIs this provider needs.
+	 *
+	 * Called late (never at construction) because theme and plugin builders can
+	 * load at different points. Implementations must verify every class or method
+	 * they later call, so a builder API change degrades to a no-op instead of a
+	 * fatal error.
+	 *
+	 * @return bool
+	 */
+	public function is_available();
+
+	/**
+	 * Register the provider's own builder-side hooks.
+	 *
+	 * Called once, only when {@see BuilderProvider::is_available()} is true.
+	 * Providers must not register popup rendering or asset finalization hooks
+	 * here; the coordinator owns those.
+	 *
+	 * @return void
+	 */
+	public function register_hooks();
+}

--- a/classes/Interfaces/BuilderProvider/EditsPopups.php
+++ b/classes/Interfaces/BuilderProvider/EditsPopups.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Direct popup editing capability.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Interfaces\BuilderProvider;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Implemented by providers whose builder can edit popup posts directly.
+ *
+ * Popups are registered non-publicly-queryable on purpose. A builder that
+ * edits them through a front-end request needs that query restored, but only
+ * for the one popup being edited and only for a user who may edit it.
+ *
+ * @since 1.25.0
+ */
+interface EditsPopups {
+
+	/**
+	 * Whether this request is the builder's editor or canvas for a popup.
+	 *
+	 * Implementations return the popup ID the builder is asking for, without
+	 * performing authorization. The coordinator validates post type,
+	 * capability, and login state, so a provider cannot accidentally widen
+	 * access.
+	 *
+	 * @return int Popup ID the builder requested, or 0 when not such a request.
+	 */
+	public function get_requested_popup_id();
+
+	/**
+	 * Whether the request targets the isolated editing canvas.
+	 *
+	 * Builders separate the editor shell (chrome, panels) from the canvas
+	 * iframe that renders the document. Only the canvas gets Popup Maker's
+	 * isolated template; the shell must be left alone.
+	 *
+	 * @return bool
+	 */
+	public function is_canvas_request();
+}

--- a/classes/Interfaces/BuilderProvider/LoadsDocumentAssets.php
+++ b/classes/Interfaces/BuilderProvider/LoadsDocumentAssets.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Secondary document asset capability.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Interfaces\BuilderProvider;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Implemented by providers whose builder needs help loading assets for popups.
+ *
+ * Popups are *secondary* documents: they are not the main query post, and they
+ * may be discovered before the main loop (preloaded) or after it (a click
+ * trigger found while filtering `the_content`). Builders only load assets for
+ * the main document on their own.
+ *
+ * Finalization stays with each provider because builder asset APIs differ.
+ * The coordinator owns *when* finalization happens and guarantees it succeeds
+ * at most once per batch. Providers own *what* finalization does.
+ *
+ * @since 1.25.0
+ */
+interface LoadsDocumentAssets {
+
+	/**
+	 * Whether the popup's assets belong to this builder.
+	 *
+	 * Kept on the asset capability rather than inferred from
+	 * `RendersDocuments`: a builder may render through `the_content` while still
+	 * needing help loading assets for the secondary popup document.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return bool
+	 */
+	public function is_builder_document( $popup_id );
+
+	/**
+	 * Collect assets for one popup document.
+	 *
+	 * Called immediately after the document renders, while the builder's own
+	 * render-time state is still valid. Implementations should accumulate work
+	 * rather than emit it, so many popups collapse into one finalization.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return void
+	 */
+	public function collect_document_assets( $popup_id );
+
+	/**
+	 * Finalize every asset collected since the last finalization.
+	 *
+	 * Called at batch boundaries by the coordinator, never by the provider.
+	 * Implementations must be safe to call when nothing was collected, and
+	 * must not repeat one-time global bootstrap work.
+	 *
+	 * @param bool $after_head Whether output has already passed `wp_head()`,
+	 *                         in which case enqueueing is no longer effective
+	 *                         and markup must be printed instead.
+	 *
+	 * @return bool Whether the collected assets were finalized. Returning
+	 *              false leaves them pending for the next boundary.
+	 */
+	public function finalize_document_assets( $after_head );
+}

--- a/classes/Interfaces/BuilderProvider/ProvidesPreviewUrl.php
+++ b/classes/Interfaces/BuilderProvider/ProvidesPreviewUrl.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Builder preview URL capability.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Interfaces\BuilderProvider;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Implemented by providers that redirect their builder's preview button.
+ *
+ * Preview URL filters do not call the builder runtime, so the coordinator
+ * registers them once even when the builder has not finished bootstrapping.
+ * This is independent from the provider's available runtime operations.
+ *
+ * @since 1.25.0
+ */
+interface ProvidesPreviewUrl {
+
+	/**
+	 * Register the builder-specific preview URL filter.
+	 *
+	 * @return void
+	 */
+	public function register_preview_url();
+}

--- a/classes/Interfaces/BuilderProvider/RendersDocuments.php
+++ b/classes/Interfaces/BuilderProvider/RendersDocuments.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Builder document rendering capability.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Interfaces\BuilderProvider;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Implemented by providers that can render a popup's builder document.
+ *
+ * The contract is stable ("give me HTML for this popup") even though builder
+ * APIs differ in how they return rendered documents.
+ *
+ * @since 1.25.0
+ */
+interface RendersDocuments {
+
+	/**
+	 * Whether the popup's content is built with this builder.
+	 *
+	 * Must be cheap and side-effect free; the coordinator calls it for every
+	 * loaded popup on every request.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return bool
+	 */
+	public function is_builder_document( $popup_id );
+
+	/**
+	 * Render the popup's builder document.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return string|null Rendered markup, or null to fall back to post content.
+	 */
+	public function render_document( $popup_id );
+}

--- a/classes/Plugin/Core.php
+++ b/classes/Plugin/Core.php
@@ -43,6 +43,8 @@ final class Core extends \PopupMaker\Plugin\Container {
 			'Admin'         => new \PopupMaker\Controllers\Admin( $this ),
 			'Assets'        => new \PopupMaker\Controllers\Assets( $this ),
 			'CallToActions' => new \PopupMaker\Controllers\CallToActions( $this ),
+			'Previews'      => new \PopupMaker\Controllers\Previews( $this ),
+			'Builders'      => new \PopupMaker\Controllers\Builders( $this ),
 			'Compatibility' => new \PopupMaker\Controllers\Compatibility( $this ),
 			'Debug'         => new \PopupMaker\Controllers\Debug( $this ),
 			'PostTypes'     => new \PopupMaker\Controllers\PostTypes( $this ),

--- a/classes/Previews.php
+++ b/classes/Previews.php
@@ -1,160 +1,168 @@
 <?php
 /**
- * Manage popup prevews.
+ * Legacy popup preview API.
  *
  * @package PopupMaker
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
- * Class PUM_Previews
+ * Backward-compatible facade for the popup preview controller.
  *
- * This class sets up the necessary changes to allow admins & editors to preview popups on the front end.
+ * @deprecated 1.25.0 Use the Previews controller from PopupMaker\plugin().
  */
 class PUM_Previews {
 
 	/**
-	 * Initiator method.
+	 * Initialize preview hooks.
+	 *
+	 * @deprecated 1.25.0 Preview hooks are initialized by the plugin container.
+	 *
+	 * @return void
 	 */
 	public static function init() {
-		add_action( 'template_redirect', [ __CLASS__, 'force_load_preview' ] );
-		add_filter( 'pum_popup_is_loadable', [ __CLASS__, 'is_loadable' ], 1000, 2 );
-		add_filter( 'pum_popup_data_attr', [ __CLASS__, 'data_attr' ], 1000, 2 );
-		add_filter( 'pum_popup_get_public_settings', [ __CLASS__, 'get_public_settings' ], 1000, 2 );
+		_deprecated_function( __METHOD__, '1.25.0', 'PopupMaker\Controllers\Previews::init()' );
+
+		$controller = static::controller();
+
+		if ( $controller ) {
+			$controller->init();
+		}
 	}
 
 	/**
-	 * Get popup id for previewing.
+	 * Get the popup ID for a core editor preview.
+	 *
+	 * @deprecated 1.25.0 Use PopupMaker\Controllers\Previews::get_popup_preview().
 	 *
 	 * @return false|int
 	 */
 	public static function get_popup_preview() {
-		static $preview_id;
+		_deprecated_function( __METHOD__, '1.25.0', 'PopupMaker\Controllers\Previews::get_popup_preview()' );
 
-		if ( isset( $preview_id ) ) {
-			return $preview_id;
-		}
+		$controller = static::controller();
 
-		$preview_id = false;
-
-		if (
-			! isset( $_GET['popup_preview'] ) ||
-			! isset( $_GET['popup'] ) ||
-			// Overridden as wp_verify_nonce is already safe: https://github.com/WordPress/WordPress-Coding-Standards/issues/869#issuecomment-611782416.
-			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			! wp_verify_nonce( $_GET['popup_preview'], 'popup-preview' )
-		) {
-			return false;
-		}
-
-		$popup_id = sanitize_text_field( wp_unslash( $_GET['popup'] ) );
-
-		if ( is_numeric( $_GET['popup'] ) && absint( $_GET['popup'] ) > 0 ) {
-			$preview_id = absint( $_GET['popup'] );
-		} else {
-			$post       = get_page_by_path( $popup_id, OBJECT, 'popup' );
-			$preview_id = $post->ID;
-		}
-
-		return $preview_id;
+		return $controller ? $controller->get_popup_preview() : false;
 	}
 
 	/**
-	 * Sets the Popup Post Type public arg to true for content editors.
+	 * Force the current core editor preview popup to load.
 	 *
-	 * This enables them to use the built in preview links.
+	 * @deprecated 1.25.0 Use PopupMaker\Controllers\Previews::force_load_preview().
 	 *
-	 * @param int $popup_id Popup ID.
-	 *
-	 * @return bool
-	 */
-	private static function is_previewing_popup( $popup_id = 0 ) {
-		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
-			return false;
-		}
-
-		$preview_id = static::get_popup_preview();
-
-		return $popup_id === $preview_id && current_user_can( 'edit_post', $preview_id );
-	}
-
-	/**
-	 * Force popup to load no matter its status if its supposed to be previewed.
+	 * @return void
 	 */
 	public static function force_load_preview() {
-		$preview_id = static::get_popup_preview();
+		_deprecated_function( __METHOD__, '1.25.0', 'PopupMaker\Controllers\Previews::force_load_preview()' );
 
-		// The preview nonce is shared across block-editor screens; require edit
-		// access to this specific popup before force-loading draft/private content.
-		if ( ! $preview_id || ! current_user_can( 'edit_post', $preview_id ) ) {
-			return;
-		}
+		$controller = static::controller();
 
-		$popup = pum_get_popup( $preview_id );
-
-		if ( $popup->is_valid() && $preview_id === $popup->ID ) {
-			PUM_Site_Popups::preload_popup( $popup );
+		if ( $controller ) {
+			$controller->force_load_preview();
 		}
 	}
 
 	/**
-	 * For popup previews this will force only the correct popup to load.
+	 * Filter popup loadability during a preview.
 	 *
-	 * @param bool $loadable Is popup loadable.
+	 * @deprecated 1.25.0 Use PopupMaker\Controllers\Previews::is_loadable().
+	 *
+	 * @param bool $loadable Whether the popup is loadable.
 	 * @param int  $popup_id Popup ID.
 	 *
 	 * @return bool
 	 */
 	public static function is_loadable( $loadable, $popup_id ) {
-		return self::is_previewing_popup( $popup_id ) ? true : $loadable;
+		_deprecated_function( __METHOD__, '1.25.0', 'PopupMaker\Controllers\Previews::is_loadable()' );
+
+		$controller = static::controller();
+
+		return $controller ? $controller->is_loadable( $loadable, $popup_id ) : $loadable;
 	}
 
 	/**
-	 * On popup previews add an admin debug trigger.
+	 * Filter legacy popup data attributes during a preview.
 	 *
-	 * @deprecated 1.16.10 Use get_public_settings instead.
+	 * @deprecated 1.25.0 Use PopupMaker\Controllers\Previews::data_attr().
 	 *
-	 * @param array $data_attr Array of popup data attributes.
+	 * @param array $data_attr Popup data attributes.
 	 * @param int   $popup_id Popup ID.
 	 *
 	 * @return mixed
 	 */
 	public static function data_attr( $data_attr, $popup_id ) {
-		if ( ! self::is_previewing_popup( $popup_id ) ) {
-			return $data_attr;
-		}
+		_deprecated_function( __METHOD__, '1.25.0', 'PopupMaker\Controllers\Previews::data_attr()' );
 
-		$data_attr['triggers'] = [
-			[
-				'type' => 'admin_debug',
-			],
-		];
+		$controller = static::controller();
 
-		return $data_attr;
+		return $controller ? $controller->data_attr( $data_attr, $popup_id ) : $data_attr;
 	}
 
 	/**
-	 * On popup previews add an admin debug trigger.
+	 * Filter popup public settings during a preview.
 	 *
-	 * @param array           $settings Array of settigs.
-	 * @param PUM_Model_Popup $popup Popup model object.
+	 * @deprecated 1.25.0 Use PopupMaker\Controllers\Previews::get_public_settings().
+	 *
+	 * @param array           $settings Popup public settings.
+	 * @param PUM_Model_Popup $popup Popup model.
 	 *
 	 * @return array
 	 */
 	public static function get_public_settings( $settings, $popup ) {
-		if ( ! self::is_previewing_popup( $popup->ID ) ) {
-			return $settings;
-		}
+		_deprecated_function( __METHOD__, '1.25.0', 'PopupMaker\Controllers\Previews::get_public_settings()' );
 
-		$settings['triggers'] = [
-			[
-				'type' => 'admin_debug',
-			],
-		];
+		$controller = static::controller();
 
-		return $settings;
+		return $controller ? $controller->get_public_settings( $settings, $popup ) : $settings;
+	}
+
+	/**
+	 * Restore the popup query for an authorized builder request.
+	 *
+	 * @deprecated 1.25.0 Handled by PopupMaker\Controllers\Builders.
+	 *
+	 * @param mixed $query_vars Parsed query variables.
+	 *
+	 * @return mixed
+	 */
+	public static function allow_builder_preview_request( $query_vars ) {
+		_deprecated_function( __METHOD__, '1.25.0', 'PopupMaker\Controllers\Builders::allow_builder_request()' );
+
+		$builders = PopupMaker\plugin()->get_controller( 'Builders' );
+
+		return $builders instanceof PopupMaker\Controllers\Builders
+			? $builders->allow_builder_request( $query_vars )
+			: $query_vars;
+	}
+
+	/**
+	 * Select the isolated popup canvas for a builder request.
+	 *
+	 * @deprecated 1.25.0 Handled by PopupMaker\Controllers\Builders.
+	 *
+	 * @param string $template Selected template path.
+	 *
+	 * @return string
+	 */
+	public static function use_builder_preview_template( $template ) {
+		_deprecated_function( __METHOD__, '1.25.0', 'PopupMaker\Controllers\Builders::use_popup_canvas()' );
+
+		$builders = PopupMaker\plugin()->get_controller( 'Builders' );
+
+		return $builders instanceof PopupMaker\Controllers\Builders
+			? $builders->use_popup_canvas( $template )
+			: $template;
+	}
+
+	/**
+	 * Get the modern preview controller.
+	 *
+	 * @return PopupMaker\Controllers\Previews|null
+	 */
+	private static function controller() {
+		$controller = PopupMaker\plugin()->get_controller( 'Previews' );
+
+		return $controller instanceof PopupMaker\Controllers\Previews ? $controller : null;
 	}
 }

--- a/classes/Services/BuilderPreviewUrl.php
+++ b/classes/Services/BuilderPreviewUrl.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * Signed builder preview URLs.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Services;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Creates and verifies signed standalone popup preview URLs.
+ *
+ * This is the one piece of preview handling that is genuinely identical across
+ * builders, so it lives in a stateless service rather than a trait: both sides
+ * of the signature must agree, and a trait copied into each provider makes that
+ * agreement easy to break.
+ *
+ * These URLs exist because WordPress cannot produce a preview URL for a
+ * non-publicly-queryable post type. Unlike a builder's own canvas request —
+ * which carries no nonce and relies on capability alone — this URL is one we
+ * mint, so it is signed.
+ *
+ * @since 1.25.0
+ */
+class BuilderPreviewUrl {
+
+	/**
+	 * Request argument naming the builder being previewed.
+	 */
+	const BUILDER_ARG = 'pum-builder-preview';
+
+	/**
+	 * Create a signed standalone preview URL for a popup.
+	 *
+	 * @param int    $popup_id Popup ID.
+	 * @param string $builder  Provider key.
+	 *
+	 * @return string Preview URL, or an empty string for invalid input.
+	 */
+	public static function create( $popup_id, $builder ) {
+		$popup_id = absint( $popup_id );
+		$builder  = sanitize_key( $builder );
+
+		if ( ! $popup_id || '' === $builder ) {
+			return '';
+		}
+
+		return add_query_arg(
+			[
+				'post_type'       => 'popup',
+				'p'               => $popup_id,
+				self::BUILDER_ARG => $builder,
+				'_wpnonce'        => wp_create_nonce( self::action( $popup_id, $builder ) ),
+			],
+			home_url( '/' )
+		);
+	}
+
+	/**
+	 * Read the popup ID from a signed standalone preview request.
+	 *
+	 * Verifies the signature only. The coordinator still checks post type and
+	 * capability, so a valid signature alone never grants access.
+	 *
+	 * @param string $builder Provider key.
+	 *
+	 * @return int Popup ID, or 0 when the request is absent or unsigned.
+	 */
+	public static function read_request( $builder ) {
+		$builder = sanitize_key( $builder );
+
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Verified below.
+		if (
+			! isset( $_GET[ self::BUILDER_ARG ], $_GET['p'], $_GET['_wpnonce'] ) ||
+			! is_scalar( $_GET[ self::BUILDER_ARG ] ) ||
+			! is_scalar( $_GET['p'] ) ||
+			! is_scalar( $_GET['_wpnonce'] )
+		) {
+			return 0;
+		}
+
+		$requested = sanitize_key( wp_unslash( $_GET[ self::BUILDER_ARG ] ) );
+		$popup_id  = absint( wp_unslash( $_GET['p'] ) );
+		$nonce     = sanitize_text_field( wp_unslash( $_GET['_wpnonce'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ( '' === $builder || $builder !== $requested || ! $popup_id ) {
+			return 0;
+		}
+
+		if ( ! wp_verify_nonce( $nonce, self::action( $popup_id, $builder ) ) ) {
+			return 0;
+		}
+
+		return $popup_id;
+	}
+
+	/**
+	 * Build the nonce action for a popup and builder pair.
+	 *
+	 * Binding both values means a signature for one popup cannot be replayed
+	 * against another.
+	 *
+	 * @param int    $popup_id Popup ID.
+	 * @param string $builder  Provider key.
+	 *
+	 * @return string
+	 */
+	private static function action( $popup_id, $builder ) {
+		return 'pum_builder_preview_' . $builder . '_' . absint( $popup_id );
+	}
+}

--- a/classes/Services/BuilderProviders.php
+++ b/classes/Services/BuilderProviders.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Page builder provider registry.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Services;
+
+use PopupMaker\Interfaces\BuilderProvider;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Collects page builder providers and exposes the available ones.
+ *
+ * Deliberately shaped like the form provider collector
+ * (`PUM_Integrations::$integrations` plus `get_enabled_form_integrations()`):
+ * a keyed map, one registration filter, and availability decided by asking each
+ * provider rather than by inspecting it from outside.
+ *
+ * Availability is resolved lazily on every lookup. Provider probes are cheap,
+ * and not caching them avoids freezing a builder as unavailable while a
+ * third-party `init` callback is still constructing its API.
+ *
+ * @since 1.25.0
+ */
+class BuilderProviders {
+
+	/**
+	 * Registered providers keyed by provider key.
+	 *
+	 * @var array<string,BuilderProvider>
+	 */
+	private $providers = [];
+
+	/**
+	 * Register a provider.
+	 *
+	 * Later registrations replace earlier ones for the same key, which lets an
+	 * add-on swap a bundled provider without unhooking anything.
+	 *
+	 * @param BuilderProvider $provider Provider instance.
+	 *
+	 * @return void
+	 */
+	public function register( BuilderProvider $provider ) {
+		$key = sanitize_key( $provider->key() );
+
+		if ( '' === $key ) {
+			return;
+		}
+
+		$this->providers[ $key ] = $provider;
+	}
+
+	/**
+	 * Get every registered provider, available or not.
+	 *
+	 * @return array<string,BuilderProvider>
+	 */
+	public function all() {
+		return $this->providers;
+	}
+
+	/**
+	 * Get the providers whose builder is active and usable.
+	 *
+	 * @return array<string,BuilderProvider>
+	 */
+	public function available() {
+		$available = [];
+
+		foreach ( $this->providers as $key => $provider ) {
+			if ( $provider->is_available() ) {
+				$available[ $key ] = $provider;
+			}
+		}
+
+		return $available;
+	}
+
+	/**
+	 * Get one available provider by key.
+	 *
+	 * @param string $key Provider key.
+	 *
+	 * @return BuilderProvider|null
+	 */
+	public function get( $key ) {
+		$available = $this->available();
+		$key       = sanitize_key( $key );
+
+		return isset( $available[ $key ] ) ? $available[ $key ] : null;
+	}
+
+	/**
+	 * Get available providers implementing a given capability interface.
+	 *
+	 * @param string $capability Fully qualified capability interface name.
+	 *
+	 * @return array<string,BuilderProvider>
+	 */
+	public function supporting( $capability ) {
+		$matches = [];
+
+		foreach ( $this->available() as $key => $provider ) {
+			if ( $provider instanceof $capability ) {
+				$matches[ $key ] = $provider;
+			}
+		}
+
+		return $matches;
+	}
+}

--- a/includes/legacy/class-popup-maker.php
+++ b/includes/legacy/class-popup-maker.php
@@ -168,7 +168,6 @@ class Popup_Maker {
 		PUM_Admin::init();
 		PUM_Utils_Upgrades::instance();
 		PUM_Newsletters::init();
-		PUM_Previews::init();
 		PUM_Integrations::init();
 		PUM_Privacy::init();
 

--- a/templates/single-popup.php
+++ b/templates/single-popup.php
@@ -24,13 +24,6 @@ if ( ! pum_is_popup( $popup ) ) {
 }
 
 $previous_popup = \PopupMaker\get_current_popup();
-$has_title      = '' !== $popup->get_title();
-$show_close     = $popup->show_close_button();
-$body_classes   = [ 'pum-builder-preview' ];
-
-if ( $popup->get_setting( 'overlay_disabled', false ) ) {
-	$body_classes[] = 'pum-builder-preview-overlay-disabled';
-}
 
 ?><!doctype html>
 <html <?php language_attributes(); ?>>
@@ -38,95 +31,16 @@ if ( $popup->get_setting( 'overlay_disabled', false ) ) {
 	<meta charset="<?php bloginfo( 'charset' ); ?>">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<?php wp_head(); ?>
-	<style id="pum-builder-preview-styles">
-		html,
-		body.pum-builder-preview {
-			min-height: 100%;
-		}
-
-		body.pum-builder-preview {
-			margin: 0;
-			min-height: 100vh;
-			overflow: auto;
-		}
-
-		body.pum-builder-preview.pum-builder-preview-overlay-disabled {
-			background: transparent !important;
-		}
-
-		body.pum-builder-preview > .pum-builder-preview-popup {
-			display: block !important;
-			opacity: 1 !important;
-			visibility: visible !important;
-		}
-
-		body.pum-builder-preview .pum-container {
-			display: block !important;
-			opacity: 1 !important;
-			visibility: visible !important;
-		}
-
-		body.pum-builder-preview .pum-close[aria-disabled="true"] {
-			display: block !important;
-			pointer-events: none !important;
-		}
-	</style>
 </head>
-<?php
-/**
- * A DOM-owning builder can emit its own body tag and wrapper through the standard
- * body and footer hooks. The shared template remains unaware of builder markup.
- */
-if ( ! apply_filters( 'popup_maker/builder_canvas_body_tag', false, $body_classes ) ) {
-	?>
-	<body <?php body_class( $body_classes ); ?>>
-	<?php
-}
-
-wp_body_open();
-?>
+<body <?php body_class(); ?>>
+	<?php wp_body_open(); ?>
 	<?php if ( have_posts() ) : ?>
 		<?php while ( have_posts() ) : ?>
 			<?php
 			the_post();
 			\PopupMaker\set_current_popup( $popup );
+			pum_template_part( 'popup' );
 			?>
-			<div
-				id="pum-<?php pum_popup_ID(); ?>"
-				role="dialog"
-				aria-modal="false"
-				<?php if ( $has_title ) : ?>
-					aria-labelledby="pum_popup_title_<?php pum_popup_ID(); ?>"
-				<?php else : ?>
-					aria-label="<?php esc_attr_e( 'Popup preview', 'popup-maker' ); ?>"
-				<?php endif; ?>
-				class="<?php pum_popup_classes(); ?> pum-builder-preview-popup"
-				<?php pum_popup_data_attr(); ?>
-			>
-				<div id="popmake-<?php pum_popup_ID(); ?>" class="<?php pum_popup_classes( null, 'container' ); ?>">
-					<?php do_action( 'pum_popup_before_title' ); ?>
-					<?php do_action( 'popmake_popup_before_inner' ); // Backward compatibility. ?>
-
-					<?php if ( $has_title ) : ?>
-						<div id="pum_popup_title_<?php pum_popup_ID(); ?>" class="<?php pum_popup_classes( null, 'title' ); ?>">
-							<?php pum_popup_title(); ?>
-						</div>
-					<?php endif; ?>
-
-					<?php do_action( 'pum_popup_before_content' ); ?>
-					<div class="<?php pum_popup_classes( null, 'content' ); ?>" <?php pum_popup_content_tabindex_attr(); ?>>
-						<?php pum_popup_content(); ?>
-					</div>
-					<?php do_action( 'pum_popup_after_content' ); ?>
-					<?php do_action( 'popmake_popup_after_inner' ); // Backward compatibility. ?>
-
-					<?php if ( $show_close ) : ?>
-						<button type="button" class="<?php pum_popup_classes( null, 'close' ); ?>" aria-label="<?php esc_attr_e( 'Close', 'popup-maker' ); ?>" aria-disabled="true" tabindex="-1">
-							<?php pum_popup_close_text(); ?>
-						</button>
-					<?php endif; ?>
-				</div>
-			</div>
 		<?php endwhile; ?>
 	<?php endif; ?>
 
@@ -134,115 +48,5 @@ wp_body_open();
 	\PopupMaker\set_current_popup( $previous_popup );
 	wp_footer();
 	?>
-	<script id="pum-builder-preview-script">
-		( function ( $, PUM ) {
-			'use strict';
-
-			if ( ! $ || ! PUM || 'function' !== typeof PUM.getPopup ) {
-				return;
-			}
-
-			var popupId = <?php echo absint( $popup_id ); ?>,
-				$popup = PUM.getPopup( popupId ),
-				$container,
-				resizeObserver;
-
-			function constrainPopupToVisibleViewport() {
-				var inset = 10,
-					bounds = {
-						left: inset,
-						top: $( 'body' ).hasClass( 'admin-bar' ) ? 42 : inset,
-						right: window.innerWidth - inset,
-						bottom: window.innerHeight - inset
-					},
-					frameRect,
-					containerRect,
-					offsetLeft,
-					offsetTop;
-
-				if ( ! $container || ! $container.length ) {
-					return;
-				}
-
-				if ( window.frameElement && window.parent !== window ) {
-					try {
-						frameRect = window.frameElement.getBoundingClientRect();
-						bounds.left = Math.max( bounds.left, inset - frameRect.left );
-						bounds.top = Math.max( bounds.top, inset - frameRect.top );
-						bounds.right = Math.min(
-							bounds.right,
-							window.parent.innerWidth - frameRect.left - inset
-						);
-						bounds.bottom = Math.min(
-							bounds.bottom,
-							window.parent.innerHeight - frameRect.top - inset
-						);
-					} catch ( error ) {
-						// Keep the iframe's own viewport bounds across origins.
-					}
-				}
-
-				if ( bounds.right <= bounds.left || bounds.bottom <= bounds.top ) {
-					return;
-				}
-
-				containerRect = $container[ 0 ].getBoundingClientRect();
-				offsetLeft = containerRect.width <= bounds.right - bounds.left
-					? Math.max(
-						bounds.left - containerRect.left,
-						Math.min( 0, bounds.right - containerRect.right )
-					)
-					: Math.max( 0, bounds.left - containerRect.left );
-				offsetTop = containerRect.height <= bounds.bottom - bounds.top
-					? Math.max(
-						bounds.top - containerRect.top,
-						Math.min( 0, bounds.bottom - containerRect.bottom )
-					)
-					: Math.max( 0, bounds.top - containerRect.top );
-
-				$container.css( {
-					left: ( parseFloat( $container.css( 'left' ) ) || 0 ) + offsetLeft,
-					top: ( parseFloat( $container.css( 'top' ) ) || 0 ) + offsetTop
-				} );
-			}
-
-			function repositionPopup() {
-				if ( ! $popup || ! $popup.length || ! $popup.closest( 'body' ).length ) {
-					return;
-				}
-
-				$popup.popmake( 'reposition' );
-				$popup.find( '.pum-close' ).attr( {
-					'aria-disabled': 'true',
-					tabindex: '-1'
-				} );
-
-				$( document ).trigger( 'pumBuilderPreviewReposition', [ $popup, popupId ] );
-				constrainPopupToVisibleViewport();
-			}
-
-			if ( $popup && $popup.length ) {
-				$popup.on( 'pumBeforeClose.pumBuilderPreview', function () {
-					$popup.addClass( 'preventClose' );
-				} );
-				$popup.on( 'pumAfterOpen.pumBuilderPreview', repositionPopup );
-
-				$container = $popup.find( '.pum-container' );
-
-				if ( 'ResizeObserver' in window && $container.length ) {
-					resizeObserver = new ResizeObserver( repositionPopup );
-					resizeObserver.observe( $container[ 0 ] );
-				}
-			}
-
-			if ( PUM.initialized ) {
-				repositionPopup();
-			} else {
-				$( document ).one( 'pumInitialized.pumBuilderPreview', repositionPopup );
-			}
-
-			$( window ).on( 'resize.pumBuilderPreview', repositionPopup );
-		} )( window.jQuery, window.PUM );
-	</script>
 </body>
 </html>

--- a/templates/single-popup.php
+++ b/templates/single-popup.php
@@ -1,11 +1,248 @@
 <?php
 /**
- * Single-Popup Templates
+ * Single Popup Template.
  *
  * @package   PopupMaker
  * @copyright Copyright (c) 2024, Code Atlantic LLC
  */
 
-get_header();
+$is_builder_preview = (bool) apply_filters( 'popup_maker/is_builder_preview', false );
 
-get_footer();
+// Preserve the legacy Bricks template behavior.
+// Keep it until Bricks adopts the shared builder preview controller.
+if ( ! $is_builder_preview ) {
+	get_header();
+	get_footer();
+	return;
+}
+
+$popup_id = absint( get_queried_object_id() );
+$popup    = pum_get_popup( $popup_id );
+
+if ( ! pum_is_popup( $popup ) ) {
+	return;
+}
+
+$previous_popup = \PopupMaker\get_current_popup();
+$has_title      = '' !== $popup->get_title();
+$show_close     = $popup->show_close_button();
+$body_classes   = [ 'pum-builder-preview' ];
+
+if ( $popup->get_setting( 'overlay_disabled', false ) ) {
+	$body_classes[] = 'pum-builder-preview-overlay-disabled';
+}
+
+?><!doctype html>
+<html <?php language_attributes(); ?>>
+<head>
+	<meta charset="<?php bloginfo( 'charset' ); ?>">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<?php wp_head(); ?>
+	<style id="pum-builder-preview-styles">
+		html,
+		body.pum-builder-preview {
+			min-height: 100%;
+		}
+
+		body.pum-builder-preview {
+			margin: 0;
+			min-height: 100vh;
+			overflow: auto;
+		}
+
+		body.pum-builder-preview.pum-builder-preview-overlay-disabled {
+			background: transparent !important;
+		}
+
+		body.pum-builder-preview > .pum-builder-preview-popup {
+			display: block !important;
+			opacity: 1 !important;
+			visibility: visible !important;
+		}
+
+		body.pum-builder-preview .pum-container {
+			display: block !important;
+			opacity: 1 !important;
+			visibility: visible !important;
+		}
+
+		body.pum-builder-preview .pum-close[aria-disabled="true"] {
+			display: block !important;
+			pointer-events: none !important;
+		}
+	</style>
+</head>
+<?php
+/**
+ * A DOM-owning builder can emit its own body tag and wrapper through the standard
+ * body and footer hooks. The shared template remains unaware of builder markup.
+ */
+if ( ! apply_filters( 'popup_maker/builder_canvas_body_tag', false, $body_classes ) ) {
+	?>
+	<body <?php body_class( $body_classes ); ?>>
+	<?php
+}
+
+wp_body_open();
+?>
+	<?php if ( have_posts() ) : ?>
+		<?php while ( have_posts() ) : ?>
+			<?php
+			the_post();
+			\PopupMaker\set_current_popup( $popup );
+			?>
+			<div
+				id="pum-<?php pum_popup_ID(); ?>"
+				role="dialog"
+				aria-modal="false"
+				<?php if ( $has_title ) : ?>
+					aria-labelledby="pum_popup_title_<?php pum_popup_ID(); ?>"
+				<?php else : ?>
+					aria-label="<?php esc_attr_e( 'Popup preview', 'popup-maker' ); ?>"
+				<?php endif; ?>
+				class="<?php pum_popup_classes(); ?> pum-builder-preview-popup"
+				<?php pum_popup_data_attr(); ?>
+			>
+				<div id="popmake-<?php pum_popup_ID(); ?>" class="<?php pum_popup_classes( null, 'container' ); ?>">
+					<?php do_action( 'pum_popup_before_title' ); ?>
+					<?php do_action( 'popmake_popup_before_inner' ); // Backward compatibility. ?>
+
+					<?php if ( $has_title ) : ?>
+						<div id="pum_popup_title_<?php pum_popup_ID(); ?>" class="<?php pum_popup_classes( null, 'title' ); ?>">
+							<?php pum_popup_title(); ?>
+						</div>
+					<?php endif; ?>
+
+					<?php do_action( 'pum_popup_before_content' ); ?>
+					<div class="<?php pum_popup_classes( null, 'content' ); ?>" <?php pum_popup_content_tabindex_attr(); ?>>
+						<?php pum_popup_content(); ?>
+					</div>
+					<?php do_action( 'pum_popup_after_content' ); ?>
+					<?php do_action( 'popmake_popup_after_inner' ); // Backward compatibility. ?>
+
+					<?php if ( $show_close ) : ?>
+						<button type="button" class="<?php pum_popup_classes( null, 'close' ); ?>" aria-label="<?php esc_attr_e( 'Close', 'popup-maker' ); ?>" aria-disabled="true" tabindex="-1">
+							<?php pum_popup_close_text(); ?>
+						</button>
+					<?php endif; ?>
+				</div>
+			</div>
+		<?php endwhile; ?>
+	<?php endif; ?>
+
+	<?php
+	\PopupMaker\set_current_popup( $previous_popup );
+	wp_footer();
+	?>
+	<script id="pum-builder-preview-script">
+		( function ( $, PUM ) {
+			'use strict';
+
+			if ( ! $ || ! PUM || 'function' !== typeof PUM.getPopup ) {
+				return;
+			}
+
+			var popupId = <?php echo absint( $popup_id ); ?>,
+				$popup = PUM.getPopup( popupId ),
+				$container,
+				resizeObserver;
+
+			function constrainPopupToVisibleViewport() {
+				var inset = 10,
+					bounds = {
+						left: inset,
+						top: $( 'body' ).hasClass( 'admin-bar' ) ? 42 : inset,
+						right: window.innerWidth - inset,
+						bottom: window.innerHeight - inset
+					},
+					frameRect,
+					containerRect,
+					offsetLeft,
+					offsetTop;
+
+				if ( ! $container || ! $container.length ) {
+					return;
+				}
+
+				if ( window.frameElement && window.parent !== window ) {
+					try {
+						frameRect = window.frameElement.getBoundingClientRect();
+						bounds.left = Math.max( bounds.left, inset - frameRect.left );
+						bounds.top = Math.max( bounds.top, inset - frameRect.top );
+						bounds.right = Math.min(
+							bounds.right,
+							window.parent.innerWidth - frameRect.left - inset
+						);
+						bounds.bottom = Math.min(
+							bounds.bottom,
+							window.parent.innerHeight - frameRect.top - inset
+						);
+					} catch ( error ) {
+						// Keep the iframe's own viewport bounds across origins.
+					}
+				}
+
+				if ( bounds.right <= bounds.left || bounds.bottom <= bounds.top ) {
+					return;
+				}
+
+				containerRect = $container[ 0 ].getBoundingClientRect();
+				offsetLeft = containerRect.width <= bounds.right - bounds.left
+					? Math.max(
+						bounds.left - containerRect.left,
+						Math.min( 0, bounds.right - containerRect.right )
+					)
+					: Math.max( 0, bounds.left - containerRect.left );
+				offsetTop = containerRect.height <= bounds.bottom - bounds.top
+					? Math.max(
+						bounds.top - containerRect.top,
+						Math.min( 0, bounds.bottom - containerRect.bottom )
+					)
+					: Math.max( 0, bounds.top - containerRect.top );
+
+				$container.css( {
+					left: ( parseFloat( $container.css( 'left' ) ) || 0 ) + offsetLeft,
+					top: ( parseFloat( $container.css( 'top' ) ) || 0 ) + offsetTop
+				} );
+			}
+
+			function repositionPopup() {
+				if ( ! $popup || ! $popup.length || ! $popup.closest( 'body' ).length ) {
+					return;
+				}
+
+				$popup.popmake( 'reposition' );
+				$popup.find( '.pum-close' ).attr( {
+					'aria-disabled': 'true',
+					tabindex: '-1'
+				} );
+
+				$( document ).trigger( 'pumBuilderPreviewReposition', [ $popup, popupId ] );
+				constrainPopupToVisibleViewport();
+			}
+
+			if ( $popup && $popup.length ) {
+				$popup.on( 'pumBeforeClose.pumBuilderPreview', function () {
+					$popup.addClass( 'preventClose' );
+				} );
+				$popup.on( 'pumAfterOpen.pumBuilderPreview', repositionPopup );
+
+				$container = $popup.find( '.pum-container' );
+
+				if ( 'ResizeObserver' in window && $container.length ) {
+					resizeObserver = new ResizeObserver( repositionPopup );
+					resizeObserver.observe( $container[ 0 ] );
+				}
+			}
+
+			if ( PUM.initialized ) {
+				repositionPopup();
+			} else {
+				$( document ).one( 'pumInitialized.pumBuilderPreview', repositionPopup );
+			}
+
+			$( window ).on( 'resize.pumBuilderPreview', repositionPopup );
+		} )( window.jQuery, window.PUM );
+	</script>
+</body>
+</html>

--- a/tests/php/tests/Builder_Providers_Test.php
+++ b/tests/php/tests/Builder_Providers_Test.php
@@ -1,0 +1,884 @@
+<?php
+/**
+ * Builder provider contract tests.
+ *
+ * @package Popup_Maker
+ */
+
+use PopupMaker\Interfaces\BuilderProvider;
+use PopupMaker\Interfaces\BuilderProvider\EditsPopups;
+use PopupMaker\Interfaces\BuilderProvider\LoadsDocumentAssets;
+use PopupMaker\Interfaces\BuilderProvider\RendersDocuments;
+use PopupMaker\Services\BuilderPreviewUrl;
+use PopupMaker\Services\BuilderProviders;
+
+/**
+ * Test the builder-agnostic provider registry, coordinator, and signed previews.
+ *
+ * These tests deliberately use stub providers rather than a live builder so the
+ * shared contracts are verified without third-party builders installed.
+ */
+class Builder_Providers_Test extends WP_UnitTestCase {
+
+	/**
+	 * Original query parameters.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private $original_get;
+
+	/**
+	 * Preserve request globals.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test fixture preserves request globals.
+		$this->original_get = $_GET;
+	}
+
+	/**
+	 * Restore global state.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		$_GET = $this->original_get;
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The registry only exposes providers whose builder is available.
+	 *
+	 * @return void
+	 */
+	public function test_registry_hides_unavailable_providers() {
+		$registry = new BuilderProviders();
+		$late     = $this->make_provider( 'late', false );
+
+		$registry->register( $this->make_provider( 'present', true ) );
+		$registry->register( $this->make_provider( 'absent', false ) );
+		$registry->register( $late );
+
+		$this->assertSame( [ 'present', 'absent', 'late' ], array_keys( $registry->all() ) );
+		$this->assertSame( [ 'present' ], array_keys( $registry->available() ) );
+		$this->assertNull( $registry->get( 'absent' ) );
+		$this->assertInstanceOf( BuilderProvider::class, $registry->get( 'present' ) );
+
+		$late->available = true;
+
+		$this->assertSame( [ 'present', 'late' ], array_keys( $registry->available() ) );
+
+		global $wp_current_filter;
+
+		$previous_current_filter = $wp_current_filter;
+		$wp_current_filter[]     = 'plugins_loaded';
+
+		try {
+			$controller = $this->make_coordinator( [] );
+		} finally {
+			$wp_current_filter = $previous_current_filter;
+		}
+
+		$this->assertSame( 20, has_action( 'plugins_loaded', [ $controller, 'register_providers' ] ) );
+
+		$extension = $this->make_provider( 'extension', true );
+		$register  = function ( $providers ) use ( $extension ) {
+			if ( $providers instanceof BuilderProviders ) {
+				$providers->register( $extension );
+			}
+		};
+
+		add_action( 'popup_maker/register_builder_providers', $register );
+
+		try {
+			$controller->register_providers();
+
+			$this->assertSame( $extension, $controller->providers()->get( 'extension' ) );
+		} finally {
+			remove_action( 'popup_maker/register_builder_providers', $register );
+			remove_action( 'plugins_loaded', [ $controller, 'register_providers' ], 20 );
+		}
+	}
+
+	/**
+	 * Capability lookups only match providers implementing the interface.
+	 *
+	 * @return void
+	 */
+	public function test_registry_filters_by_capability() {
+		$registry = new BuilderProviders();
+
+		$registry->register( $this->make_provider( 'plain', true ) );
+		$registry->register( $this->make_edit_provider( 'editor', 0 ) );
+
+		$this->assertSame( [ 'editor' ], array_keys( $registry->supporting( EditsPopups::class ) ) );
+		$this->assertSame( [], array_keys( $registry->supporting( RendersDocuments::class ) ) );
+	}
+
+	/**
+	 * A signed preview URL round-trips for the builder that created it.
+	 *
+	 * @return void
+	 */
+	public function test_signed_preview_url_round_trips() {
+		$popup_id   = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$controller = $this->make_coordinator( [ $this->make_provider( 'preview-only', true ) ] );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->apply_request( BuilderPreviewUrl::create( $popup_id, 'preview-only' ) );
+
+		$this->assertSame(
+			[ $popup_id, $popup_id, $popup_id ],
+			[
+				BuilderPreviewUrl::read_request( 'preview-only' ),
+				$controller->get_edit_popup_id(),
+				$controller->allow_builder_request( [] )['p'],
+			],
+			'Signed previews work without EditsPopups and restore the popup query.'
+		);
+	}
+
+	/**
+	 * A signature issued for one builder cannot be replayed against another.
+	 *
+	 * @return void
+	 */
+	public function test_signed_preview_url_is_bound_to_its_builder() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+
+		$this->apply_request( BuilderPreviewUrl::create( $popup_id, 'bricks' ) );
+
+		$this->assertSame( 0, BuilderPreviewUrl::read_request( 'elementor' ) );
+	}
+
+	/**
+	 * A signature issued for one popup cannot be replayed against another.
+	 *
+	 * @return void
+	 */
+	public function test_signed_preview_url_is_bound_to_its_popup() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$other_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+
+		$this->apply_request( BuilderPreviewUrl::create( $popup_id, 'bricks' ) );
+
+		$_GET['p'] = (string) $other_id;
+
+		$this->assertSame( 0, BuilderPreviewUrl::read_request( 'bricks' ) );
+	}
+
+	/**
+	 * Missing or tampered signatures are rejected.
+	 *
+	 * @return void
+	 */
+	public function test_unsigned_preview_requests_are_rejected() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+
+		$_GET = [
+			'pum-builder-preview' => 'bricks',
+			'p'                   => (string) $popup_id,
+		];
+
+		$this->assertSame( 0, BuilderPreviewUrl::read_request( 'bricks' ), 'A missing nonce must be rejected.' );
+
+		$_GET['_wpnonce'] = 'tampered';
+
+		$this->assertSame( 0, BuilderPreviewUrl::read_request( 'bricks' ), 'A tampered nonce must be rejected.' );
+	}
+
+	/**
+	 * An unauthenticated visitor cannot query a popup through a builder request.
+	 *
+	 * @return void
+	 */
+	public function test_logged_out_builder_request_is_not_authorized() {
+		$popup_id   = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$controller = $this->make_coordinator( [ $this->make_edit_provider( 'stub', $popup_id ) ] );
+
+		wp_set_current_user( 0 );
+
+		$this->assertSame( 0, $controller->get_edit_popup_id() );
+		$this->assertSame( [], $controller->allow_builder_request( [] ) );
+	}
+
+	/**
+	 * A user without edit rights on the popup cannot query it.
+	 *
+	 * @return void
+	 */
+	public function test_unauthorized_user_cannot_query_popup() {
+		$popup_id   = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$controller = $this->make_coordinator( [ $this->make_edit_provider( 'stub', $popup_id ) ] );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$this->assertSame( 0, $controller->get_edit_popup_id() );
+	}
+
+	/**
+	 * A builder request naming a non-popup post is ignored.
+	 *
+	 * @return void
+	 */
+	public function test_non_popup_post_is_ignored() {
+		$page_id    = $this->factory->post->create( [ 'post_type' => 'page' ] );
+		$controller = $this->make_coordinator( [ $this->make_edit_provider( 'stub', $page_id ) ] );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->assertSame( 0, $controller->get_edit_popup_id() );
+	}
+
+	/**
+	 * An authorized request restores the popup query.
+	 *
+	 * @return void
+	 */
+	public function test_authorized_request_restores_popup_query() {
+		$popup_id   = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+		$controller = $this->make_coordinator( [ $this->make_edit_provider( 'stub', $popup_id ) ] );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$query_vars = $controller->allow_builder_request( [] );
+
+		$this->assertSame( $popup_id, $query_vars['p'] );
+		$this->assertSame( 'popup', $query_vars['post_type'] );
+		$this->assertArrayNotHasKey( 'post_status', $query_vars, 'Published popups need no status override.' );
+	}
+
+	/**
+	 * A draft popup is queryable by an authorized editor.
+	 *
+	 * Builders open unsaved documents, which are drafts. A front-end query
+	 * returns only published and private posts, so without this the editor 404s.
+	 *
+	 * @return void
+	 */
+	public function test_draft_popup_is_queryable_for_authorized_editor() {
+		$popup_id   = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+		$controller = $this->make_coordinator( [ $this->make_edit_provider( 'stub', $popup_id ) ] );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$query_vars = $controller->allow_builder_request( [] );
+
+		$this->assertSame( 'draft', $query_vars['post_status'] );
+	}
+
+	/**
+	 * A draft canvas preloads its popup before head assets are printed.
+	 *
+	 * @return void
+	 */
+	public function test_draft_canvas_preloads_its_popup_assets() {
+		$popup_id   = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+		$controller = $this->make_coordinator( [ $this->make_edit_provider( 'stub', $popup_id ) ] );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->go_to(
+			add_query_arg(
+				[
+					'post_type' => 'popup',
+					'p'         => $popup_id,
+				],
+				home_url( '/' )
+			)
+		);
+
+		$preloaded = [];
+		$capture   = function ( $loaded_id ) use ( &$preloaded ) {
+			$preloaded[] = absint( $loaded_id );
+		};
+
+		add_action( 'pum_preload_popup', $capture );
+
+		try {
+			do_action( 'wp_enqueue_scripts' );
+		} finally {
+			remove_action( 'pum_preload_popup', $capture );
+		}
+
+		$this->assertContains( $popup_id, $preloaded, 'The draft canvas must enqueue Popup Maker CSS and JavaScript before wp_head().' );
+	}
+
+	/**
+	 * An ordinary front-end request never exposes a popup permalink.
+	 *
+	 * @return void
+	 */
+	public function test_ordinary_request_leaves_query_untouched() {
+		$this->factory->post->create( [ 'post_type' => 'popup' ] );
+
+		$controller = $this->make_coordinator( [ $this->make_edit_provider( 'stub', 0 ) ] );
+
+		$this->assertSame( 0, $controller->get_edit_popup_id() );
+		$this->assertSame( [ 'name' => 'hello-world' ], $controller->allow_builder_request( [ 'name' => 'hello-world' ] ) );
+		$this->assertFalse( get_post_type_object( 'popup' )->publicly_queryable );
+	}
+
+	/**
+	 * A provider that renders the editor shell does not get the popup canvas.
+	 *
+	 * @return void
+	 */
+	public function test_shell_request_does_not_use_popup_canvas() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$provider = $this->make_edit_provider( 'stub', $popup_id, false );
+
+		$controller = $this->make_coordinator( [ $provider ] );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->assertSame( $popup_id, $controller->get_edit_popup_id() );
+		$this->assertSame( 0, $controller->get_canvas_popup_id() );
+		$this->assertSame( 'theme.php', $controller->use_popup_canvas( 'theme.php' ) );
+	}
+
+	/**
+	 * A builder editor shell renders no popups at all.
+	 *
+	 * The shell is a normal front-end request, so without suppression Popup Maker
+	 * renders the popup in its footer as a fixed, full-screen overlay at its own
+	 * stacking order — covering the entire builder interface.
+	 *
+	 * @return void
+	 */
+	public function test_editor_shell_renders_no_popups() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+
+		// A shell request: the provider claims the popup but it is not the canvas.
+		$controller = $this->make_coordinator( [ $this->make_edit_provider( 'stub', $popup_id, false ) ] );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$popups = \PopupMaker\plugin()->get_controller( 'Frontend\Popups' );
+
+		add_action( 'wp_footer', [ $popups, 'render_popups' ] );
+
+		$this->assertSame( 0, $controller->get_canvas_popup_id(), 'The shell is not the canvas.' );
+		$this->assertSame( 'theme.php', $controller->use_popup_canvas( 'theme.php' ), 'The shell keeps its own template.' );
+		$this->assertFalse(
+			has_action( 'wp_footer', [ $popups, 'render_popups' ] ),
+			'The footer render must be suppressed so no popup covers the builder.'
+		);
+	}
+
+	/**
+	 * Many popups collapse into a single finalization per batch boundary.
+	 *
+	 * Directly covers the requirement that six builder popups must not trigger
+	 * six one-time asset bootstraps.
+	 *
+	 * @return void
+	 */
+	public function test_six_popups_finalize_assets_once_per_batch() {
+		$provider   = $this->make_asset_provider( 'stub' );
+		$controller = $this->make_coordinator( [ $provider ] );
+
+		$popup_ids = [];
+
+		for ( $i = 0; $i < 6; $i++ ) {
+			$popup_ids[] = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		}
+
+		foreach ( $popup_ids as $popup_id ) {
+			$controller->render_popup_content( 'original', $popup_id );
+		}
+
+		$this->assertSame( 6, $provider->collected, 'Every popup should be collected.' );
+		$this->assertSame( 0, $provider->finalized, 'Collection alone must not finalize.' );
+
+		$controller->flush_pending_assets();
+		$controller->flush_pending_assets();
+
+		$this->assertSame( 1, $provider->finalized, 'Six popups must finalize once.' );
+		$this->assertFalse( $provider->last_after_head, 'The early batch must run before head output.' );
+	}
+
+	/**
+	 * A popup rendered twice only collects its assets once.
+	 *
+	 * @return void
+	 */
+	public function test_repeated_render_collects_assets_once() {
+		$provider   = $this->make_asset_provider( 'stub' );
+		$controller = $this->make_coordinator( [ $provider ] );
+		$popup_id   = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+
+		$controller->render_popup_content( 'original', $popup_id );
+		$controller->render_popup_content( 'original', $popup_id );
+
+		$this->assertSame( 1, $provider->collected );
+		$this->assertSame( 0, $provider->finalized, 'Rendering twice must not finalize the batch early.' );
+	}
+
+	/**
+	 * A popup discovered after head output finalizes in the late batch.
+	 *
+	 * Mirrors a `popmake-123` click trigger found while filtering the content.
+	 *
+	 * @return void
+	 */
+	public function test_late_discovered_popup_finalizes_after_head() {
+		$provider   = $this->make_asset_provider( 'stub' );
+		$controller = $this->make_coordinator( [ $provider ] );
+
+		// Nothing pending during the early boundary.
+		$controller->flush_pending_assets();
+
+		$this->assertSame( 0, $provider->finalized );
+
+		$controller->render_popup_content( 'original', $this->factory->post->create( [ 'post_type' => 'popup' ] ) );
+		$controller->flush_pending_assets_late();
+
+		$this->assertSame( 1, $provider->finalized );
+		$this->assertTrue( $provider->last_after_head, 'The late batch must report that head output has passed.' );
+	}
+
+	/**
+	 * A failed finalization stays pending for the next boundary.
+	 *
+	 * @return void
+	 */
+	public function test_failed_finalization_is_retried() {
+		$provider           = $this->make_asset_provider( 'stub' );
+		$provider->succeeds = false;
+		$controller         = $this->make_coordinator( [ $provider ] );
+
+		$controller->render_popup_content( 'original', $this->factory->post->create( [ 'post_type' => 'popup' ] ) );
+		$controller->flush_pending_assets();
+
+		$this->assertSame( 1, $provider->finalized );
+
+		$provider->succeeds = true;
+		$controller->flush_pending_assets_late();
+		$controller->flush_pending_assets_late();
+
+		$this->assertSame( 2, $provider->finalized, 'A retried batch finalizes once more, then stops.' );
+	}
+
+	/**
+	 * Content for a popup no builder claims is returned unchanged.
+	 *
+	 * @return void
+	 */
+	public function test_non_builder_popup_content_is_unchanged() {
+		$provider           = $this->make_asset_provider( 'stub' );
+		$provider->is_owner = false;
+		$controller         = $this->make_coordinator( [ $provider ] );
+
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+
+		$this->assertSame( 'original', $controller->render_popup_content( 'original', $popup_id ) );
+		$this->assertSame( 0, $provider->collected );
+
+		$empty_renderer = \Mockery::mock( BuilderProvider::class . ', ' . RendersDocuments::class );
+		$empty_renderer->shouldReceive( 'key' )->andReturn( 'empty-renderer' );
+		$empty_renderer->shouldReceive( 'is_available' )->andReturn( true );
+		$empty_renderer->shouldReceive( 'is_builder_document' )->with( $popup_id )->andReturn( true );
+		$empty_renderer->shouldReceive( 'render_document' )->with( $popup_id )->andReturn( '' );
+
+		try {
+			$controller = $this->make_coordinator( [ $empty_renderer ] );
+
+			$this->assertSame( '', $controller->render_popup_content( 'stale legacy content', $popup_id ) );
+		} finally {
+			\Mockery::close();
+		}
+	}
+
+	/**
+	 * The integration is a no-op when no builder is available.
+	 *
+	 * @return void
+	 */
+	public function test_unavailable_builder_is_a_no_op() {
+		$provider            = $this->make_asset_provider( 'stub' );
+		$provider->available = false;
+		$controller          = $this->make_coordinator( [ $provider ] );
+
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+
+		$this->assertSame( 'original', $controller->render_popup_content( 'original', $popup_id ) );
+		$this->assertSame( 0, $controller->get_edit_popup_id() );
+		$this->assertSame( 0, $controller->get_canvas_popup_id() );
+
+		$controller->flush_pending_assets();
+
+		$this->assertSame( 0, $provider->finalized );
+	}
+
+	/**
+	 * Apply a preview URL's query string to the request globals.
+	 *
+	 * @param string $url Preview URL.
+	 *
+	 * @return void
+	 */
+	private function apply_request( $url ) {
+		$query = (string) wp_parse_url( $url, PHP_URL_QUERY );
+		$args  = [];
+
+		parse_str( $query, $args );
+
+		$_GET = $args;
+	}
+
+	/**
+	 * Build a coordinator seeded with stub providers.
+	 *
+	 * @param BuilderProvider[] $providers Providers to register.
+	 *
+	 * @return \PopupMaker\Controllers\Builders
+	 */
+	private function make_coordinator( array $providers ) {
+		$controller = new class( \PopupMaker\plugin(), $providers ) extends \PopupMaker\Controllers\Builders {
+
+			/**
+			 * Providers to register instead of the bundled ones.
+			 *
+			 * @var BuilderProvider[]
+			 */
+			private $stubs;
+
+			/**
+			 * Construct with stub providers.
+			 *
+			 * @param \PopupMaker\Plugin\Core $container Plugin container.
+			 * @param BuilderProvider[]       $stubs     Providers to register.
+			 */
+			public function __construct( $container, array $stubs ) {
+				$this->stubs = $stubs;
+
+				parent::__construct( $container );
+			}
+
+			/**
+			 * Use the stub providers.
+			 *
+			 * @return BuilderProvider[]
+			 */
+			protected function default_providers() {
+				return $this->stubs;
+			}
+		};
+
+		$controller->init();
+
+		return $controller;
+	}
+
+	/**
+	 * Build a minimal provider.
+	 *
+	 * @param string $key       Provider key.
+	 * @param bool   $available Whether the builder is available.
+	 *
+	 * @return BuilderProvider
+	 */
+	private function make_provider( $key, $available ) {
+		return new class( $key, $available ) implements BuilderProvider {
+
+			/**
+			 * Provider key.
+			 *
+			 * @var string
+			 */
+			private $provider_key;
+
+			/**
+			 * Whether the builder is available.
+			 *
+			 * @var bool
+			 */
+			public $available;
+
+			/**
+			 * Construct the stub.
+			 *
+			 * @param string $key       Provider key.
+			 * @param bool   $available Whether the builder is available.
+			 */
+			public function __construct( $key, $available ) {
+				$this->provider_key = $key;
+				$this->available    = $available;
+			}
+
+			/**
+			 * Provider key.
+			 *
+			 * @return string
+			 */
+			public function key() {
+				return $this->provider_key;
+			}
+
+			/**
+			 * Availability.
+			 *
+			 * @return bool
+			 */
+			public function is_available() {
+				return $this->available;
+			}
+
+			/**
+			 * This stub registers no hooks.
+			 *
+			 * @return void
+			 */
+			public function register_hooks() {}
+		};
+	}
+
+	/**
+	 * Build a provider that claims an editor request.
+	 *
+	 * @param string $key       Provider key.
+	 * @param int    $popup_id  Popup ID to claim.
+	 * @param bool   $is_canvas Whether the request is the isolated canvas.
+	 *
+	 * @return BuilderProvider
+	 */
+	private function make_edit_provider( $key, $popup_id, $is_canvas = true ) {
+		return new class( $key, $popup_id, $is_canvas ) implements BuilderProvider, EditsPopups {
+
+			/**
+			 * Provider key.
+			 *
+			 * @var string
+			 */
+			private $provider_key;
+
+			/**
+			 * Popup ID to claim.
+			 *
+			 * @var int
+			 */
+			private $popup_id;
+
+			/**
+			 * Whether the request is the canvas.
+			 *
+			 * @var bool
+			 */
+			private $is_canvas;
+
+			/**
+			 * Construct the stub.
+			 *
+			 * @param string $key       Provider key.
+			 * @param int    $popup_id  Popup ID to claim.
+			 * @param bool   $is_canvas Whether the request is the canvas.
+			 */
+			public function __construct( $key, $popup_id, $is_canvas ) {
+				$this->provider_key = $key;
+				$this->popup_id     = $popup_id;
+				$this->is_canvas    = $is_canvas;
+			}
+
+			/**
+			 * Provider key.
+			 *
+			 * @return string
+			 */
+			public function key() {
+				return $this->provider_key;
+			}
+
+			/**
+			 * Availability.
+			 *
+			 * @return bool
+			 */
+			public function is_available() {
+				return true;
+			}
+
+			/**
+			 * This stub registers no hooks.
+			 *
+			 * @return void
+			 */
+			public function register_hooks() {}
+
+			/**
+			 * Claimed popup ID.
+			 *
+			 * @return int
+			 */
+			public function get_requested_popup_id() {
+				return $this->popup_id;
+			}
+
+			/**
+			 * Whether this is the canvas request.
+			 *
+			 * @return bool
+			 */
+			public function is_canvas_request() {
+				return $this->is_canvas;
+			}
+		};
+	}
+
+	/**
+	 * Build a provider that owns assets without rendering documents.
+	 *
+	 * @param string $key Provider key.
+	 *
+	 * @return BuilderProvider
+	 */
+	private function make_asset_provider( $key ) {
+		return new class( $key ) implements BuilderProvider, LoadsDocumentAssets {
+
+			/**
+			 * Provider key.
+			 *
+			 * @var string
+			 */
+			private $provider_key;
+
+			/**
+			 * Whether the builder is available.
+			 *
+			 * @var bool
+			 */
+			public $available = true;
+
+			/**
+			 * Whether this builder owns the documents it is asked about.
+			 *
+			 * @var bool
+			 */
+			public $is_owner = true;
+
+			/**
+			 * Whether finalization succeeds.
+			 *
+			 * @var bool
+			 */
+			public $succeeds = true;
+
+			/**
+			 * Number of documents collected.
+			 *
+			 * @var int
+			 */
+			public $collected = 0;
+
+			/**
+			 * Number of finalization attempts.
+			 *
+			 * @var int
+			 */
+			public $finalized = 0;
+
+			/**
+			 * Whether the last finalization reported post-head output.
+			 *
+			 * @var bool
+			 */
+			public $last_after_head = false;
+
+			/**
+			 * Construct the stub.
+			 *
+			 * @param string $key Provider key.
+			 */
+			public function __construct( $key ) {
+				$this->provider_key = $key;
+			}
+
+			/**
+			 * Provider key.
+			 *
+			 * @return string
+			 */
+			public function key() {
+				return $this->provider_key;
+			}
+
+			/**
+			 * Availability.
+			 *
+			 * @return bool
+			 */
+			public function is_available() {
+				return $this->available;
+			}
+
+			/**
+			 * This stub registers no hooks.
+			 *
+			 * @return void
+			 */
+			public function register_hooks() {}
+
+			/**
+			 * Whether this builder owns the document.
+			 *
+			 * @param int $popup_id Popup ID.
+			 *
+			 * @return bool
+			 */
+			public function is_builder_document( $popup_id ) {
+				unset( $popup_id );
+
+				return $this->available && $this->is_owner;
+			}
+
+			/**
+			 * Collect the document's assets.
+			 *
+			 * @param int $popup_id Popup ID.
+			 *
+			 * @return void
+			 */
+			public function collect_document_assets( $popup_id ) {
+				unset( $popup_id );
+
+				++$this->collected;
+			}
+
+			/**
+			 * Finalize collected assets.
+			 *
+			 * @param bool $after_head Whether head output has passed.
+			 *
+			 * @return bool
+			 */
+			public function finalize_document_assets( $after_head ) {
+				$this->last_after_head = (bool) $after_head;
+
+				++$this->finalized;
+
+				return $this->succeeds;
+			}
+		};
+	}
+}

--- a/tests/php/tests/Builder_Providers_Test.php
+++ b/tests/php/tests/Builder_Providers_Test.php
@@ -47,6 +47,10 @@ class Builder_Providers_Test extends WP_UnitTestCase {
 	public function tearDown(): void {
 		$_GET = $this->original_get;
 		wp_set_current_user( 0 );
+		wp_dequeue_script( 'pum-builder-preview' );
+		wp_deregister_script( 'pum-builder-preview' );
+		wp_dequeue_style( 'pum-builder-preview' );
+		wp_deregister_style( 'pum-builder-preview' );
 
 		parent::tearDown();
 	}
@@ -323,6 +327,9 @@ class Builder_Providers_Test extends WP_UnitTestCase {
 		}
 
 		$this->assertContains( $popup_id, $preloaded, 'The draft canvas must enqueue Popup Maker CSS and JavaScript before wp_head().' );
+		$this->assertTrue( wp_script_is( 'pum-builder-preview', 'enqueued' ) );
+		$this->assertTrue( wp_style_is( 'pum-builder-preview', 'enqueued' ) );
+		$this->assertContains( 'pum-builder-preview', $controller->filter_canvas_body_classes( [] ) );
 	}
 
 	/**

--- a/tests/php/tests/Elementor_Compatibility_Test.php
+++ b/tests/php/tests/Elementor_Compatibility_Test.php
@@ -1,0 +1,305 @@
+<?php
+/**
+ * Elementor builder compatibility tests.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Test Elementor popup preview requests.
+ */
+class Elementor_Compatibility_Test extends WP_UnitTestCase {
+
+	/**
+	 * Original query parameters.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private $original_get;
+
+	/**
+	 * Preserve query parameters before each test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test fixture preserves request globals.
+		$this->original_get = $_GET;
+	}
+
+	/**
+	 * Restore global state after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		$_GET = $this->original_get;
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * An authorized Elementor preview can query its popup.
+	 *
+	 * @return void
+	 */
+	public function test_authorized_elementor_preview_restores_popup_post_type() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+		$_GET = [
+			'elementor-preview' => (string) $popup_id,
+			'p'                 => (string) $popup_id,
+			'post_type'         => 'popup',
+		];
+
+		$query_vars = apply_filters( 'request', [ 'p' => (string) $popup_id ] );
+
+		$this->assertSame( $popup_id, $query_vars['p'] );
+		$this->assertSame( 'popup', $query_vars['post_type'] );
+		$this->assertTrue( apply_filters( 'pum_popup_is_loadable', false, $popup_id ) );
+		$this->assertFalse( apply_filters( 'pum_popup_is_loadable', true, $popup_id + 1 ) );
+	}
+
+	/**
+	 * An authorized preview uses the shared popup builder canvas.
+	 *
+	 * @return void
+	 */
+	public function test_authorized_elementor_preview_uses_builder_canvas_template() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+		$_GET = [
+			'elementor-preview' => (string) $popup_id,
+			'p'                 => (string) $popup_id,
+			'post_type'         => 'popup',
+		];
+
+		$original_query  = $GLOBALS['wp_query'];
+		$popups          = \PopupMaker\plugin()->get_controller( 'Frontend\Popups' );
+		$footer_priority = has_action( 'wp_footer', [ $popups, 'render_popups' ] );
+
+		$GLOBALS['wp_query'] = new WP_Query(
+			[
+				'p'           => $popup_id,
+				'post_type'   => 'popup',
+				'post_status' => 'any',
+			]
+		);
+
+		try {
+			$this->assertTrue( apply_filters( 'popup_maker/is_builder_preview', false ) );
+			$this->assertSame(
+				Popup_Maker::$DIR . 'templates/single-popup.php',
+				apply_filters( 'template_include', 'theme-single.php' )
+			);
+			$this->assertFalse( has_action( 'wp_footer', [ $popups, 'render_popups' ] ) );
+		} finally {
+			$GLOBALS['wp_query'] = $original_query;
+
+			if ( false !== $footer_priority && false === has_action( 'wp_footer', [ $popups, 'render_popups' ] ) ) {
+				add_action( 'wp_footer', [ $popups, 'render_popups' ], $footer_priority );
+			}
+		}
+	}
+
+	/**
+	 * Elementor's standalone preview uses the authenticated popup canvas.
+	 *
+	 * @return void
+	 */
+	public function test_elementor_wp_preview_url_uses_popup_canvas() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+
+		$document = new class( $popup_id ) {
+			/**
+			 * Popup ID.
+			 *
+			 * @var int
+			 */
+			private $popup_id;
+
+			/**
+			 * Constructor.
+			 *
+			 * @param int $popup_id Popup ID.
+			 */
+			public function __construct( $popup_id ) {
+				$this->popup_id = $popup_id;
+			}
+
+			/**
+			 * Get the document ID.
+			 *
+			 * @return int Popup ID.
+			 */
+			public function get_main_id() {
+				return $this->popup_id;
+			}
+		};
+
+		$preview_url = apply_filters( 'elementor/document/urls/wp_preview', '', $document );
+		$query       = [];
+		parse_str( (string) wp_parse_url( $preview_url, PHP_URL_QUERY ), $query );
+
+		$this->assertSame( 'popup', $query['post_type'] );
+		$this->assertSame( (string) $popup_id, $query['p'] );
+		$this->assertSame( 'elementor', $query['pum-builder-preview'] );
+		$this->assertNotFalse( wp_verify_nonce( $query['_wpnonce'], 'pum_builder_preview_elementor_' . $popup_id ) );
+	}
+
+	/**
+	 * A valid standalone Elementor preview can query its popup.
+	 *
+	 * @return void
+	 */
+	public function test_authorized_standalone_elementor_preview_restores_popup_post_type() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+		$_GET = [
+			'pum-builder-preview' => 'elementor',
+			'p'                   => (string) $popup_id,
+			'_wpnonce'            => wp_create_nonce( 'pum_builder_preview_elementor_' . $popup_id ),
+		];
+
+		$query_vars = apply_filters( 'request', [ 'p' => (string) $popup_id ] );
+
+		$this->assertSame( $popup_id, $query_vars['p'] );
+		$this->assertSame( 'popup', $query_vars['post_type'] );
+	}
+
+	/**
+	 * An invalid standalone nonce must not expose a popup query.
+	 *
+	 * @return void
+	 */
+	public function test_invalid_standalone_nonce_does_not_restore_popup_post_type() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+		$_GET = [
+			'pum-builder-preview' => 'elementor',
+			'p'                   => (string) $popup_id,
+			'_wpnonce'            => wp_create_nonce( 'pum_builder_preview_elementor_' . ( $popup_id + 1 ) ),
+		];
+
+		$query_vars = apply_filters( 'request', [ 'p' => (string) $popup_id ] );
+
+		$this->assertArrayNotHasKey( 'post_type', $query_vars );
+	}
+
+	/**
+	 * A mismatched preview ID must not expose a popup query.
+	 *
+	 * @return void
+	 */
+	public function test_mismatched_elementor_preview_does_not_restore_popup_post_type() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+		$_GET = [
+			'elementor-preview' => (string) $popup_id,
+			'p'                 => (string) ( $popup_id + 1 ),
+			'post_type'         => 'popup',
+		];
+
+		$query_vars = apply_filters( 'request', [ 'p' => (string) ( $popup_id + 1 ) ] );
+
+		$this->assertArrayNotHasKey( 'post_type', $query_vars );
+	}
+
+	/**
+	 * Logged-out preview requests must remain non-queryable.
+	 *
+	 * @return void
+	 */
+	public function test_logged_out_elementor_preview_does_not_restore_popup_post_type() {
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		$_GET = [
+			'elementor-preview' => (string) $popup_id,
+			'p'                 => (string) $popup_id,
+			'post_type'         => 'popup',
+		];
+
+		$query_vars = apply_filters( 'request', [ 'p' => (string) $popup_id ] );
+
+		$this->assertArrayNotHasKey( 'post_type', $query_vars );
+		$this->assertTrue( apply_filters( 'pum_popup_is_loadable', true, $popup_id ) );
+	}
+
+	/**
+	 * A logged-in user without popup permissions must remain blocked.
+	 *
+	 * @return void
+	 */
+	public function test_user_without_popup_permission_does_not_restore_popup_post_type() {
+		$subscriber_id = $this->factory->user->create( [ 'role' => 'subscriber' ] );
+		$popup_id      = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		wp_set_current_user( $subscriber_id );
+		$_GET = [
+			'elementor-preview' => (string) $popup_id,
+			'p'                 => (string) $popup_id,
+			'post_type'         => 'popup',
+		];
+
+		$query_vars = apply_filters( 'request', [ 'p' => (string) $popup_id ] );
+
+		$this->assertArrayNotHasKey( 'post_type', $query_vars );
+		$this->assertTrue( apply_filters( 'pum_popup_is_loadable', true, $popup_id ) );
+	}
+}

--- a/tests/php/tests/Previews_Test.php
+++ b/tests/php/tests/Previews_Test.php
@@ -1,0 +1,163 @@
+<?php
+/**
+ * Popup preview controller tests.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Test core editor preview behavior after the controller migration.
+ */
+class Previews_Test extends WP_UnitTestCase {
+
+	/**
+	 * Original query parameters.
+	 *
+	 * @var array<string,mixed>
+	 */
+	private $original_get;
+
+	/**
+	 * Preserve query parameters before each test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test fixture preserves request globals.
+		$this->original_get = $_GET;
+	}
+
+	/**
+	 * Restore global state after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		$_GET = $this->original_get;
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * The modern controller owns the preview hooks.
+	 *
+	 * @return void
+	 */
+	public function test_modern_controller_owns_preview_hooks() {
+		$previews = \PopupMaker\plugin()->get_controller( 'Previews' );
+
+		$this->assertInstanceOf( \PopupMaker\Controllers\Previews::class, $previews );
+		$this->assertNotFalse( has_filter( 'pum_popup_is_loadable', [ $previews, 'is_loadable' ] ) );
+		$this->assertFalse( has_filter( 'pum_popup_is_loadable', [ PUM_Previews::class, 'is_loadable' ] ) );
+	}
+
+	/**
+	 * Core editor previews retain their load and debug-trigger behavior.
+	 *
+	 * @return void
+	 */
+	public function test_core_editor_preview_behavior_is_preserved() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+		$_GET = [
+			'popup_preview' => wp_create_nonce( 'popup-preview' ),
+			'popup'         => (string) $popup_id,
+		];
+
+		$settings = apply_filters( 'pum_popup_get_public_settings', [], pum_get_popup( $popup_id ) );
+		$toolbar  = \PopupMaker\plugin()->get_controller( 'Admin\\Toolbar' );
+
+		if ( ! class_exists( 'WP_Admin_Bar' ) ) {
+			require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
+		}
+
+		$admin_bar = new WP_Admin_Bar();
+
+		$toolbar->add_preview_edit_link( $admin_bar );
+		$edit_node = $admin_bar->get_node( 'edit' );
+
+		$this->assertTrue( apply_filters( 'pum_popup_is_loadable', false, $popup_id ) );
+		$this->assertSame( 'admin_debug', $settings['triggers'][0]['type'] );
+		$this->assertInstanceOf( stdClass::class, $edit_node );
+		$this->assertSame( get_edit_post_link( $popup_id, 'raw' ), $edit_node->href );
+		$this->assertSame( get_post_type_object( 'popup' )->labels->edit_item, $edit_node->title );
+
+		$_GET['popup_preview'] = 'tampered';
+		$admin_bar             = new WP_Admin_Bar();
+
+		$toolbar->add_preview_edit_link( $admin_bar );
+
+		$this->assertNull( $admin_bar->get_node( 'edit' ) );
+	}
+
+	/**
+	 * An unknown popup slug fails safely.
+	 *
+	 * @return void
+	 */
+	public function test_unknown_popup_preview_slug_returns_false() {
+		$_GET = [
+			'popup_preview' => wp_create_nonce( 'popup-preview' ),
+			'popup'         => 'missing-popup',
+		];
+
+		$previews = \PopupMaker\plugin()->get_controller( 'Previews' );
+
+		$this->assertFalse( $previews->get_popup_preview() );
+	}
+
+	/**
+	 * Builder previews do not register the popup's live triggers.
+	 *
+	 * @return void
+	 */
+	public function test_builder_preview_strips_live_triggers() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+		$_GET = [
+			'elementor-preview' => (string) $popup_id,
+			'p'                 => (string) $popup_id,
+			'post_type'         => 'popup',
+		];
+
+		$triggers  = [ [ 'type' => 'auto_open' ] ];
+		$data_attr = apply_filters( 'pum_popup_data_attr', [ 'triggers' => $triggers ], $popup_id );
+		$settings  = apply_filters(
+			'pum_popup_get_public_settings',
+			[ 'triggers' => $triggers ],
+			pum_get_popup( $popup_id )
+		);
+		$toolbar   = \PopupMaker\plugin()->get_controller( 'Admin\\Toolbar' );
+
+		if ( ! class_exists( 'WP_Admin_Bar' ) ) {
+			require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
+		}
+
+		$admin_bar = new WP_Admin_Bar();
+
+		$toolbar->add_preview_edit_link( $admin_bar );
+		$edit_node = $admin_bar->get_node( 'edit' );
+
+		$this->assertSame( [], $data_attr['triggers'] );
+		$this->assertSame( [], $settings['triggers'] );
+		$this->assertInstanceOf( stdClass::class, $edit_node );
+		$this->assertSame( get_edit_post_link( $popup_id, 'raw' ), $edit_node->href );
+	}
+}

--- a/webpack.old.config.js
+++ b/webpack.old.config.js
@@ -13,6 +13,8 @@ const srcPath = path.join( process.cwd(), 'assets/js/src' );
 const distPath = path.join( process.cwd(), 'dist/assets' );
 
 const jsBuilds = {
+	// Builder previews
+	'builder-preview': `${ srcPath }/integration/builder-preview.js`,
 	// Site
 	site: `${ srcPath }/site/index.js`,
 	// Admin
@@ -106,7 +108,8 @@ const config = {
 		maxAge: isProduction ? 1000 * 60 * 60 * 24 * 7 : 1000 * 60 * 60 * 24,
 		compression: 'gzip',
 		name: `popup-maker-legacy-${ NODE_ENV }`,
-		version: require( path.resolve( process.cwd(), 'package.json' ) ).version,
+		version: require( path.resolve( process.cwd(), 'package.json' ) )
+			.version,
 	},
 	optimization: {
 		...defaultConfig.optimization,


### PR DESCRIPTION
## Summary

Introduces the shared provider registry, capability interfaces, lifecycle coordinator, signed preview service, and isolated popup canvas, then migrates Elementor as the reference provider.

- Opens Popup Maker popups directly in Elementor.
- Uses the real themed popup canvas for editing and previewing.
- Preserves Elementor document rendering and interactive frontend widgets.
- Centralizes authorization, content routing, preview URLs, and secondary asset batching.
- Preserves the existing Bricks and Divi integrations unchanged; their provider migrations are separate child PRs.

This PR contains shared infrastructure plus Elementor only: 20 files changed. It does not add a Bricks, Divi, or other new builder provider.

## Verification

```text
composer run strauss: PASS
PHPCS on changed PHP files: 6 / 6, 0 issues
Aggregate PHPUnit with Bricks active: 937 tests, 2066 assertions, 2 skipped — PASS
Aggregate PHPUnit with Bricks absent: 937 tests, 2008 assertions, 14 skipped — PASS
PHPStan: 28 pre-existing errors, 0 in changed files
```

## Stack

Base: `develop`.
Next: Bricks in #1294.