### PR TITLE
Add Visual Composer popup builder support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 -   Added complete Brizy support for building Popup Maker popups, including visual editing, frontend styling, and interactive elements.
 -   Added complete Elementor support for building Popup Maker popups, including editor previews, frontend styling, and interactive widgets.
 -   Added complete SiteOrigin Page Builder support for building Popup Maker popups, including its Live Editor and properly styled frontend layouts.
+-   Added complete Visual Composer support for building Popup Maker popups, including visual editing, frontend styling, and interactive elements.
 
 **Improvements**
 

--- a/classes/Builders/VisualComposer.php
+++ b/classes/Builders/VisualComposer.php
@@ -49,6 +49,71 @@ class VisualComposer extends PageBuilder {
 	 */
 	public function register_hooks() {
 		add_action( 'wp_enqueue_scripts', [ $this, 'flush_preloaded_assets' ], 12 );
+
+		if ( ! function_exists( 'vchelper' ) ) {
+			return;
+		}
+
+		try {
+			$events = vchelper( 'Events' );
+
+			if ( is_object( $events ) && method_exists( $events, 'listen' ) ) {
+				$events->listen( 'vcv:api:postSaved', [ $this, 'remember_saved_document' ] );
+			}
+		} catch ( \Throwable $error ) {
+			unset( $error );
+		}
+	}
+
+	/**
+	 * Honor Visual Composer's Role Manager and post access rules.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return bool
+	 */
+	public function can_edit_document( $popup_id ) {
+		if ( ! function_exists( 'vchelper' ) ) {
+			return false;
+		}
+
+		try {
+			$access = vchelper( 'AccessUserCapabilities' );
+
+			return is_object( $access ) &&
+				method_exists( $access, 'canEdit' ) &&
+				(bool) $access->canEdit( absint( $popup_id ) );
+		} catch ( \Throwable $error ) {
+			unset( $error );
+
+			return false;
+		}
+	}
+
+	/**
+	 * Remember Visual Composer after its authenticated save event.
+	 *
+	 * Parameter names mirror Visual Composer's associative event payload.
+	 *
+	 * @param mixed $sourceId Saved post ID.
+	 * @param mixed $post     Saved post object.
+	 *
+	 * @return void
+	 */
+	public function remember_saved_document( $sourceId = 0, $post = null ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+		unset( $post );
+
+		if ( ! is_numeric( $sourceId ) ) { // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+			return;
+		}
+
+		$popup_id = absint( $sourceId ); // phpcs:ignore WordPress.NamingConventions.ValidVariableName.VariableNotSnakeCase
+
+		if ( ! $popup_id || ! $this->owns_document( $popup_id ) ) {
+			return;
+		}
+
+		$this->remember_document_owner( $popup_id );
 	}
 
 	/**
@@ -90,7 +155,12 @@ class VisualComposer extends PageBuilder {
 	 * @return bool
 	 */
 	public function owns_document( $popup_id ) {
-		return (bool) get_post_meta( absint( $popup_id ), 'vcv-be-editor', true );
+		$popup_id     = absint( $popup_id );
+		$page_content = get_post_meta( $popup_id, 'vcv-pageContent', true );
+		$saved_editor = get_post_meta( $popup_id, 'vcv-be-editor', true );
+
+		// Mirrors Visual Composer's Gutenberg::isVisualComposerPage() marker.
+		return ! empty( $page_content ) && 'gutenberg' !== $saved_editor;
 	}
 
 	/**

--- a/classes/Builders/VisualComposer.php
+++ b/classes/Builders/VisualComposer.php
@@ -90,13 +90,7 @@ class VisualComposer extends PageBuilder {
 	 * @return bool
 	 */
 	public function owns_document( $popup_id ) {
-		$popup_id = absint( $popup_id );
-
-		if ( $popup_id && $popup_id === $this->get_requested_popup_id() ) {
-			return true;
-		}
-
-		return (bool) get_post_meta( $popup_id, 'vcv-be-editor', true );
+		return (bool) get_post_meta( absint( $popup_id ), 'vcv-be-editor', true );
 	}
 
 	/**

--- a/classes/Builders/VisualComposer.php
+++ b/classes/Builders/VisualComposer.php
@@ -1,0 +1,205 @@
+<?php
+/**
+ * Visual Composer builder integration.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Builders;
+
+use PopupMaker\Base\PageBuilder;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Integrates Visual Composer editing and secondary document assets.
+ *
+ * @since 1.25.0
+ */
+class VisualComposer extends PageBuilder {
+
+	/**
+	 * Popup documents already given to Visual Composer's asset queue.
+	 *
+	 * @var array<int,bool>
+	 */
+	private $collected_documents = [];
+
+	/**
+	 * Whether the current asset batch has been emitted.
+	 *
+	 * @var bool
+	 */
+	private $assets_finalized = false;
+
+	/**
+	 * Whether Visual Composer's request API is available.
+	 *
+	 * @return bool
+	 */
+	public function is_available() {
+		return defined( 'VCV_VERSION' ) && function_exists( 'vchelper' );
+	}
+
+	/**
+	 * Flush popup assets after Popup Maker's normal preload pass.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_action( 'wp_enqueue_scripts', [ $this, 'flush_preloaded_assets' ], 12 );
+	}
+
+	/**
+	 * Get the popup ID requested by Visual Composer's shell or editable page.
+	 *
+	 * @return int
+	 */
+	public function get_requested_popup_id() {
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended -- Capability checked by the coordinator.
+		$is_shell = isset( $_GET['vcv-action'] ) && is_scalar( $_GET['vcv-action'] ) && 'frontend' === sanitize_key( wp_unslash( $_GET['vcv-action'] ) );
+
+		if ( ! $is_shell && ! isset( $_GET['vcv-editable'] ) ) {
+			return 0;
+		}
+
+		if ( ! isset( $_GET['vcv-source-id'] ) || ! is_scalar( $_GET['vcv-source-id'] ) ) {
+			return 0;
+		}
+
+		return absint( wp_unslash( $_GET['vcv-source-id'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * Whether Visual Composer is rendering its editable page.
+	 *
+	 * @return bool
+	 */
+	public function is_canvas_request() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Capability checked by the coordinator.
+		return isset( $_GET['vcv-editable'] );
+	}
+
+	/**
+	 * Whether a popup was saved with Visual Composer.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return bool
+	 */
+	public function owns_document( $popup_id ) {
+		$popup_id = absint( $popup_id );
+
+		if ( $popup_id && $popup_id === $this->get_requested_popup_id() ) {
+			return true;
+		}
+
+		return (bool) get_post_meta( $popup_id, 'vcv-be-editor', true );
+	}
+
+	/**
+	 * Supply the native editor mount or collect visitor assets.
+	 *
+	 * Visitor markup continues through WordPress's normal content pipeline.
+	 *
+	 * @param int  $popup_id         Popup ID.
+	 * @param bool $is_editor_canvas Whether this is the native editor canvas.
+	 *
+	 * @return string|null
+	 */
+	public function render_document( $popup_id, $is_editor_canvas = false ) {
+		if ( $is_editor_canvas ) {
+			return '<div id="vcv-editor"></div>';
+		}
+
+		$this->collect_document_assets( $popup_id );
+
+		if ( did_action( 'wp_head' ) && ! doing_action( 'wp_head' ) ) {
+			$this->finalize_document_assets( true );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Add a secondary popup to Visual Composer's existing asset queue.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return void
+	 */
+	public function collect_document_assets( $popup_id ) {
+		$popup_id = absint( $popup_id );
+
+		if ( ! $popup_id || isset( $this->collected_documents[ $popup_id ] ) || ! function_exists( 'vchelper' ) ) {
+			return;
+		}
+
+		try {
+			$assets = vchelper( 'AssetsEnqueue' );
+
+			if ( ! is_object( $assets ) || ! method_exists( $assets, 'addToEnqueueList' ) ) {
+				return;
+			}
+
+			$assets->addToEnqueueList( $popup_id );
+			$this->collected_documents[ $popup_id ] = true;
+			$this->assets_finalized                 = false;
+		} catch ( \Throwable $error ) {
+			unset( $error );
+		}
+	}
+
+	/**
+	 * Flush assets collected by Popup Maker's preload pass.
+	 *
+	 * @return void
+	 */
+	public function flush_preloaded_assets() {
+		$this->finalize_document_assets( false );
+	}
+
+	/**
+	 * Ask Visual Composer to enqueue the current secondary asset batch.
+	 *
+	 * @param bool $after_head Whether head output has already been sent.
+	 *
+	 * @return bool
+	 */
+	public function finalize_document_assets( $after_head ) {
+		if ( ! $this->collected_documents || $this->assets_finalized ) {
+			return true;
+		}
+
+		if ( ! function_exists( 'vcevent' ) ) {
+			return false;
+		}
+
+		global $wp_styles;
+
+		$before = $wp_styles instanceof \WP_Styles ? (array) $wp_styles->queue : [];
+
+		try {
+			vcevent( 'vcv:assets:enqueue:css:list' );
+		} catch ( \Throwable $error ) {
+			unset( $error );
+
+			return false;
+		}
+
+		if ( $after_head ) {
+			$after = $wp_styles instanceof \WP_Styles ? (array) $wp_styles->queue : [];
+			$new   = array_values( array_diff( $after, $before ) );
+
+			if ( $new ) {
+				wp_print_styles( $new );
+			}
+		}
+
+		$this->assets_finalized = true;
+
+		return true;
+	}
+}

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -107,6 +107,10 @@ class Builders extends Controller {
 			$builders[] = \PopupMaker\Builders\Brizy::class;
 		}
 
+		if ( defined( 'VCV_VERSION' ) || function_exists( 'vchelper' ) ) {
+			$builders[] = \PopupMaker\Builders\VisualComposer::class;
+		}
+
 		return $builders;
 	}
 

--- a/tests/php/fixtures/class-pum-visual-composer-service.php
+++ b/tests/php/fixtures/class-pum-visual-composer-service.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Visual Composer service contract used by test mocks.
+ *
+ * @package Popup_Maker
+ */
+
+/** Visual Composer service methods exercised by the adapter tests. */
+abstract class PUM_Visual_Composer_Service {
+
+	/**
+	 * @param int $post_id Document ID.
+	 * @return void
+	 */
+	abstract public function addToEnqueueList( $post_id ); // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Mirrors Visual Composer's API.
+
+	/**
+	 * @param int $post_id Document ID.
+	 * @return bool
+	 */
+	abstract public function canEdit( $post_id ); // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Mirrors Visual Composer's API.
+
+	/**
+	 * @param string   $event    Event name.
+	 * @param callable $listener Event listener.
+	 * @return void
+	 */
+	abstract public function listen( $event, $listener );
+}

--- a/tests/php/fixtures/visual-composer-api.php
+++ b/tests/php/fixtures/visual-composer-api.php
@@ -13,7 +13,9 @@
  * @return object|null
  */
 function vchelper( $service ) {
-	return 'AssetsEnqueue' === $service ? $GLOBALS['pum_visual_composer_assets'] : null;
+	return isset( $GLOBALS['pum_visual_composer_helpers'][ $service ] )
+		? $GLOBALS['pum_visual_composer_helpers'][ $service ]
+		: null;
 }
 
 /**

--- a/tests/php/fixtures/visual-composer-api.php
+++ b/tests/php/fixtures/visual-composer-api.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Visual Composer API doubles.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Get a Visual Composer service double.
+ *
+ * @param string $service Requested service.
+ *
+ * @return object|null
+ */
+function vchelper( $service ) {
+	return 'AssetsEnqueue' === $service ? $GLOBALS['pum_visual_composer_assets'] : null;
+}
+
+/**
+ * Dispatch a Visual Composer event double.
+ *
+ * @param string $event Event name.
+ *
+ * @return void
+ */
+function vcevent( $event ) {
+	if ( 'vcv:assets:enqueue:css:list' === $event ) {
+		++$GLOBALS['pum_visual_composer_events'];
+	}
+}

--- a/tests/php/tests/Page_Builders_Test.php
+++ b/tests/php/tests/Page_Builders_Test.php
@@ -146,16 +146,19 @@ class Page_Builders_Test extends WP_UnitTestCase {
 			class_exists( 'FLBuilder', false ) ||
 			class_exists( 'SiteOrigin_Panels', false ) ||
 			defined( 'BRIZY_VERSION' ) ||
-			class_exists( 'Brizy_Editor', false )
+			class_exists( 'Brizy_Editor', false ) ||
+			defined( 'VCV_VERSION' ) ||
+			function_exists( 'vchelper' )
 		) {
 			$this->markTestSkipped( 'A bundled builder is active in this test environment.' );
 		}
 
-		$elementor_loaded  = class_exists( \PopupMaker\Builders\Elementor::class, false );
-		$beaver_loaded     = class_exists( \PopupMaker\Builders\BeaverBuilder::class, false );
-		$siteorigin_loaded = class_exists( \PopupMaker\Builders\SiteOrigin::class, false );
-		$brizy_loaded      = class_exists( \PopupMaker\Builders\Brizy::class, false );
-		$controller        = new class( \PopupMaker\plugin() ) extends \PopupMaker\Controllers\Builders {
+		$elementor_loaded       = class_exists( \PopupMaker\Builders\Elementor::class, false );
+		$beaver_loaded          = class_exists( \PopupMaker\Builders\BeaverBuilder::class, false );
+		$siteorigin_loaded      = class_exists( \PopupMaker\Builders\SiteOrigin::class, false );
+		$brizy_loaded           = class_exists( \PopupMaker\Builders\Brizy::class, false );
+		$visual_composer_loaded = class_exists( \PopupMaker\Builders\VisualComposer::class, false );
+		$controller             = new class( \PopupMaker\plugin() ) extends \PopupMaker\Controllers\Builders {
 
 			/** @var int */
 			public $builders_constructed = 0;
@@ -178,6 +181,7 @@ class Page_Builders_Test extends WP_UnitTestCase {
 		$this->assertSame( $beaver_loaded, class_exists( \PopupMaker\Builders\BeaverBuilder::class, false ) );
 		$this->assertSame( $siteorigin_loaded, class_exists( \PopupMaker\Builders\SiteOrigin::class, false ) );
 		$this->assertSame( $brizy_loaded, class_exists( \PopupMaker\Builders\Brizy::class, false ) );
+		$this->assertSame( $visual_composer_loaded, class_exists( \PopupMaker\Builders\VisualComposer::class, false ) );
 	}
 
 	/** @return void */

--- a/tests/php/tests/Visual_Composer_Builder_Test.php
+++ b/tests/php/tests/Visual_Composer_Builder_Test.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * Visual Composer builder tests.
+ *
+ * @package Popup_Maker
+ */
+
+use PopupMaker\Builders\VisualComposer;
+
+/**
+ * Verify Visual Composer request routing and document rendering.
+ */
+class Visual_Composer_Builder_Test extends WP_UnitTestCase {
+
+	/** @var array<string,mixed> */
+	private $original_get;
+
+	/** @return void */
+	public function setUp(): void {
+		parent::setUp();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test fixture preserves request globals.
+		$this->original_get = $_GET;
+	}
+
+	/** @return void */
+	public function tearDown(): void {
+		$_GET = $this->original_get;
+
+		parent::tearDown();
+	}
+
+	/** @return void */
+	public function test_only_editable_request_uses_popup_canvas() {
+		$builder = new VisualComposer( \PopupMaker\plugin() );
+
+		$_GET = [
+			'vcv-action'    => 'frontend',
+			'vcv-source-id' => '123',
+		];
+
+		$this->assertSame( 123, $builder->get_requested_popup_id() );
+		$this->assertFalse( $builder->is_canvas_request() );
+
+		$_GET = [
+			'vcv-editable'  => '1',
+			'vcv-source-id' => '123',
+		];
+
+		$this->assertSame( 123, $builder->get_requested_popup_id() );
+		$this->assertTrue( $builder->is_canvas_request() );
+		$this->assertSame( '<div id="vcv-editor"></div>', $builder->render_document( 123, true ) );
+	}
+
+	/** @return void */
+	public function test_document_ownership_uses_visual_composer_meta() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+		$builder  = new VisualComposer( \PopupMaker\plugin() );
+
+		$this->assertFalse( $builder->owns_document( $popup_id ) );
+
+		$_GET = [
+			'vcv-editable'  => '1',
+			'vcv-source-id' => (string) $popup_id,
+		];
+
+		$this->assertTrue( $builder->owns_document( $popup_id ) );
+
+		$_GET = [];
+
+		update_post_meta( $popup_id, 'vcv-be-editor', '1' );
+
+		$this->assertTrue( $builder->owns_document( $popup_id ) );
+	}
+
+	/** @return void */
+	public function test_secondary_assets_are_batched_and_deduplicated() {
+		if ( function_exists( 'vchelper' ) || function_exists( 'vcevent' ) ) {
+			$this->markTestSkipped( 'This regression test supplies isolated Visual Composer API doubles.' );
+		}
+
+		require_once dirname( __DIR__ ) . '/fixtures/visual-composer-api.php';
+
+		$GLOBALS['pum_visual_composer_assets'] = new class() {
+
+			/** @var int[] */
+			public $posts = [];
+
+			/**
+			 * @param int $post_id Document ID.
+			 * @return void
+			 */
+			// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Mirrors Visual Composer's API.
+			public function addToEnqueueList( $post_id ) {
+				$this->posts[] = absint( $post_id );
+			}
+		};
+		$GLOBALS['pum_visual_composer_events'] = 0;
+
+		$builder = new VisualComposer( \PopupMaker\plugin() );
+		$builder->collect_document_assets( 123 );
+		$builder->collect_document_assets( 123 );
+		$builder->collect_document_assets( 456 );
+		$builder->flush_preloaded_assets();
+		$builder->flush_preloaded_assets();
+
+		$this->assertSame( [ 123, 456 ], $GLOBALS['pum_visual_composer_assets']->posts );
+		$this->assertSame( 1, $GLOBALS['pum_visual_composer_events'] );
+
+		$builder->collect_document_assets( 789 );
+		$builder->finalize_document_assets( true );
+
+		$this->assertSame( [ 123, 456, 789 ], $GLOBALS['pum_visual_composer_assets']->posts );
+		$this->assertSame( 2, $GLOBALS['pum_visual_composer_events'] );
+	}
+}

--- a/tests/php/tests/Visual_Composer_Builder_Test.php
+++ b/tests/php/tests/Visual_Composer_Builder_Test.php
@@ -73,9 +73,13 @@ class Visual_Composer_Builder_Test extends WP_UnitTestCase {
 
 		$_GET = [];
 
-		update_post_meta( $popup_id, 'vcv-be-editor', '1' );
+		update_post_meta( $popup_id, 'vcv-pageContent', rawurlencode( '{"elements":[]}' ) );
 
 		$this->assertTrue( $builder->owns_document( $popup_id ) );
+
+		update_post_meta( $popup_id, 'vcv-be-editor', 'gutenberg' );
+
+		$this->assertFalse( $builder->owns_document( $popup_id ) );
 	}
 
 	/** @return void */
@@ -86,7 +90,7 @@ class Visual_Composer_Builder_Test extends WP_UnitTestCase {
 
 		require_once dirname( __DIR__ ) . '/fixtures/visual-composer-api.php';
 
-		$GLOBALS['pum_visual_composer_assets'] = new class() {
+		$assets                                 = new class() {
 
 			/** @var int[] */
 			public $posts = [];
@@ -100,22 +104,85 @@ class Visual_Composer_Builder_Test extends WP_UnitTestCase {
 				$this->posts[] = absint( $post_id );
 			}
 		};
-		$GLOBALS['pum_visual_composer_events'] = 0;
+		$access                                 = new class() {
 
-		$builder = new VisualComposer( \PopupMaker\plugin() );
+			/** @var bool */
+			public $allowed = true;
+
+			/**
+			 * @param int $post_id Post ID.
+			 * @return bool
+			 */
+			// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Mirrors Visual Composer's API.
+			public function canEdit( $post_id ) {
+				unset( $post_id );
+
+				return $this->allowed;
+			}
+		};
+		$events                                 = new class() {
+
+			/** @var array<string,callable> */
+			public $listeners = [];
+
+			/**
+			 * @param string   $event    Event name.
+			 * @param callable $listener Event listener.
+			 * @return void
+			 */
+			public function listen( $event, $listener ) {
+				$this->listeners[ $event ] = $listener;
+			}
+		};
+		$GLOBALS['pum_visual_composer_helpers'] = [
+			'AccessUserCapabilities' => $access,
+			'AssetsEnqueue'          => $assets,
+			'Events'                 => $events,
+		];
+		$GLOBALS['pum_visual_composer_events']  = 0;
+
+		$builder  = new class( \PopupMaker\plugin() ) extends VisualComposer {
+
+			/** @var int */
+			public $remembered_owner = 0;
+
+			/**
+			 * @param int $popup_id Popup ID.
+			 * @return void
+			 */
+			protected function remember_document_owner( $popup_id ) {
+				$this->remembered_owner = absint( $popup_id );
+			}
+		};
+		$popup_id = self::factory()->post->create( [ 'post_type' => 'popup' ] );
+
+		$this->assertTrue( $builder->can_edit_document( $popup_id ) );
+		$access->allowed = false;
+		$this->assertFalse( $builder->can_edit_document( $popup_id ) );
+		$access->allowed = true;
+
+		$builder->register_hooks();
+		$this->assertArrayHasKey( 'vcv:api:postSaved', $events->listeners );
+
+		update_post_meta( $popup_id, 'vcv-pageContent', rawurlencode( '{"elements":[]}' ) );
+		call_user_func( $events->listeners['vcv:api:postSaved'], $popup_id, get_post( $popup_id ) );
+		$this->assertSame( $popup_id, $builder->remembered_owner );
+
 		$builder->collect_document_assets( 123 );
 		$builder->collect_document_assets( 123 );
 		$builder->collect_document_assets( 456 );
 		$builder->flush_preloaded_assets();
 		$builder->flush_preloaded_assets();
 
-		$this->assertSame( [ 123, 456 ], $GLOBALS['pum_visual_composer_assets']->posts );
+		$this->assertSame( [ 123, 456 ], $assets->posts );
 		$this->assertSame( 1, $GLOBALS['pum_visual_composer_events'] );
 
 		$builder->collect_document_assets( 789 );
 		$builder->finalize_document_assets( true );
 
-		$this->assertSame( [ 123, 456, 789 ], $GLOBALS['pum_visual_composer_assets']->posts );
+		$this->assertSame( [ 123, 456, 789 ], $assets->posts );
 		$this->assertSame( 2, $GLOBALS['pum_visual_composer_events'] );
+
+		remove_action( 'wp_enqueue_scripts', [ $builder, 'flush_preloaded_assets' ], 12 );
 	}
 }

--- a/tests/php/tests/Visual_Composer_Builder_Test.php
+++ b/tests/php/tests/Visual_Composer_Builder_Test.php
@@ -26,6 +26,7 @@ class Visual_Composer_Builder_Test extends WP_UnitTestCase {
 	/** @return void */
 	public function tearDown(): void {
 		$_GET = $this->original_get;
+		\Mockery::close();
 
 		parent::tearDown();
 	}
@@ -82,58 +83,49 @@ class Visual_Composer_Builder_Test extends WP_UnitTestCase {
 		$this->assertFalse( $builder->owns_document( $popup_id ) );
 	}
 
-	/** @return void */
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 * @return void
+	 */
 	public function test_secondary_assets_are_batched_and_deduplicated() {
 		if ( function_exists( 'vchelper' ) || function_exists( 'vcevent' ) ) {
 			$this->markTestSkipped( 'This regression test supplies isolated Visual Composer API doubles.' );
 		}
 
+		require_once dirname( __DIR__ ) . '/fixtures/class-pum-visual-composer-service.php';
 		require_once dirname( __DIR__ ) . '/fixtures/visual-composer-api.php';
 
-		$assets                                 = new class() {
+		$posts     = [];
+		$allowed   = true;
+		$listeners = [];
+		$assets    = \Mockery::mock( PUM_Visual_Composer_Service::class );
+		$assets->shouldReceive( 'addToEnqueueList' )
+			->times( 3 )
+			->andReturnUsing(
+				function ( $post_id ) use ( &$posts ) {
+					$posts[] = absint( $post_id );
+				}
+			);
+		$access = \Mockery::mock( PUM_Visual_Composer_Service::class );
+		$access->shouldReceive( 'canEdit' )
+			->twice()
+			->andReturnUsing(
+				function ( $post_id ) use ( &$allowed ) {
+					unset( $post_id );
 
-			/** @var int[] */
-			public $posts = [];
-
-			/**
-			 * @param int $post_id Document ID.
-			 * @return void
-			 */
-			// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Mirrors Visual Composer's API.
-			public function addToEnqueueList( $post_id ) {
-				$this->posts[] = absint( $post_id );
-			}
-		};
-		$access                                 = new class() {
-
-			/** @var bool */
-			public $allowed = true;
-
-			/**
-			 * @param int $post_id Post ID.
-			 * @return bool
-			 */
-			// phpcs:ignore WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid -- Mirrors Visual Composer's API.
-			public function canEdit( $post_id ) {
-				unset( $post_id );
-
-				return $this->allowed;
-			}
-		};
-		$events                                 = new class() {
-
-			/** @var array<string,callable> */
-			public $listeners = [];
-
-			/**
-			 * @param string   $event    Event name.
-			 * @param callable $listener Event listener.
-			 * @return void
-			 */
-			public function listen( $event, $listener ) {
-				$this->listeners[ $event ] = $listener;
-			}
-		};
+					return $allowed;
+				}
+			);
+		$events = \Mockery::mock( PUM_Visual_Composer_Service::class );
+		$events->shouldReceive( 'listen' )
+			->once()
+			->with( 'vcv:api:postSaved', \Mockery::type( 'callable' ) )
+			->andReturnUsing(
+				function ( $event, $listener ) use ( &$listeners ) {
+					$listeners[ $event ] = $listener;
+				}
+			);
 		$GLOBALS['pum_visual_composer_helpers'] = [
 			'AccessUserCapabilities' => $access,
 			'AssetsEnqueue'          => $assets,
@@ -157,15 +149,14 @@ class Visual_Composer_Builder_Test extends WP_UnitTestCase {
 		$popup_id = self::factory()->post->create( [ 'post_type' => 'popup' ] );
 
 		$this->assertTrue( $builder->can_edit_document( $popup_id ) );
-		$access->allowed = false;
+		$allowed = false;
 		$this->assertFalse( $builder->can_edit_document( $popup_id ) );
-		$access->allowed = true;
 
 		$builder->register_hooks();
-		$this->assertArrayHasKey( 'vcv:api:postSaved', $events->listeners );
+		$this->assertArrayHasKey( 'vcv:api:postSaved', $listeners );
 
 		update_post_meta( $popup_id, 'vcv-pageContent', rawurlencode( '{"elements":[]}' ) );
-		call_user_func( $events->listeners['vcv:api:postSaved'], $popup_id, get_post( $popup_id ) );
+		call_user_func( $listeners['vcv:api:postSaved'], $popup_id, get_post( $popup_id ) );
 		$this->assertSame( $popup_id, $builder->remembered_owner );
 
 		$builder->collect_document_assets( 123 );
@@ -174,13 +165,13 @@ class Visual_Composer_Builder_Test extends WP_UnitTestCase {
 		$builder->flush_preloaded_assets();
 		$builder->flush_preloaded_assets();
 
-		$this->assertSame( [ 123, 456 ], $assets->posts );
+		$this->assertSame( [ 123, 456 ], $posts );
 		$this->assertSame( 1, $GLOBALS['pum_visual_composer_events'] );
 
 		$builder->collect_document_assets( 789 );
 		$builder->finalize_document_assets( true );
 
-		$this->assertSame( [ 123, 456, 789 ], $assets->posts );
+		$this->assertSame( [ 123, 456, 789 ], $posts );
 		$this->assertSame( 2, $GLOBALS['pum_visual_composer_events'] );
 
 		remove_action( 'wp_enqueue_scripts', [ $builder, 'flush_preloaded_assets' ], 12 );

--- a/tests/php/tests/Visual_Composer_Builder_Test.php
+++ b/tests/php/tests/Visual_Composer_Builder_Test.php
@@ -69,7 +69,7 @@ class Visual_Composer_Builder_Test extends WP_UnitTestCase {
 			'vcv-source-id' => (string) $popup_id,
 		];
 
-		$this->assertTrue( $builder->owns_document( $popup_id ) );
+		$this->assertFalse( $builder->owns_document( $popup_id ), 'A request alone must not claim frontend ownership.' );
 
 		$_GET = [];
 


### PR DESCRIPTION
## Summary

Adds complete Visual Composer support with one focused adapter and one lazy detector.

- Honors Visual Composer Role Manager access.
- Recognizes its separate editor shell and editable iframe requests.
- Supplies the native Visual Composer editor mount inside the real Popup Maker themed container.
- Leaves visitor markup in the normal WordPress content pipeline.
- Adds each secondary popup once to Visual Composer's native asset queue and emits one CSS batch, including styles discovered after the document head.
- Adds no Visual Composer-specific preview script or positioning workaround.
- Adds an Unreleased changelog entry for Visual Composer support.

The branch is based directly on `develop` and has no dependency on another builder PR.

## Verification

- Full PHPUnit: 958 tests, 2,178 assertions, 2 environment-dependent skips.
- Focused PHPUnit: 18 tests, 84 assertions.
- PHPCS, targeted PHPStan, and git diff check passed.
- Previously live-tested with Visual Composer 45.16.1.
- Confirmed a Visual Composer-built main page and popup render together without duplicate stylesheet URLs.
- Confirmed editor controls and saving, site-theme background, Popup Maker theme and close control, and configured popup geometry.
