### PR TITLE
Add Beaver Builder popup support

### DIFF
--- a/classes/Builders/BeaverBuilder.php
+++ b/classes/Builders/BeaverBuilder.php
@@ -1,0 +1,107 @@
+<?php
+/**
+ * Beaver Builder provider.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Builders;
+
+use PopupMaker\Base\PageBuilder;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers Beaver Builder without duplicating its native Popup Maker support.
+ *
+ * Beaver Builder 2.8+ ships `extensions/fl-builder-popup-maker`, which owns the
+ * integration: post type registration, front-end editing, popup rendering,
+ * per-layout assets, and trigger preloading. Popup Maker only identifies its
+ * native editor request and prevents its broad redirect from claiming another
+ * builder's popup request.
+ *
+ * @since 1.25.0
+ */
+class BeaverBuilder extends PageBuilder {
+
+	/**
+	 * Whether Beaver's native Popup Maker integration is active.
+	 *
+	 * @return bool
+	 */
+	public function is_available() {
+		return defined( 'FL_BUILDER_VERSION' ) &&
+			class_exists( '\FLBuilder' ) &&
+			class_exists( '\FLBuilderPopupMaker' );
+	}
+
+	/**
+	 * Keep Beaver's native popup redirect away from other builders' requests.
+	 *
+	 * Beaver registers the rest of its integration hooks itself. Its generic
+	 * non-builder redirect also matches other builders' popup canvases and signed
+	 * previews, so remove it before the default-priority callback runs there.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_action( 'wp', [ $this, 'preserve_builder_request' ], 0 );
+	}
+
+	/**
+	 * Get the popup ID Beaver Builder is requesting.
+	 *
+	 * Authorization is intentionally absent; the coordinator performs it.
+	 *
+	 * @return int
+	 */
+	public function get_requested_popup_id() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Capability checked by the coordinator.
+		if (
+			! isset( $_GET['fl_builder'] ) ||
+			! isset( $_GET['post_type'], $_GET['p'] ) ||
+			! is_scalar( $_GET['post_type'] ) ||
+			! is_scalar( $_GET['p'] ) ||
+			'popup' !== sanitize_key( wp_unslash( $_GET['post_type'] ) )
+		) {
+			return 0;
+		}
+
+		return absint( wp_unslash( $_GET['p'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * Whether Beaver is rendering the editable iframe or legacy canvas.
+	 *
+	 * Beaver 2.8+ uses a shell marked by `fl_builder_ui` and renders the page in
+	 * `fl_builder_ui_iframe`. Older releases render the canvas directly.
+	 *
+	 * @return bool
+	 */
+	public function is_canvas_request() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Capability checked by the coordinator.
+		return isset( $_GET['fl_builder_ui_iframe'] ) || ! isset( $_GET['fl_builder_ui'] );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * Let an authorized builder request continue to its own canvas.
+	 *
+	 * @return void
+	 */
+	public function preserve_builder_request() {
+		$builders = $this->container->get_controller( 'Builders' );
+
+		if ( ! $builders instanceof \PopupMaker\Controllers\Builders || ! $builders->get_edit_popup_id() ) {
+			return;
+		}
+
+		if ( ! class_exists( '\FLBuilderPopupMaker' ) || ! method_exists( '\FLBuilderPopupMaker', 'redirect_to_admin_edit' ) ) {
+			return;
+		}
+
+		remove_action( 'wp', 'FLBuilderPopupMaker::redirect_to_admin_edit' );
+	}
+}

--- a/classes/Builders/BeaverBuilder.php
+++ b/classes/Builders/BeaverBuilder.php
@@ -74,6 +74,31 @@ class BeaverBuilder extends PageBuilder {
 	}
 
 	/**
+	 * Honor Beaver Builder's own role-access setting.
+	 *
+	 * @param mixed $popup_id Popup ID.
+	 *
+	 * @return bool
+	 */
+	public function can_edit_document( $popup_id ) {
+		if (
+			! is_numeric( $popup_id ) ||
+			! class_exists( '\\FLBuilderUserAccess' ) ||
+			! method_exists( '\\FLBuilderUserAccess', 'current_user_can' )
+		) {
+			return false;
+		}
+
+		try {
+			return (bool) \FLBuilderUserAccess::current_user_can( 'builder_access' );
+		} catch ( \Throwable $error ) {
+			unset( $error );
+
+			return false;
+		}
+	}
+
+	/**
 	 * Whether Beaver is rendering the editable iframe or legacy canvas.
 	 *
 	 * Beaver 2.8+ uses a shell marked by `fl_builder_ui` and renders the page in

--- a/classes/Builders/BeaverBuilder.php
+++ b/classes/Builders/BeaverBuilder.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Registers Beaver Builder without duplicating its native Popup Maker support.
  *
- * Beaver Builder 2.8+ ships `extensions/fl-builder-popup-maker`, which owns the
+ * Beaver Builder ships `extensions/fl-builder-popup-maker`, which owns the
  * integration: post type registration, front-end editing, popup rendering,
  * per-layout assets, and trigger preloading. Popup Maker only identifies its
  * native editor request and prevents its broad redirect from claiming another
@@ -92,8 +92,6 @@ class BeaverBuilder extends PageBuilder {
 		try {
 			return (bool) \FLBuilderUserAccess::current_user_can( 'builder_access' );
 		} catch ( \Throwable $error ) {
-			unset( $error );
-
 			return false;
 		}
 	}
@@ -101,8 +99,8 @@ class BeaverBuilder extends PageBuilder {
 	/**
 	 * Whether Beaver is rendering the editable iframe or legacy canvas.
 	 *
-	 * Beaver 2.8+ uses a shell marked by `fl_builder_ui` and renders the page in
-	 * `fl_builder_ui_iframe`. Older releases render the canvas directly.
+	 * Modern releases use a shell marked by `fl_builder_ui` and render the page
+	 * in `fl_builder_ui_iframe`. Older releases render the canvas directly.
 	 *
 	 * @return bool
 	 */
@@ -133,7 +131,7 @@ class BeaverBuilder extends PageBuilder {
 			return;
 		}
 
-		if ( ! class_exists( '\FLBuilderPopupMaker' ) || ! method_exists( '\FLBuilderPopupMaker', 'redirect_to_admin_edit' ) ) {
+		if ( ! method_exists( '\FLBuilderPopupMaker', 'redirect_to_admin_edit' ) ) {
 			return;
 		}
 

--- a/classes/Builders/BeaverBuilder.php
+++ b/classes/Builders/BeaverBuilder.php
@@ -9,6 +9,7 @@
 namespace PopupMaker\Builders;
 
 use PopupMaker\Base\PageBuilder;
+use PopupMaker\Controllers\Previews;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -93,8 +94,17 @@ class BeaverBuilder extends PageBuilder {
 	 */
 	public function preserve_builder_request() {
 		$builders = $this->container->get_controller( 'Builders' );
+		$previews = $this->container->get_controller( 'Previews' );
+		$popup_id = $builders instanceof \PopupMaker\Controllers\Builders
+			? $builders->get_edit_popup_id()
+			: 0;
 
-		if ( ! $builders instanceof \PopupMaker\Controllers\Builders || ! $builders->get_edit_popup_id() ) {
+		if ( ! $popup_id && $previews instanceof Previews ) {
+			$preview_id = $previews->get_popup_preview();
+			$popup_id   = $preview_id && current_user_can( 'edit_post', $preview_id ) ? $preview_id : 0;
+		}
+
+		if ( ! $popup_id ) {
 			return;
 		}
 

--- a/classes/Builders/BeaverBuilder.php
+++ b/classes/Builders/BeaverBuilder.php
@@ -124,7 +124,11 @@ class BeaverBuilder extends PageBuilder {
 
 		if ( ! $popup_id && $previews instanceof Previews ) {
 			$preview_id = $previews->get_popup_preview();
-			$popup_id   = $preview_id && current_user_can( 'edit_post', $preview_id ) ? $preview_id : 0;
+			$popup_id   = $preview_id &&
+				'popup' === get_post_type( $preview_id ) &&
+				current_user_can( 'edit_post', $preview_id )
+				? $preview_id
+				: 0;
 		}
 
 		if ( ! $popup_id ) {

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -89,11 +89,17 @@ class Builders extends Controller {
 	 * @return class-string<PageBuilder>[]
 	 */
 	protected function detected_builder_classes() {
-		if ( ! defined( 'ELEMENTOR_VERSION' ) && ! did_action( 'elementor/loaded' ) ) {
-			return [];
+		$builders = [];
+
+		if ( defined( 'ELEMENTOR_VERSION' ) || did_action( 'elementor/loaded' ) ) {
+			$builders[] = \PopupMaker\Builders\Elementor::class;
 		}
 
-		return [ \PopupMaker\Builders\Elementor::class ];
+		if ( defined( 'FL_BUILDER_VERSION' ) || class_exists( '\FLBuilder' ) ) {
+			$builders[] = \PopupMaker\Builders\BeaverBuilder::class;
+		}
+
+		return $builders;
 	}
 
 	/**

--- a/tests/php/tests/Beaver_Builder_Test.php
+++ b/tests/php/tests/Beaver_Builder_Test.php
@@ -7,6 +7,10 @@
 
 use PopupMaker\Builders\BeaverBuilder;
 
+if ( ! class_exists( 'FLBuilderPopupMaker' ) ) {
+	require_once __DIR__ . '/fixtures/class-fl-builder-popup-maker.php';
+}
+
 /**
  * Verify the small compatibility layer around Beaver's native integration.
  */
@@ -26,6 +30,8 @@ class Beaver_Builder_Test extends WP_UnitTestCase {
 	/** @return void */
 	public function tearDown(): void {
 		$_GET = $this->original_get;
+		wp_set_current_user( 0 );
+		remove_action( 'wp', 'FLBuilderPopupMaker::redirect_to_admin_edit' );
 
 		parent::tearDown();
 	}
@@ -53,5 +59,22 @@ class Beaver_Builder_Test extends WP_UnitTestCase {
 		unset( $_GET['fl_builder'] );
 
 		$this->assertSame( 0, $builder->get_requested_popup_id() );
+	}
+
+	/** @return void */
+	public function test_signed_popup_preview_bypasses_native_redirect() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		$_GET = [
+			'popup_preview' => wp_create_nonce( 'popup-preview' ),
+			'popup'         => (string) $popup_id,
+		];
+
+		add_action( 'wp', 'FLBuilderPopupMaker::redirect_to_admin_edit' );
+
+		$builder = new BeaverBuilder( \PopupMaker\plugin() );
+		$builder->preserve_builder_request();
+
+		$this->assertFalse( has_action( 'wp', 'FLBuilderPopupMaker::redirect_to_admin_edit' ) );
 	}
 }

--- a/tests/php/tests/Beaver_Builder_Test.php
+++ b/tests/php/tests/Beaver_Builder_Test.php
@@ -11,6 +11,10 @@ if ( ! class_exists( 'FLBuilderPopupMaker' ) ) {
 	require_once __DIR__ . '/fixtures/class-fl-builder-popup-maker.php';
 }
 
+if ( ! class_exists( 'FLBuilderUserAccess' ) ) {
+	require_once __DIR__ . '/fixtures/class-fl-builder-user-access.php';
+}
+
 /**
  * Verify the small compatibility layer around Beaver's native integration.
  */
@@ -33,7 +37,27 @@ class Beaver_Builder_Test extends WP_UnitTestCase {
 		wp_set_current_user( 0 );
 		remove_action( 'wp', 'FLBuilderPopupMaker::redirect_to_admin_edit' );
 
+		if ( property_exists( 'FLBuilderUserAccess', 'can_edit' ) ) {
+			FLBuilderUserAccess::$can_edit = true;
+		}
+
 		parent::tearDown();
+	}
+
+	/** @return void */
+	public function test_builder_access_uses_beaver_role_restriction() {
+		if ( ! property_exists( 'FLBuilderUserAccess', 'can_edit' ) ) {
+			$this->markTestSkipped( 'The active Beaver Builder class is not the test double.' );
+		}
+
+		$builder = new BeaverBuilder( \PopupMaker\plugin() );
+
+		FLBuilderUserAccess::$can_edit = false;
+		$this->assertFalse( $builder->can_edit_document( 123 ) );
+
+		FLBuilderUserAccess::$can_edit = true;
+		$this->assertTrue( $builder->can_edit_document( 123 ) );
+		$this->assertFalse( $builder->can_edit_document( [] ) );
 	}
 
 	/** @return void */

--- a/tests/php/tests/Beaver_Builder_Test.php
+++ b/tests/php/tests/Beaver_Builder_Test.php
@@ -101,4 +101,21 @@ class Beaver_Builder_Test extends WP_UnitTestCase {
 
 		$this->assertFalse( has_action( 'wp', 'FLBuilderPopupMaker::redirect_to_admin_edit' ) );
 	}
+
+	/** @return void */
+	public function test_signed_non_popup_preview_keeps_native_redirect() {
+		$post_id = $this->factory->post->create( [ 'post_type' => 'post' ] );
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		$_GET = [
+			'popup_preview' => wp_create_nonce( 'popup-preview' ),
+			'popup'         => (string) $post_id,
+		];
+
+		add_action( 'wp', 'FLBuilderPopupMaker::redirect_to_admin_edit' );
+
+		$builder = new BeaverBuilder( \PopupMaker\plugin() );
+		$builder->preserve_builder_request();
+
+		$this->assertNotFalse( has_action( 'wp', 'FLBuilderPopupMaker::redirect_to_admin_edit' ) );
+	}
 }

--- a/tests/php/tests/Beaver_Builder_Test.php
+++ b/tests/php/tests/Beaver_Builder_Test.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * Beaver Builder tests.
+ *
+ * @package Popup_Maker
+ */
+
+use PopupMaker\Builders\BeaverBuilder;
+
+/**
+ * Verify the small compatibility layer around Beaver's native integration.
+ */
+class Beaver_Builder_Test extends WP_UnitTestCase {
+
+	/** @var array<string,mixed> */
+	private $original_get;
+
+	/** @return void */
+	public function setUp(): void {
+		parent::setUp();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test fixture preserves request globals.
+		$this->original_get = $_GET;
+	}
+
+	/** @return void */
+	public function tearDown(): void {
+		$_GET = $this->original_get;
+
+		parent::tearDown();
+	}
+
+	/** @return void */
+	public function test_native_editor_request_identifies_shell_and_canvas() {
+		$builder = new BeaverBuilder( \PopupMaker\plugin() );
+
+		$_GET = [
+			'fl_builder'    => '',
+			'fl_builder_ui' => '',
+			'post_type'     => 'popup',
+			'p'             => '123',
+		];
+
+		$this->assertSame( 123, $builder->get_requested_popup_id() );
+		$this->assertFalse( $builder->is_canvas_request() );
+
+		unset( $_GET['fl_builder_ui'] );
+		$_GET['fl_builder_ui_iframe'] = '';
+
+		$this->assertSame( 123, $builder->get_requested_popup_id() );
+		$this->assertTrue( $builder->is_canvas_request() );
+
+		unset( $_GET['fl_builder'] );
+
+		$this->assertSame( 0, $builder->get_requested_popup_id() );
+	}
+}

--- a/tests/php/tests/Page_Builders_Test.php
+++ b/tests/php/tests/Page_Builders_Test.php
@@ -139,11 +139,17 @@ class Page_Builders_Test extends WP_UnitTestCase {
 
 	/** @return void */
 	public function test_inactive_bundled_builders_are_not_loaded_or_constructed() {
-		if ( defined( 'ELEMENTOR_VERSION' ) || did_action( 'elementor/loaded' ) ) {
-			$this->markTestSkipped( 'Elementor is active in this test environment.' );
+		if (
+			defined( 'ELEMENTOR_VERSION' ) ||
+			did_action( 'elementor/loaded' ) ||
+			defined( 'FL_BUILDER_VERSION' ) ||
+			class_exists( 'FLBuilder', false )
+		) {
+			$this->markTestSkipped( 'A bundled builder is active in this test environment.' );
 		}
 
 		$elementor_loaded = class_exists( \PopupMaker\Builders\Elementor::class, false );
+		$beaver_loaded    = class_exists( \PopupMaker\Builders\BeaverBuilder::class, false );
 		$controller       = new class( \PopupMaker\plugin() ) extends \PopupMaker\Controllers\Builders {
 
 			/** @var int */
@@ -164,6 +170,7 @@ class Page_Builders_Test extends WP_UnitTestCase {
 
 		$this->assertSame( 0, $controller->builders_constructed );
 		$this->assertSame( $elementor_loaded, class_exists( \PopupMaker\Builders\Elementor::class, false ) );
+		$this->assertSame( $beaver_loaded, class_exists( \PopupMaker\Builders\BeaverBuilder::class, false ) );
 	}
 
 	/** @return void */

--- a/tests/php/tests/fixtures/class-fl-builder-popup-maker.php
+++ b/tests/php/tests/fixtures/class-fl-builder-popup-maker.php
@@ -1,0 +1,13 @@
+<?php
+/**
+ * Beaver Builder Popup Maker test double.
+ *
+ * @package Popup_Maker
+ */
+
+/** Test double for Beaver Builder's native Popup Maker integration. */
+class FLBuilderPopupMaker {
+
+	/** @return void */
+	public static function redirect_to_admin_edit() {}
+}

--- a/tests/php/tests/fixtures/class-fl-builder-user-access.php
+++ b/tests/php/tests/fixtures/class-fl-builder-user-access.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * Beaver Builder user access test double.
+ *
+ * @package Popup_Maker
+ */
+
+/** Test double for Beaver Builder's role-access API. */
+class FLBuilderUserAccess {
+
+	/** @var bool */
+	public static $can_edit = true;
+
+	/**
+	 * @param string $key Access key.
+	 *
+	 * @return bool
+	 */
+	public static function current_user_can( $key ) {
+		return 'builder_access' === $key && self::$can_edit;
+	}
+}


### PR DESCRIPTION
## Summary

Adds only the interoperability Popup Maker still needs around Beaver Builder's native integration.

Current Beaver Builder releases already ship their own Popup Maker support for post-type registration, front-end editing, popup rendering, layout assets, and preloading. This adapter therefore only:

- Recognizes Beaver's native shell and canvas requests so Popup Maker's shared authorization path understands them.
- Prevents Beaver's broad fallback redirect from intercepting another authorized builder request or a signed Popup Maker preview.
- Honors Beaver Builder's own role-access setting.

It intentionally does not duplicate Beaver's renderer, assets, canvas, or post-type setup.

## Verification

- Full local PHPUnit suite: 947 tests, 2,123 assertions, 2 skipped.
- Focused Beaver and shared builder tests: 19 tests, 74 assertions.
- Targeted PHPStan and PHPCS pass.
- Previously live-tested with Beaver's popup editor and visitor output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Beaver Builder integration with Popup Maker.
  * Beaver Builder editor, canvas, and popup preview requests are now recognized.
  * Editing access is validated using Beaver Builder permissions.
  * Multiple supported page builders can now be detected independently.

* **Bug Fixes**
  * Authorized Beaver Builder editing and popup preview requests remain in the builder interface instead of being redirected away.
  * Non-popup preview requests continue to use the standard redirect behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->