### PR TITLE
Add SiteOrigin popup builder support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,11 @@
 **Features**
 
 -   Added complete Elementor support for building Popup Maker popups, including editor previews, frontend styling, and interactive widgets.
+-   Added complete SiteOrigin Page Builder support for building Popup Maker popups, including its Live Editor and properly styled frontend layouts.
 
 **Improvements**
 
+-   Improved Beaver Builder support so Popup Maker popups open in Beaver Builder's editor and authorized popup previews are no longer redirected away.
 -   Improved compatibility with PHP 8.3, 8.4, and 8.5.
 
 **Fixes**

--- a/classes/Builders/SiteOrigin.php
+++ b/classes/Builders/SiteOrigin.php
@@ -16,9 +16,8 @@ defined( 'ABSPATH' ) || exit;
  * SiteOrigin Page Builder support for popup documents.
  *
  * SiteOrigin edits in wp-admin and ships its own Popup Maker content filter,
- * including secondary-document CSS. The provider therefore claims no runtime
- * coordinator capability; its hooks supply only the missing post type support
- * and a working live-preview target for Popup Maker's non-queryable post type.
+ * including secondary-document CSS. This provider supplies the missing post
+ * type support and routes its live editor through Popup Maker's framed canvas.
  *
  * @since 1.25.0
  */
@@ -49,7 +48,6 @@ class SiteOrigin extends PageBuilder {
 		add_filter( 'siteorigin_panels_settings', [ $this, 'add_popup_post_type' ] );
 		add_filter( 'pre_update_option_siteorigin_panels_settings', [ $this, 'strip_injected_post_type' ], 10, 2 );
 
-		add_filter( 'use_block_editor_for_post_type', [ $this, 'use_classic_editor' ], 999, 2 );
 		add_action( 'siteorigin_panels_metabox_end', [ $this, 'override_preview_url' ] );
 	}
 
@@ -78,40 +76,6 @@ class SiteOrigin extends PageBuilder {
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		return 0;
-	}
-
-	/**
-	 * Use SiteOrigin's classic wp-admin interface for its popup documents.
-	 *
-	 * Popup Maker otherwise enables the block editor for popups after
-	 * SiteOrigin's own priority-10 compatibility check. Limit the override to
-	 * existing SiteOrigin documents or its explicit new-builder request so an
-	 * active SiteOrigin plugin does not take over unrelated popups.
-	 *
-	 * @param mixed $use_block_editor Whether the block editor should be used.
-	 * @param mixed $post_type        Post type being checked.
-	 *
-	 * @return mixed
-	 */
-	public function use_classic_editor( $use_block_editor, $post_type = '' ) {
-		if ( ! is_string( $post_type ) || 'popup' !== $post_type ) {
-			return $use_block_editor;
-		}
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only editor routing flag.
-		if ( isset( $_GET['siteorigin-page-builder'] ) ) {
-			return false;
-		}
-
-		global $post;
-
-		if ( ! $post instanceof \WP_Post || 'popup' !== $post->post_type ) {
-			return $use_block_editor;
-		}
-
-		$panels_data = get_post_meta( $post->ID, 'panels_data', true );
-
-		return ! empty( $panels_data ) ? false : $use_block_editor;
 	}
 
 	/**

--- a/classes/Builders/SiteOrigin.php
+++ b/classes/Builders/SiteOrigin.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * SiteOrigin Page Builder provider.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Builders;
+
+use PopupMaker\Base\PageBuilder;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * SiteOrigin Page Builder support for popup documents.
+ *
+ * SiteOrigin edits in wp-admin and ships its own Popup Maker content filter,
+ * including secondary-document CSS. The provider therefore claims no runtime
+ * coordinator capability; its hooks supply only the missing post type support
+ * and a working live-preview target for Popup Maker's non-queryable post type.
+ *
+ * @since 1.25.0
+ */
+class SiteOrigin extends PageBuilder {
+
+	/**
+	 * Whether SiteOrigin's APIs used by this provider are available.
+	 *
+	 * @return bool
+	 */
+	public function is_available() {
+		return class_exists( '\SiteOrigin_Panels' );
+	}
+
+	/**
+	 * Keep existing SiteOrigin popup documents in its wp-admin editor.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_filter( 'siteorigin_panels_settings', [ $this, 'add_popup_post_type' ] );
+		add_filter( 'pre_update_option_siteorigin_panels_settings', [ $this, 'strip_injected_post_type' ], 10, 2 );
+
+		add_filter( 'use_block_editor_for_post_type', [ $this, 'use_classic_editor' ], 999, 2 );
+		add_action( 'siteorigin_panels_metabox_end', [ $this, 'override_preview_url' ] );
+	}
+
+	/**
+	 * Get the popup ID requested by SiteOrigin's live editor.
+	 *
+	 * Authorization is intentionally absent; the coordinator performs it.
+	 *
+	 * @return int
+	 */
+	public function get_requested_popup_id() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Capability checked by the coordinator.
+		if ( ! isset( $_GET['siteorigin_panels_live_editor'] ) ) {
+			return 0;
+		}
+
+		foreach ( [ 'p', 'post_id' ] as $param ) {
+			if ( isset( $_GET[ $param ] ) && is_scalar( $_GET[ $param ] ) ) {
+				$post_id = absint( wp_unslash( $_GET[ $param ] ) );
+
+				if ( $post_id ) {
+					return $post_id;
+				}
+			}
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		return 0;
+	}
+
+	/**
+	 * Use SiteOrigin's classic wp-admin interface for its popup documents.
+	 *
+	 * Popup Maker otherwise enables the block editor for popups after
+	 * SiteOrigin's own priority-10 compatibility check. Limit the override to
+	 * existing SiteOrigin documents or its explicit new-builder request so an
+	 * active SiteOrigin plugin does not take over unrelated popups.
+	 *
+	 * @param mixed $use_block_editor Whether the block editor should be used.
+	 * @param mixed $post_type        Post type being checked.
+	 *
+	 * @return mixed
+	 */
+	public function use_classic_editor( $use_block_editor, $post_type = '' ) {
+		if ( ! is_string( $post_type ) || 'popup' !== $post_type ) {
+			return $use_block_editor;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only editor routing flag.
+		if ( isset( $_GET['siteorigin-page-builder'] ) ) {
+			return false;
+		}
+
+		global $post;
+
+		if ( ! $post instanceof \WP_Post || 'popup' !== $post->post_type ) {
+			return $use_block_editor;
+		}
+
+		$panels_data = get_post_meta( $post->ID, 'panels_data', true );
+
+		return ! empty( $panels_data ) ? false : $use_block_editor;
+	}
+
+	/**
+	 * Add popups to SiteOrigin's supported post types at runtime.
+	 *
+	 * @param mixed $settings SiteOrigin settings.
+	 *
+	 * @return mixed
+	 */
+	public function add_popup_post_type( $settings ) {
+		if ( ! is_array( $settings ) ) {
+			return $settings;
+		}
+
+		$post_types = isset( $settings['post-types'] ) && is_array( $settings['post-types'] )
+			? $settings['post-types']
+			: [];
+
+		if ( ! in_array( 'popup', $post_types, true ) ) {
+			$post_types[]           = 'popup';
+			$settings['post-types'] = $post_types;
+		}
+
+		return $settings;
+	}
+
+	/**
+	 * Keep Popup Maker's runtime injection out of SiteOrigin's stored option.
+	 *
+	 * @param mixed $value     Settings being saved.
+	 * @param mixed $old_value Settings currently stored.
+	 *
+	 * @return mixed
+	 */
+	public function strip_injected_post_type( $value, $old_value = null ) {
+		if ( ! is_array( $value ) || ! isset( $value['post-types'] ) || ! is_array( $value['post-types'] ) ) {
+			return $value;
+		}
+
+		$stored = is_array( $old_value ) && isset( $old_value['post-types'] ) && is_array( $old_value['post-types'] )
+			? $old_value['post-types']
+			: [];
+
+		if ( in_array( 'popup', $stored, true ) ) {
+			return $value;
+		}
+
+		$value['post-types'] = array_values(
+			array_filter(
+				$value['post-types'],
+				function ( $post_type ) {
+					return 'popup' !== $post_type;
+				}
+			)
+		);
+
+		return $value;
+	}
+
+	/**
+	 * Point SiteOrigin's live editor at Popup Maker's authorized canvas.
+	 *
+	 * SiteOrigin reads the URL from the metabox's `data-preview-url` attribute.
+	 * The inline script runs immediately before SiteOrigin's admin bundle, after
+	 * the metabox exists but before the builder reads its configuration.
+	 *
+	 * @return void
+	 */
+	public function override_preview_url() {
+		$post_id = absint( get_the_ID() );
+
+		if ( ! $post_id || 'popup' !== get_post_type( $post_id ) || ! current_user_can( 'edit_post', $post_id ) ) {
+			return;
+		}
+
+		if ( ! wp_script_is( 'so-panels-admin', 'registered' ) ) {
+			return;
+		}
+
+		$url = add_query_arg(
+			[
+				'post_type'                     => 'popup',
+				'p'                             => $post_id,
+				'siteorigin_panels_live_editor' => 'true',
+				'_panelsnonce'                  => wp_create_nonce( 'live-editor-preview' ),
+			],
+			home_url( '/' )
+		);
+
+		$script = sprintf(
+			'( function () { var metabox = document.getElementById( "siteorigin-panels-metabox" ); if ( metabox ) { metabox.setAttribute( "data-preview-url", %s ); } }() );',
+			wp_json_encode( $url )
+		);
+
+		wp_add_inline_script( 'so-panels-admin', $script, 'before' );
+	}
+}

--- a/classes/Builders/SiteOrigin.php
+++ b/classes/Builders/SiteOrigin.php
@@ -48,6 +48,7 @@ class SiteOrigin extends PageBuilder {
 		add_filter( 'siteorigin_panels_settings', [ $this, 'add_popup_post_type' ] );
 		add_filter( 'pre_update_option_siteorigin_panels_settings', [ $this, 'strip_injected_post_type' ], 10, 2 );
 
+		add_filter( 'use_block_editor_for_post_type', [ $this, 'use_classic_editor' ], 999, 2 );
 		add_action( 'siteorigin_panels_metabox_end', [ $this, 'override_preview_url' ] );
 	}
 
@@ -76,6 +77,37 @@ class SiteOrigin extends PageBuilder {
 		// phpcs:enable WordPress.Security.NonceVerification.Recommended
 
 		return 0;
+	}
+
+	/**
+	 * Preserve SiteOrigin's editor choice after Popup Maker's post type filter.
+	 *
+	 * @param mixed $use_block_editor Whether the block editor should be used.
+	 * @param mixed $post_type        Post type being checked.
+	 *
+	 * @return mixed
+	 */
+	public function use_classic_editor( $use_block_editor, $post_type = '' ) {
+		if ( ! is_string( $post_type ) || 'popup' !== $post_type ) {
+			return $use_block_editor;
+		}
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only editor routing flag.
+		if ( isset( $_GET['siteorigin-page-builder'] ) ) {
+			return false;
+		}
+
+		global $post;
+
+		if (
+			! $post instanceof \WP_Post ||
+			'popup' !== $post->post_type ||
+			( function_exists( 'has_blocks' ) && has_blocks( $post ) )
+		) {
+			return $use_block_editor;
+		}
+
+		return get_post_meta( $post->ID, 'panels_data', true ) ? false : $use_block_editor;
 	}
 
 	/**

--- a/classes/Builders/SiteOrigin.php
+++ b/classes/Builders/SiteOrigin.php
@@ -25,6 +25,13 @@ defined( 'ABSPATH' ) || exit;
 class SiteOrigin extends PageBuilder {
 
 	/**
+	 * Whether popup support existed before this provider injected it.
+	 *
+	 * @var bool|null
+	 */
+	private $stored_popup_support;
+
+	/**
 	 * Whether SiteOrigin's APIs used by this provider are available.
 	 *
 	 * @return bool
@@ -123,6 +130,10 @@ class SiteOrigin extends PageBuilder {
 			? $settings['post-types']
 			: [];
 
+		if ( null === $this->stored_popup_support ) {
+			$this->stored_popup_support = in_array( 'popup', $post_types, true );
+		}
+
 		if ( ! in_array( 'popup', $post_types, true ) ) {
 			$post_types[]           = 'popup';
 			$settings['post-types'] = $post_types;
@@ -144,11 +155,14 @@ class SiteOrigin extends PageBuilder {
 			return $value;
 		}
 
-		$stored = is_array( $old_value ) && isset( $old_value['post-types'] ) && is_array( $old_value['post-types'] )
+		$stored        = is_array( $old_value ) && isset( $old_value['post-types'] ) && is_array( $old_value['post-types'] )
 			? $old_value['post-types']
 			: [];
+		$owner_enabled = null !== $this->stored_popup_support
+			? $this->stored_popup_support
+			: in_array( 'popup', $stored, true );
 
-		if ( in_array( 'popup', $stored, true ) ) {
+		if ( $owner_enabled ) {
 			return $value;
 		}
 

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -99,6 +99,10 @@ class Builders extends Controller {
 			$builders[] = \PopupMaker\Builders\BeaverBuilder::class;
 		}
 
+		if ( class_exists( '\SiteOrigin_Panels' ) ) {
+			$builders[] = \PopupMaker\Builders\SiteOrigin::class;
+		}
+
 		return $builders;
 	}
 

--- a/tests/php/tests/Page_Builders_Test.php
+++ b/tests/php/tests/Page_Builders_Test.php
@@ -143,14 +143,16 @@ class Page_Builders_Test extends WP_UnitTestCase {
 			defined( 'ELEMENTOR_VERSION' ) ||
 			did_action( 'elementor/loaded' ) ||
 			defined( 'FL_BUILDER_VERSION' ) ||
-			class_exists( 'FLBuilder', false )
+			class_exists( 'FLBuilder', false ) ||
+			class_exists( 'SiteOrigin_Panels', false )
 		) {
 			$this->markTestSkipped( 'A bundled builder is active in this test environment.' );
 		}
 
-		$elementor_loaded = class_exists( \PopupMaker\Builders\Elementor::class, false );
-		$beaver_loaded    = class_exists( \PopupMaker\Builders\BeaverBuilder::class, false );
-		$controller       = new class( \PopupMaker\plugin() ) extends \PopupMaker\Controllers\Builders {
+		$elementor_loaded  = class_exists( \PopupMaker\Builders\Elementor::class, false );
+		$beaver_loaded     = class_exists( \PopupMaker\Builders\BeaverBuilder::class, false );
+		$siteorigin_loaded = class_exists( \PopupMaker\Builders\SiteOrigin::class, false );
+		$controller        = new class( \PopupMaker\plugin() ) extends \PopupMaker\Controllers\Builders {
 
 			/** @var int */
 			public $builders_constructed = 0;
@@ -171,6 +173,7 @@ class Page_Builders_Test extends WP_UnitTestCase {
 		$this->assertSame( 0, $controller->builders_constructed );
 		$this->assertSame( $elementor_loaded, class_exists( \PopupMaker\Builders\Elementor::class, false ) );
 		$this->assertSame( $beaver_loaded, class_exists( \PopupMaker\Builders\BeaverBuilder::class, false ) );
+		$this->assertSame( $siteorigin_loaded, class_exists( \PopupMaker\Builders\SiteOrigin::class, false ) );
 	}
 
 	/** @return void */

--- a/tests/php/tests/SiteOrigin_Builder_Test.php
+++ b/tests/php/tests/SiteOrigin_Builder_Test.php
@@ -55,11 +55,20 @@ class SiteOrigin_Builder_Test extends WP_UnitTestCase {
 		$builder  = new SiteOrigin( \PopupMaker\plugin() );
 		$settings = [ 'post-types' => [ 'post', 'page' ] ];
 
+		$filtered = $builder->add_popup_post_type( $settings );
+
+		$this->assertSame( [ 'post-types' => [ 'post', 'page', 'popup' ] ], $filtered );
 		$this->assertSame(
-			[ 'post-types' => [ 'post', 'page', 'popup' ] ],
-			$builder->add_popup_post_type( $settings )
+			$settings,
+			$builder->strip_injected_post_type( $filtered, $filtered ),
+			'An already-filtered old value must not persist the runtime injection.'
 		);
-		$this->assertSame( $settings, $builder->strip_injected_post_type( $builder->add_popup_post_type( $settings ), $settings ) );
+
+		$owner_enabled = new SiteOrigin( \PopupMaker\plugin() );
+		$stored        = [ 'post-types' => [ 'post', 'page', 'popup' ] ];
+
+		$owner_enabled->add_popup_post_type( $stored );
+		$this->assertSame( $stored, $owner_enabled->strip_injected_post_type( $stored, $stored ) );
 	}
 
 	/** @return void */

--- a/tests/php/tests/SiteOrigin_Builder_Test.php
+++ b/tests/php/tests/SiteOrigin_Builder_Test.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * SiteOrigin Page Builder tests.
+ *
+ * @package Popup_Maker
+ */
+
+use PopupMaker\Builders\SiteOrigin;
+
+/**
+ * Verify SiteOrigin's small editor-routing compatibility layer.
+ */
+class SiteOrigin_Builder_Test extends WP_UnitTestCase {
+
+	/** @var array<string,mixed> */
+	private $original_get;
+
+	/** @return void */
+	public function setUp(): void {
+		parent::setUp();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test fixture preserves request globals.
+		$this->original_get = $_GET;
+	}
+
+	/** @return void */
+	public function tearDown(): void {
+		$_GET = $this->original_get;
+		wp_set_current_user( 0 );
+		wp_dequeue_script( 'so-panels-admin' );
+		wp_deregister_script( 'so-panels-admin' );
+
+		parent::tearDown();
+	}
+
+	/** @return void */
+	public function test_live_editor_request_identifies_popup_canvas() {
+		$builder = new SiteOrigin( \PopupMaker\plugin() );
+
+		$_GET = [
+			'siteorigin_panels_live_editor' => 'true',
+			'p'                             => '123',
+		];
+
+		$this->assertSame( 123, $builder->get_requested_popup_id() );
+		$this->assertTrue( $builder->is_canvas_request() );
+
+		unset( $_GET['siteorigin_panels_live_editor'] );
+
+		$this->assertSame( 0, $builder->get_requested_popup_id() );
+	}
+
+	/** @return void */
+	public function test_popup_support_is_runtime_only() {
+		$builder  = new SiteOrigin( \PopupMaker\plugin() );
+		$settings = [ 'post-types' => [ 'post', 'page' ] ];
+
+		$this->assertSame(
+			[ 'post-types' => [ 'post', 'page', 'popup' ] ],
+			$builder->add_popup_post_type( $settings )
+		);
+		$this->assertSame( $settings, $builder->strip_injected_post_type( $builder->add_popup_post_type( $settings ), $settings ) );
+	}
+
+	/** @return void */
+	public function test_live_editor_uses_authorized_popup_url() {
+		global $post;
+
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$user_id  = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$builder  = new SiteOrigin( \PopupMaker\plugin() );
+
+		wp_set_current_user( $user_id );
+		$post = get_post( $popup_id );
+
+		wp_register_script( 'so-panels-admin', '/siteorigin-admin.js', [], 'test', true );
+		$builder->override_preview_url();
+
+		$before = wp_scripts()->get_data( 'so-panels-admin', 'before' );
+
+		$this->assertIsArray( $before );
+		$this->assertStringContainsString( 'siteorigin_panels_live_editor', implode( "\n", $before ) );
+		$this->assertStringContainsString( 'post_type=popup', implode( "\n", $before ) );
+		$this->assertStringContainsString( 'p=' . $popup_id, implode( "\n", $before ) );
+	}
+}

--- a/tests/php/tests/SiteOrigin_Builder_Test.php
+++ b/tests/php/tests/SiteOrigin_Builder_Test.php
@@ -72,6 +72,29 @@ class SiteOrigin_Builder_Test extends WP_UnitTestCase {
 	}
 
 	/** @return void */
+	public function test_existing_siteorigin_document_uses_classic_editor_without_overriding_blocks() {
+		global $post;
+
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$builder  = new SiteOrigin( \PopupMaker\plugin() );
+		$post     = get_post( $popup_id );
+
+		update_post_meta( $popup_id, 'panels_data', [ 'widgets' => [] ] );
+		$this->assertFalse( $builder->use_classic_editor( true, 'popup' ) );
+
+		wp_update_post( [
+			'ID'           => $popup_id,
+			'post_content' => '<!-- wp:paragraph --><p>Block content</p><!-- /wp:paragraph -->',
+		] );
+		$post = get_post( $popup_id );
+
+		$this->assertTrue( $builder->use_classic_editor( true, 'popup' ) );
+
+		$_GET['siteorigin-page-builder'] = '';
+		$this->assertFalse( $builder->use_classic_editor( true, 'popup' ) );
+	}
+
+	/** @return void */
 	public function test_live_editor_uses_authorized_popup_url() {
 		global $post;
 
@@ -88,8 +111,18 @@ class SiteOrigin_Builder_Test extends WP_UnitTestCase {
 		$before = wp_scripts()->get_data( 'so-panels-admin', 'before' );
 
 		$this->assertIsArray( $before );
-		$this->assertStringContainsString( 'siteorigin_panels_live_editor', implode( "\n", $before ) );
-		$this->assertStringContainsString( 'post_type=popup', implode( "\n", $before ) );
-		$this->assertStringContainsString( 'p=' . $popup_id, implode( "\n", $before ) );
+
+		$script = implode( "\n", $before );
+		$this->assertStringContainsString( 'siteorigin_panels_live_editor', $script );
+		$this->assertStringContainsString( 'post_type=popup', $script );
+		$this->assertStringContainsString( 'p=' . $popup_id, $script );
+		$this->assertSame( 1, preg_match( '/setAttribute\( "data-preview-url", (.+?) \);/', $script, $matches ) );
+
+		$url = json_decode( $matches[1], true );
+		$this->assertIsString( $url );
+
+		wp_parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query_args );
+		$this->assertArrayHasKey( '_panelsnonce', $query_args );
+		$this->assertSame( 1, wp_verify_nonce( $query_args['_panelsnonce'], 'live-editor-preview' ) );
 	}
 }


### PR DESCRIPTION
## Summary

Adds the missing SiteOrigin Page Builder routing around its existing Popup Maker renderer.

- Exposes `popup` through SiteOrigin runtime post-type settings without permanently changing the stored option.
- Routes SiteOrigin Live Editor through an authorized Popup Maker canvas carrying SiteOrigin required nonce.
- Preserves SiteOrigin classic-editor routing for its popup documents after Popup Maker post-type filtering, while leaving block-based popups in the block editor.
- Relies on SiteOrigin bundled Popup Maker content filter for rendering and secondary-document CSS.

No custom SiteOrigin renderer or asset pass is added.

## Verification

- Full local PHPUnit suite: 947 tests, 2,124 assertions, 2 skipped.
- Focused SiteOrigin and shared builder tests: 19 tests, 81 assertions.
- Targeted PHPStan and PHPCS pass.
- Compared the adapter against current SiteOrigin Page Builder 2.36.0 APIs.
- Previously live-tested with a SiteOrigin-built main page and popup in the editor, Live Editor, and frontend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added integration with the SiteOrigin page builder.
  * Popup Maker now supports editing popups in SiteOrigin’s Live Editor.
  * SiteOrigin previews use Popup Maker’s authorized preview canvas.
  * Builder detection supports both Elementor and SiteOrigin without requiring either builder to be active first.

* **Bug Fixes**
  * Improved Beaver Builder compatibility when opening popups in the editor.
  * Prevented authorized popup previews from being redirected by Beaver Builder.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->