### PR TITLE
Add a systematic pre-PR ablation skill

### DIFF
--- a/.codex/skills/pre-pr-ablation/SKILL.md
+++ b/.codex/skills/pre-pr-ablation/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: pre-pr-ablation
+description: Use before finalizing or opening/updating a PR for non-trivial code changes, especially third-party integrations, compatibility layers, hooks and filters, lifecycle code, providers, abstractions, caching, or asynchronous behavior. Systematically remove and restore experimental code to prove every remaining part is necessary. Do not use for copy-only edits, simple visual UI changes, generated-file updates, or deterministic mechanical refactors.
+---
+
+# Pre-PR Ablation
+
+Ship the smallest behaviorally complete change. Treat working experimental code
+as a hypothesis: remove each part, reproduce the relevant behavior, and retain it
+only when evidence shows that it owns a requirement or failure mode.
+
+## Establish the contract
+
+Before removing anything:
+
+1. List the user-visible behaviors and safety invariants the change must preserve.
+2. Record exact project baselines: test counts, assertions/skips when stable,
+   lint/static-analysis totals, and any accepted pre-existing failures.
+3. Build the smallest realistic fixture for each failure mode. For integrations,
+   use the installed third-party version and its real editor, preview, visitor
+   path, save path, and late/deferred path when applicable.
+4. Record temporary environment changes so they can be restored: options,
+   roles/capabilities, active plugins/themes, fixture metadata, and caches.
+5. Identify regeneration boundaries such as autoloaders, prefixed vendor trees,
+   bundles, compiled CSS, page caches, and application asset caches.
+
+Do not accept computed styles, DOM presence, or a passing assertion as the sole
+evidence for a user-facing workflow. Interact with and inspect the actual UI.
+
+## Inventory every candidate
+
+Review the complete diff and enumerate each independently removable unit:
+
+- hooks, filters, priorities, callbacks, and request recognizers;
+- interfaces, traits, providers, adapters, coordinator branches, and state;
+- retries, memoization, finalizers, fallbacks, feature gates, and catches;
+- JavaScript listeners, ready passes, markers, reinitializers, and CSS overrides;
+- test-only accessors, instrumentation, debug logging, and compatibility shims;
+- duplicated ownership between the application and a third party.
+
+Include existing experimental code touched by the work, not only the latest
+addition. State the claimed behavior for every candidate before testing it.
+
+## Run the ablation loop
+
+Test one candidate at a time:
+
+1. Confirm the full current solution passes the smallest sensitive test and, for
+   user-facing behavior, works in the real UI.
+2. Remove or comment out exactly one candidate. Do not combine removals yet.
+3. Regenerate every artifact needed for the edited layer and invalidate caches.
+4. Repeat the same focused test and UI interaction under the same fixture.
+5. Classify the candidate:
+
+   - `required`: removal reproduces a failure and restoration fixes it;
+   - `conditional`: required only for a named version, mode, timing, or path;
+   - `redundant`: removal changes no contract or safety invariant;
+   - `harmful`: removal fixes behavior or prevents duplicate work;
+   - `unproven`: the test cannot distinguish it; improve the fixture before
+     deciding.
+
+6. Restore required/conditional code and delete redundant/harmful code.
+7. Record the command, meaningful output, and visible result in an ablation
+   table or durable discovery note.
+
+Never keep code merely because it looks defensive. Tie it to a reproduced edge
+case or an explicit invariant. For authorization, validation, escaping, data
+integrity, and destructive-action guards, use adversarial tests instead of
+removing protection on a happy path.
+
+## Prove the abstraction
+
+For integration or framework work:
+
+1. Fit at least two consumers with meaningfully different lifecycles when the
+   available test environment permits it.
+2. Include a negative control that already works natively and should need no
+   integration capability.
+3. Let consumers implement only capabilities they actually possess. Change the
+   interface when a consumer would otherwise fake compliance.
+4. Keep lifecycle, ordering, authorization, batching, and deduplication in the
+   coordinator. Keep each provider operation narrow and third-party-specific.
+5. Separate independent ownership dimensions such as editing, rendering,
+   assets, preview URLs, DOM ownership, and initialization timing.
+6. Gate every third-party call on the required symbol and method at the point of
+   use so API drift becomes a no-op rather than a fatal error.
+
+After single-unit ablations, retest the minimal combined set. One removal can
+make another branch newly redundant, and two individually harmless removals can
+expose a coupling. Exercise early/late timing and coexistence with other active
+integrations.
+
+## Clean and package
+
+Before declaring the branch ready:
+
+1. Remove temporary instrumentation, production test accessors, comments that
+   describe deleted experiments, and unused imports/files.
+2. Restore the runtime environment and clear generated caches once more.
+3. Run the exact full baselines and confirm new code contributes no accepted
+   warning or static-analysis error.
+4. Review the final diff for PHP/language-version constraints, third-party hook
+   defensiveness, and accidental generated or unrelated changes.
+5. Commit by coherent behavioral reason. The PR body should describe the final
+   minimal design, runtime evidence, ablations, exact verification output, and
+   any intentionally native/no-provider paths.
+
+Do not claim a behavior works without the command and its output. Do not finish
+with `unproven` candidates silently present; either improve the experiment,
+remove the candidate, or state the unresolved risk explicitly.

--- a/.codex/skills/pre-pr-ablation/SKILL.md
+++ b/.codex/skills/pre-pr-ablation/SKILL.md
@@ -49,20 +49,24 @@ test failure proves only that the test is coupled to the candidate.
 
 ## Run the ablation loop
 
-Create a reversible checkpoint or patch of the original index and worktree
-before the first ablation. Preserve unrelated changes and never use restoration
-steps that reset or overwrite them.
+Create a reversible checkpoint of every affected state before the first
+ablation: staged and unstaged tracked changes, untracked files, relevant ignored
+or generated artifacts, fixtures, database records, assets, caches, and
+temporary environment settings. Preserve unrelated state and never use
+restoration steps that reset or overwrite it.
 
 Test one candidate at a time:
 
-1. Restore or recreate the fixture and all persistent runtime state from the
-   same pre-trial snapshot. Confirm the full current solution passes the
-   smallest sensitive test and, for user-facing behavior, works in the real UI.
+1. Restore or recreate the complete pre-trial checkpoint and verify that every
+   relevant state matches it. Record the full current solution's result for the
+   smallest sensitive test and real UI. Require a pass unless the candidate is
+   explicitly suspected to be harmful; then record the expected failing
+   baseline and the defect it demonstrates.
 2. Remove exactly one candidate as a coherent change. When it is structural,
    remove its dependent references so the variant remains syntactically valid,
    autoloadable, and interface-compliant without removing unrelated behavior.
-3. Restore the same pre-trial fixture and persistent-state snapshot, regenerate
-   every artifact needed for the edited layer, and invalidate caches.
+3. Restore and verify the same complete pre-trial checkpoint, regenerate every
+   artifact needed for the edited layer, and invalidate caches.
 4. Confirm the variant builds or loads successfully, then repeat the same
    focused test and UI interaction.
 5. Classify the candidate:
@@ -93,8 +97,9 @@ removing protection on a happy path.
 
 For integration or framework work:
 
-1. Fit at least two consumers with meaningfully different lifecycles when the
-   available test environment permits it.
+1. Test at least two consumers with meaningfully different lifecycles before
+   making a cross-lifecycle claim. If the environment cannot provide both,
+   limit the claim and record the missing coverage and unresolved risk.
 2. Include a negative control that already works natively and should need no
    integration capability.
 3. Let consumers implement only capabilities they actually possess. Change the
@@ -122,8 +127,9 @@ Before declaring the branch ready:
 1. Remove temporary instrumentation, production test accessors, comments that
    describe deleted experiments, and unused imports/files.
 2. Restore the runtime environment and clear generated caches once more.
-3. Run the exact full baselines and confirm new code contributes no accepted
-   warning or static-analysis error.
+3. Run the exact full regression and static-analysis checks on the final
+   proposed branch. Compare its failures, skips, warnings, and exit status with
+   the target-branch baseline, and accept no new failure or warning.
 4. Review the final diff for PHP/language-version constraints, third-party hook
    defensiveness, and accidental generated or unrelated changes.
 5. When the project produces a package or deployable artifact, run its

--- a/.codex/skills/pre-pr-ablation/SKILL.md
+++ b/.codex/skills/pre-pr-ablation/SKILL.md
@@ -14,13 +14,16 @@ only when evidence shows that it owns a requirement or failure mode.
 Before removing anything:
 
 1. List the user-visible behaviors and safety invariants the change must preserve.
-2. Record exact project baselines: test counts, assertions/skips when stable,
-   lint/static-analysis totals, and any accepted pre-existing failures.
+2. Run the same checks against the target branch in a separate clean worktree or
+   equivalent isolated checkout before accepting failures or reduced counts as
+   pre-existing. Record its test counts, assertions/skips when stable, and
+   lint/static-analysis totals, then record the proposed change's baseline.
 3. Build the smallest realistic fixture for each failure mode. For integrations,
    use the installed third-party version and its real editor, preview, visitor
    path, save path, and late/deferred path when applicable.
-4. Record temporary environment changes so they can be restored: options,
-   roles/capabilities, active plugins/themes, fixture metadata, and caches.
+4. Record temporary environment and persistent-state changes so they can be
+   restored: options, roles/capabilities, active plugins/themes, database
+   records, fixture metadata, generated assets, and caches.
 5. Identify regeneration boundaries such as autoloaders, prefixed vendor trees,
    bundles, compiled CSS, page caches, and application asset caches.
 
@@ -40,28 +43,46 @@ Review the complete diff and enumerate each independently removable unit:
 
 Include existing experimental code touched by the work, not only the latest
 addition. State the claimed behavior for every candidate before testing it.
+Before ablating a production test accessor or instrumentation hook, make its
+test observe public behavior or use external test instrumentation; otherwise a
+test failure proves only that the test is coupled to the candidate.
 
 ## Run the ablation loop
 
+Create a reversible checkpoint or patch of the original index and worktree
+before the first ablation. Preserve unrelated changes and never use restoration
+steps that reset or overwrite them.
+
 Test one candidate at a time:
 
-1. Confirm the full current solution passes the smallest sensitive test and, for
-   user-facing behavior, works in the real UI.
-2. Remove or comment out exactly one candidate. Do not combine removals yet.
-3. Regenerate every artifact needed for the edited layer and invalidate caches.
-4. Repeat the same focused test and UI interaction under the same fixture.
+1. Restore or recreate the fixture and all persistent runtime state from the
+   same pre-trial snapshot. Confirm the full current solution passes the
+   smallest sensitive test and, for user-facing behavior, works in the real UI.
+2. Remove exactly one candidate as a coherent change. When it is structural,
+   remove its dependent references so the variant remains syntactically valid,
+   autoloadable, and interface-compliant without removing unrelated behavior.
+3. Restore the same pre-trial fixture and persistent-state snapshot, regenerate
+   every artifact needed for the edited layer, and invalidate caches.
+4. Confirm the variant builds or loads successfully, then repeat the same
+   focused test and UI interaction.
 5. Classify the candidate:
 
    - `required`: removal reproduces a failure and restoration fixes it;
    - `conditional`: required only for a named version, mode, timing, or path;
    - `redundant`: removal changes no contract or safety invariant;
-   - `harmful`: removal fixes behavior or prevents duplicate work;
+   - `harmful`: removal fixes behavior or prevents duplicate work and
+     restoration reproduces the defect;
    - `unproven`: the test cannot distinguish it; improve the fixture before
      deciding.
 
-6. Restore required/conditional code and delete redundant/harmful code.
+6. Restore required code. For conditional code, narrow it behind the
+   demonstrated condition or prove it is inert outside that condition, then
+   test both sides. Delete redundant/harmful code.
 7. Record the command, meaningful output, and visible result in an ablation
    table or durable discovery note.
+
+Repeat remove/restore trials when timing or test variance could affect a
+classification. Do not infer causality from a single flaky result.
 
 Never keep code merely because it looks defensive. Tie it to a reproduced edge
 case or an explicit invariant. For authorization, validation, escaping, data
@@ -82,13 +103,17 @@ For integration or framework work:
    coordinator. Keep each provider operation narrow and third-party-specific.
 5. Separate independent ownership dimensions such as editing, rendering,
    assets, preview URLs, DOM ownership, and initialization timing.
-6. Gate every third-party call on the required symbol and method at the point of
-   use so API drift becomes a no-op rather than a fatal error.
+6. Gate optional third-party calls on the required symbol and method at the
+   point of use, and emit an actionable diagnostic when the API is unavailable.
+   Surface an explicit failure for required operations. Fail closed when a call
+   protects authorization, validation, escaping, data integrity, or destructive
+   action safety.
 
 After single-unit ablations, retest the minimal combined set. One removal can
 make another branch newly redundant, and two individually harmless removals can
-expose a coupling. Exercise early/late timing and coexistence with other active
-integrations.
+expose a coupling. When candidates have overlapping ownership, also test viable
+alternative sets rather than assuming the first surviving set is minimal.
+Exercise early/late timing and coexistence with other active integrations.
 
 ## Clean and package
 
@@ -101,10 +126,18 @@ Before declaring the branch ready:
    warning or static-analysis error.
 4. Review the final diff for PHP/language-version constraints, third-party hook
    defensiveness, and accidental generated or unrelated changes.
-5. Commit by coherent behavioral reason. The PR body should describe the final
-   minimal design, runtime evidence, ablations, exact verification output, and
-   any intentionally native/no-provider paths.
+5. When the project produces a package or deployable artifact, run its
+   production package/build check and validate the resulting artifact through
+   the target install or smoke path. Otherwise record why packaging does not
+   apply.
+6. Commit by coherent behavioral reason. The PR body should describe the final
+   minimal design, runtime evidence, ablations, sanitized verification output,
+   and any intentionally native/no-provider paths.
 
-Do not claim a behavior works without the command and its output. Do not finish
-with `unproven` candidates silently present; either improve the experiment,
-remove the candidate, or state the unresolved risk explicitly.
+Do not claim a behavior works without durable evidence. For automated checks,
+record the command and meaningful output. For manual UI checks, record the
+fixture, interaction steps, and visible result. Redact credentials, tokens,
+signed URLs, customer data, and other secrets from recorded commands and output;
+keep unredacted logs only in an appropriately protected local location. Do not
+finish with `unproven` candidates silently present; either improve the
+experiment, remove the candidate, or state the unresolved risk explicitly.

--- a/.codex/skills/pre-pr-ablation/agents/openai.yaml
+++ b/.codex/skills/pre-pr-ablation/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Pre-PR Ablation"
+  short_description: "Prove every nontrivial change is necessary before review."
+  default_prompt: "Use $pre-pr-ablation to prove the smallest behaviorally complete change before opening or updating a PR."

--- a/.codex/skills/pre-pr-ablation/agents/openai.yaml
+++ b/.codex/skills/pre-pr-ablation/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Pre-PR Ablation"
-  short_description: "Prove every nontrivial change is necessary before review."
-  default_prompt: "Use $pre-pr-ablation to prove the smallest behaviorally complete change before opening or updating a PR."
+  short_description: "Ablate in-scope integration and infrastructure changes."
+  default_prompt: "For in-scope integration, compatibility, lifecycle, caching, or asynchronous changes—not copy-only edits, simple visual UI changes, generated-file updates, or deterministic mechanical refactors—use $pre-pr-ablation to prove the smallest behaviorally complete change before review."


### PR DESCRIPTION
## Summary

Adds a repository-local Codex skill for pre-PR cleanup of non-trivial integration and infrastructure work.

The workflow requires agents to:

1. Establish a reproducible behavioral baseline.
2. Inventory the experimental seams.
3. Remove one candidate behavior at a time.
4. Re-run the narrowest meaningful automated and visual checks.
5. Restore only behavior whose removal causes a demonstrated regression.
6. Finish with full regression, static-analysis, diff, and packaging checks.

This keeps experimental tooling out of feature PRs while making the remove/restore discipline reusable for future work.

## Validation

```text
python /Users/danieliser/.codex/skills/.system/skill-creator/scripts/quick_validate.py .codex/skills/pre-pr-ablation
Skill is valid!

git diff --check origin/develop
PASS
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated pre-PR ablation skill for evaluating, testing, and safely removing experimental changes.
  * Added an agent interface with a display name, description, and default prompt for using the skill.

* **Documentation**
  * Added guidance on applicability, isolated baselines, realistic testing, environment restoration, candidate evaluation, evidence collection, cleanup, packaging, secret redaction, and unresolved risks.
  * Documented adversarial testing, abstraction validation, combined-change testing, and reversible workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->