### PR TITLE
Add complete Elementor support for Popup Maker popups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+**Features**
+
+-   Added complete Elementor support for building Popup Maker popups, including editor previews, frontend styling, and interactive widgets.
+
 **Improvements**
 
 -   Improved compatibility with PHP 8.3, 8.4, and 8.5.

--- a/assets/js/src/integration/elementor.js
+++ b/assets/js/src/integration/elementor.js
@@ -4,27 +4,26 @@
 {
 	const formProvider = 'elementor';
 	const $ = window.jQuery;
+	const refreshedElements = new WeakSet();
 
 	const refreshWidgets = ( popup ) => {
-		const elementorRoot = popup.querySelector( '.elementor' );
-
-		if ( ! elementorRoot ) {
-			return;
-		}
-
 		if (
 			window.elementorFrontend &&
 			window.elementorFrontend.elementsHandler &&
 			typeof window.elementorFrontend.elementsHandler.runReadyTrigger ===
 				'function'
 		) {
-			$( elementorRoot )
-				.find( '[data-element_type]' )
-				.addBack( '[data-element_type]' )
+			$( popup )
+				.find( '.elementor [data-element_type]' )
 				.each( function () {
+					if ( refreshedElements.has( this ) ) {
+						return;
+					}
+
 					window.elementorFrontend.elementsHandler.runReadyTrigger(
 						this
 					);
+					refreshedElements.add( this );
 				} );
 		}
 	};
@@ -47,7 +46,7 @@
 	} );
 
 	// Reinitialize Elementor widgets after their popup becomes visible.
-	$( document ).on( 'pumAfterOpen', '.pum', function () {
+	$( document ).on( 'pumAfterOpen.pumElementor', '.pum', function () {
 		refreshWidgets( this );
 	} );
 }

--- a/assets/js/src/integration/elementor.js
+++ b/assets/js/src/integration/elementor.js
@@ -5,24 +5,49 @@
 	const formProvider = 'elementor';
 	const $ = window.jQuery;
 
-	// Elementor Forms success event.
-	$( document ).on(
-		'submit_success',
-		'.elementor-form',
-		function ( event, response ) {
-			const $form = $( this )[ 0 ];
+	const refreshWidgets = ( popup ) => {
+		const elementorRoot = popup.querySelector( '.elementor' );
 
-			// Get element_id from the widget container.
-			// Elementor form widgets are inside a .elementor-element-{id} container.
-			const $widget = $( this ).closest( '[data-id]' );
-			const elementId = $widget.length
-				? $widget.attr( 'data-id' )
-				: 'unknown';
-
-			window.PUM.integrations.formSubmission( $form, {
-				formProvider,
-				formId: elementId,
-			} );
+		if ( ! elementorRoot ) {
+			return;
 		}
-	);
+
+		if (
+			window.elementorFrontend &&
+			window.elementorFrontend.elementsHandler &&
+			typeof window.elementorFrontend.elementsHandler.runReadyTrigger ===
+				'function'
+		) {
+			$( elementorRoot )
+				.find( '[data-element_type]' )
+				.addBack( '[data-element_type]' )
+				.each( function () {
+					window.elementorFrontend.elementsHandler.runReadyTrigger(
+						this
+					);
+				} );
+		}
+	};
+
+	// Elementor Forms success event.
+	$( document ).on( 'submit_success', '.elementor-form', function () {
+		const $form = $( this );
+
+		// Get element_id from the widget container.
+		// Elementor form widgets are inside a .elementor-element-{id} container.
+		const $widget = $( this ).closest( '[data-id]' );
+		const elementId = $widget.length
+			? $widget.attr( 'data-id' )
+			: 'unknown';
+
+		window.PUM.integrations.formSubmission( $form, {
+			formProvider,
+			formId: elementId,
+		} );
+	} );
+
+	// Reinitialize Elementor widgets after their popup becomes visible.
+	$( document ).on( 'pumAfterOpen', '.pum', function () {
+		refreshWidgets( this );
+	} );
 }

--- a/assets/js/src/integration/elementor.js
+++ b/assets/js/src/integration/elementor.js
@@ -4,49 +4,25 @@
 {
 	const formProvider = 'elementor';
 	const $ = window.jQuery;
-	const refreshedElements = new WeakSet();
-
-	const refreshWidgets = ( popup ) => {
-		if (
-			window.elementorFrontend &&
-			window.elementorFrontend.elementsHandler &&
-			typeof window.elementorFrontend.elementsHandler.runReadyTrigger ===
-				'function'
-		) {
-			$( popup )
-				.find( '.elementor [data-element_type]' )
-				.each( function () {
-					if ( refreshedElements.has( this ) ) {
-						return;
-					}
-
-					window.elementorFrontend.elementsHandler.runReadyTrigger(
-						this
-					);
-					refreshedElements.add( this );
-				} );
-		}
-	};
 
 	// Elementor Forms success event.
-	$( document ).on( 'submit_success', '.elementor-form', function () {
-		const $form = $( this );
+	$( document ).on(
+		'submit_success',
+		'.elementor-form',
+		function ( event, response ) {
+			const $form = $( this )[ 0 ];
 
-		// Get element_id from the widget container.
-		// Elementor form widgets are inside a .elementor-element-{id} container.
-		const $widget = $( this ).closest( '[data-id]' );
-		const elementId = $widget.length
-			? $widget.attr( 'data-id' )
-			: 'unknown';
+			// Get element_id from the widget container.
+			// Elementor form widgets are inside a .elementor-element-{id} container.
+			const $widget = $( this ).closest( '[data-id]' );
+			const elementId = $widget.length
+				? $widget.attr( 'data-id' )
+				: 'unknown';
 
-		window.PUM.integrations.formSubmission( $form, {
-			formProvider,
-			formId: elementId,
-		} );
-	} );
-
-	// Reinitialize Elementor widgets after their popup becomes visible.
-	$( document ).on( 'pumAfterOpen.pumElementor', '.pum', function () {
-		refreshWidgets( this );
-	} );
+			window.PUM.integrations.formSubmission( $form, {
+				formProvider,
+				formId: elementId,
+			} );
+		}
+	);
 }

--- a/classes/Base/PageBuilder.php
+++ b/classes/Base/PageBuilder.php
@@ -78,6 +78,21 @@ abstract class PageBuilder {
 	}
 
 	/**
+	 * Remember this builder after its native editor saves a popup.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return void
+	 */
+	protected function remember_document_owner( $popup_id ) {
+		$builders = $this->container->get_controller( 'Builders' );
+
+		if ( $builders instanceof \PopupMaker\Controllers\Builders ) {
+			$builders->remember_document_owner( $this, $popup_id );
+		}
+	}
+
+	/**
 	 * Whether the native builder request is its editable canvas.
 	 *
 	 * Frontend builders may claim a separate shell request and return false.

--- a/classes/Base/PageBuilder.php
+++ b/classes/Base/PageBuilder.php
@@ -62,6 +62,22 @@ abstract class PageBuilder {
 	}
 
 	/**
+	 * Whether the current user satisfies this builder's own access rules.
+	 *
+	 * The controller already verifies WordPress's per-post capability. Override
+	 * this only when the builder applies an additional permission layer.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return bool
+	 */
+	public function can_edit_document( $popup_id ) {
+		unset( $popup_id );
+
+		return true;
+	}
+
+	/**
 	 * Whether the native builder request is its editable canvas.
 	 *
 	 * Frontend builders may claim a separate shell request and return false.

--- a/classes/Base/PageBuilder.php
+++ b/classes/Base/PageBuilder.php
@@ -72,8 +72,6 @@ abstract class PageBuilder {
 	 * @return bool
 	 */
 	public function can_edit_document( $popup_id ) {
-		unset( $popup_id );
-
 		return true;
 	}
 
@@ -111,8 +109,6 @@ abstract class PageBuilder {
 	 * @return bool
 	 */
 	public function owns_document( $popup_id ) {
-		unset( $popup_id );
-
 		return false;
 	}
 
@@ -127,8 +123,6 @@ abstract class PageBuilder {
 	 * @return string|null
 	 */
 	public function render_document( $popup_id, $is_editor_canvas = false ) {
-		unset( $popup_id, $is_editor_canvas );
-
 		return null;
 	}
 }

--- a/classes/Builders/Elementor.php
+++ b/classes/Builders/Elementor.php
@@ -158,7 +158,12 @@ class Elementor extends PageBuilder {
 		if ( $is_canvas && method_exists( $frontend, 'get_builder_content' ) ) {
 			$rendered = $frontend->get_builder_content( $popup_id );
 		} elseif ( method_exists( $frontend, 'get_builder_content_for_display' ) ) {
-			$rendered = $frontend->get_builder_content_for_display( $popup_id );
+			// Elementor enqueues document CSS before the head and prints it inline
+			// when Popup Maker discovers the document after the head has passed.
+			$rendered = $frontend->get_builder_content_for_display(
+				$popup_id,
+				(bool) did_action( 'wp_head' )
+			);
 		} else {
 			return null;
 		}

--- a/classes/Builders/Elementor.php
+++ b/classes/Builders/Elementor.php
@@ -80,8 +80,8 @@ class Elementor extends PageBuilder {
 	 * @return int
 	 */
 	public function get_requested_popup_id() {
-		// Elementor's iframe carries no nonce; access rests on the per-popup
-		// capability check applied by the controller.
+		// Elementor's iframe carries no nonce. The controller applies a per-popup
+		// capability check.
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		if (
 			! isset( $_GET['elementor-preview'], $_GET['p'], $_GET['post_type'] ) ||

--- a/classes/Builders/Elementor.php
+++ b/classes/Builders/Elementor.php
@@ -138,25 +138,31 @@ class Elementor extends PageBuilder {
 	/**
 	 * Render a popup through Elementor's public frontend API.
 	 *
-	 * @param int  $popup_id Popup ID.
-	 * @param bool $is_canvas Whether Elementor is rendering its editor canvas.
+	 * @param int  $popup_id        Popup ID.
+	 * @param bool $is_editor_canvas Whether Elementor is rendering its editor canvas.
 	 *
 	 * @return string|null
 	 */
-	public function render_document( $popup_id, $is_canvas = false ) {
+	public function render_document( $popup_id, $is_editor_canvas = false ) {
 		if ( ! $this->is_ready() ) {
 			return null;
 		}
 
-		$popup_id = absint( $popup_id );
-		$frontend = \Elementor\Plugin::$instance->frontend;
+		$popup_id          = absint( $popup_id );
+		$frontend          = \Elementor\Plugin::$instance->frontend;
+		$is_signed_preview = absint( BuilderPreviewUrl::read_request( $this->key() ) ) === $popup_id;
 
 		// Lets Elementor and third-party widgets register state for this
 		// secondary document before its markup is generated.
 		do_action( 'elementor/post/render', $popup_id );
 
-		if ( $is_canvas && method_exists( $frontend, 'get_builder_content' ) ) {
-			$rendered = $frontend->get_builder_content( $popup_id );
+		if ( ( $is_editor_canvas || $is_signed_preview ) && method_exists( $frontend, 'get_builder_content' ) ) {
+			// Elementor's display helper intentionally returns empty when the
+			// requested document is also the current standalone preview document.
+			$rendered = $frontend->get_builder_content(
+				$popup_id,
+				$is_signed_preview && (bool) did_action( 'wp_head' )
+			);
 		} elseif ( method_exists( $frontend, 'get_builder_content_for_display' ) ) {
 			// Elementor enqueues document CSS before the head and prints it inline
 			// when Popup Maker discovers the document after the head has passed.

--- a/classes/Builders/Elementor.php
+++ b/classes/Builders/Elementor.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Elementor page builder integration.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Builders;
+
+use PopupMaker\Base\PageBuilder;
+use PopupMaker\Services\BuilderPreviewUrl;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Adds complete Popup Maker document support to Elementor.
+ *
+ * @since 1.25.0
+ */
+class Elementor extends PageBuilder {
+
+	/**
+	 * Stable builder key.
+	 *
+	 * @var string
+	 */
+	protected $key = 'elementor';
+
+	/**
+	 * Whether Elementor's document and rendering APIs are usable.
+	 *
+	 * @return bool
+	 */
+	public function is_available() {
+		if ( ! did_action( 'elementor/loaded' ) || ! class_exists( '\Elementor\Plugin' ) ) {
+			return false;
+		}
+
+		$elementor = \Elementor\Plugin::$instance;
+
+		return isset( $elementor->documents, $elementor->frontend ) &&
+			method_exists( $elementor->documents, 'get' );
+	}
+
+	/**
+	 * Register Elementor-specific hooks.
+	 *
+	 * @return void
+	 */
+	protected function register_hooks() {
+		add_post_type_support( 'popup', 'elementor' );
+		add_filter( 'elementor/document/urls/wp_preview', [ $this, 'filter_preview_url' ], 10, 2 );
+	}
+
+	/**
+	 * Point Elementor's preview button at an authorized standalone preview.
+	 *
+	 * @param mixed $url      WordPress preview URL.
+	 * @param mixed $document Elementor document.
+	 *
+	 * @return mixed
+	 */
+	public function filter_preview_url( $url, $document ) {
+		if ( ! is_object( $document ) || ! method_exists( $document, 'get_main_id' ) ) {
+			return $url;
+		}
+
+		$popup_id = absint( $document->get_main_id() );
+
+		if (
+			! $popup_id ||
+			'popup' !== get_post_type( $popup_id ) ||
+			! current_user_can( 'edit_post', $popup_id )
+		) {
+			return $url;
+		}
+
+		return BuilderPreviewUrl::create( $popup_id, $this->key() );
+	}
+
+	/**
+	 * Read the popup ID from Elementor's preview iframe request.
+	 *
+	 * Authorization is intentionally centralized in the builder controller.
+	 *
+	 * @return int
+	 */
+	public function get_requested_popup_id() {
+		// Elementor's iframe carries no nonce; access rests on the per-popup
+		// capability check applied by the controller.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if (
+			! isset( $_GET['elementor-preview'], $_GET['p'], $_GET['post_type'] ) ||
+			! is_scalar( $_GET['elementor-preview'] ) ||
+			! is_scalar( $_GET['p'] ) ||
+			! is_scalar( $_GET['post_type'] )
+		) {
+			return 0;
+		}
+
+		$preview_id = absint( wp_unslash( $_GET['elementor-preview'] ) );
+		$post_id    = absint( wp_unslash( $_GET['p'] ) );
+		$post_type  = sanitize_key( wp_unslash( $_GET['post_type'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		if ( 'popup' !== $post_type || ! $preview_id || $preview_id !== $post_id ) {
+			return 0;
+		}
+
+		return $preview_id;
+	}
+
+	/**
+	 * Elementor's front-end preview request is its editing canvas.
+	 *
+	 * @return bool
+	 */
+	public function is_canvas_request() {
+		return true;
+	}
+
+	/**
+	 * Whether a popup is built with Elementor.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return bool
+	 */
+	public function owns_document( $popup_id ) {
+		$document = $this->get_document( $popup_id );
+
+		return $document &&
+			method_exists( $document, 'is_built_with_elementor' ) &&
+			$document->is_built_with_elementor();
+	}
+
+	/**
+	 * Render a popup through Elementor's public frontend API.
+	 *
+	 * @param int  $popup_id Popup ID.
+	 * @param bool $is_canvas Whether Elementor is rendering its editor canvas.
+	 *
+	 * @return string|null
+	 */
+	public function render_document( $popup_id, $is_canvas = false ) {
+		if ( ! $this->is_ready() ) {
+			return null;
+		}
+
+		$popup_id = absint( $popup_id );
+		$frontend = \Elementor\Plugin::$instance->frontend;
+
+		// Lets Elementor and third-party widgets register state for this
+		// secondary document before its markup is generated.
+		do_action( 'elementor/post/render', $popup_id );
+
+		if ( $is_canvas && method_exists( $frontend, 'get_builder_content' ) ) {
+			$rendered = $frontend->get_builder_content( $popup_id );
+		} elseif ( method_exists( $frontend, 'get_builder_content_for_display' ) ) {
+			$rendered = $frontend->get_builder_content_for_display( $popup_id );
+		} else {
+			return null;
+		}
+
+		return is_string( $rendered ) ? $rendered : null;
+	}
+
+	/**
+	 * Get an Elementor document for a popup.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return object|null
+	 */
+	private function get_document( $popup_id ) {
+		if ( ! $this->is_ready() ) {
+			return null;
+		}
+
+		$popup_id = absint( $popup_id );
+
+		if ( ! $popup_id || 'popup' !== get_post_type( $popup_id ) ) {
+			return null;
+		}
+
+		$document = \Elementor\Plugin::$instance->documents->get( $popup_id );
+
+		return is_object( $document ) ? $document : null;
+	}
+}

--- a/classes/Builders/Elementor.php
+++ b/classes/Builders/Elementor.php
@@ -45,6 +45,40 @@ class Elementor extends PageBuilder {
 		add_post_type_support( 'popup', 'elementor' );
 		add_filter( 'elementor/document/urls/wp_preview', [ $this, 'filter_preview_url' ], 10, 2 );
 		add_action( 'elementor/editor/after_save', [ $this, 'remember_saved_document' ], 10, 2 );
+		add_action( 'template_redirect', [ $this, 'disable_canvas_content_filter' ], 11 );
+	}
+
+	/**
+	 * Prevent Elementor from rendering the canvas document in the theme loop.
+	 *
+	 * Popup Maker renders the document once inside the popup. Elementor's normal
+	 * priority-9 content filter ignores the incoming content and renders the
+	 * current post again, so returning an empty string later cannot prevent the
+	 * duplicate work. Remove that filter only on this authorized canvas request.
+	 *
+	 * @return void
+	 */
+	public function disable_canvas_content_filter() {
+		$popup_id = $this->get_requested_popup_id();
+
+		if ( ! $popup_id || $popup_id !== $this->get_canvas_popup_id() ) {
+			return;
+		}
+
+		if ( ! class_exists( '\Elementor\Plugin' ) ) {
+			return;
+		}
+
+		$elementor = \Elementor\Plugin::$instance;
+
+		if (
+			is_object( $elementor ) &&
+			isset( $elementor->frontend ) &&
+			is_object( $elementor->frontend ) &&
+			method_exists( $elementor->frontend, 'remove_content_filter' )
+		) {
+			$elementor->frontend->remove_content_filter();
+		}
 	}
 
 	/**
@@ -216,5 +250,18 @@ class Elementor extends PageBuilder {
 		$document = \Elementor\Plugin::$instance->documents->get( $popup_id );
 
 		return is_object( $document ) ? $document : null;
+	}
+
+	/**
+	 * Get the popup rendered by the shared authorized canvas.
+	 *
+	 * @return int
+	 */
+	protected function get_canvas_popup_id() {
+		$builders = $this->container->get_controller( 'Builders' );
+
+		return $builders instanceof \PopupMaker\Controllers\Builders
+			? $builders->get_canvas_popup_id()
+			: 0;
 	}
 }

--- a/classes/Builders/Elementor.php
+++ b/classes/Builders/Elementor.php
@@ -60,8 +60,13 @@ class Elementor extends PageBuilder {
 	 */
 	public function disable_canvas_content_filter() {
 		$popup_id = $this->get_requested_popup_id();
+		$builders = $this->container->get_controller( 'Builders' );
 
-		if ( ! $popup_id || $popup_id !== $this->get_canvas_popup_id() ) {
+		if (
+			! $popup_id ||
+			! $builders instanceof \PopupMaker\Controllers\Builders ||
+			$popup_id !== $builders->get_canvas_popup_id()
+		) {
 			return;
 		}
 
@@ -90,8 +95,6 @@ class Elementor extends PageBuilder {
 	 * @return void
 	 */
 	public function remember_saved_document( $post_id, $editor_data = null ) {
-		unset( $editor_data );
-
 		if ( ! is_numeric( $post_id ) ) {
 			return;
 		}
@@ -172,8 +175,6 @@ class Elementor extends PageBuilder {
 		try {
 			return (bool) \Elementor\User::is_current_user_can_edit( absint( $popup_id ) );
 		} catch ( \Throwable $error ) {
-			unset( $error );
-
 			return false;
 		}
 	}
@@ -186,9 +187,19 @@ class Elementor extends PageBuilder {
 	 * @return bool
 	 */
 	public function owns_document( $popup_id ) {
-		$document = $this->get_document( $popup_id );
+		if ( ! $this->is_available() ) {
+			return false;
+		}
 
-		return $document &&
+		$popup_id = absint( $popup_id );
+
+		if ( ! $popup_id || 'popup' !== get_post_type( $popup_id ) ) {
+			return false;
+		}
+
+		$document = \Elementor\Plugin::$instance->documents->get( $popup_id );
+
+		return is_object( $document ) &&
 			method_exists( $document, 'is_built_with_elementor' ) &&
 			$document->is_built_with_elementor();
 	}
@@ -227,41 +238,5 @@ class Elementor extends PageBuilder {
 		}
 
 		return is_string( $rendered ) ? $rendered : null;
-	}
-
-	/**
-	 * Get an Elementor document for a popup.
-	 *
-	 * @param int $popup_id Popup ID.
-	 *
-	 * @return object|null
-	 */
-	private function get_document( $popup_id ) {
-		if ( ! $this->is_available() ) {
-			return null;
-		}
-
-		$popup_id = absint( $popup_id );
-
-		if ( ! $popup_id || 'popup' !== get_post_type( $popup_id ) ) {
-			return null;
-		}
-
-		$document = \Elementor\Plugin::$instance->documents->get( $popup_id );
-
-		return is_object( $document ) ? $document : null;
-	}
-
-	/**
-	 * Get the popup rendered by the shared authorized canvas.
-	 *
-	 * @return int
-	 */
-	protected function get_canvas_popup_id() {
-		$builders = $this->container->get_controller( 'Builders' );
-
-		return $builders instanceof \PopupMaker\Controllers\Builders
-			? $builders->get_canvas_popup_id()
-			: 0;
 	}
 }

--- a/classes/Builders/Elementor.php
+++ b/classes/Builders/Elementor.php
@@ -105,6 +105,27 @@ class Elementor extends PageBuilder {
 	}
 
 	/**
+	 * Honor Elementor's own role and document access rules.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return bool
+	 */
+	public function can_edit_document( $popup_id ) {
+		if ( ! class_exists( '\Elementor\User' ) || ! method_exists( '\Elementor\User', 'is_current_user_can_edit' ) ) {
+			return false;
+		}
+
+		try {
+			return (bool) \Elementor\User::is_current_user_can_edit( absint( $popup_id ) );
+		} catch ( \Throwable $error ) {
+			unset( $error );
+
+			return false;
+		}
+	}
+
+	/**
 	 * Whether a popup is built with Elementor.
 	 *
 	 * @param int $popup_id Popup ID.

--- a/classes/Builders/Elementor.php
+++ b/classes/Builders/Elementor.php
@@ -54,7 +54,7 @@ class Elementor extends PageBuilder {
 	 *
 	 * @return mixed
 	 */
-	public function filter_preview_url( $url, $document ) {
+	public function filter_preview_url( $url, $document = null ) {
 		if ( ! is_object( $document ) || ! method_exists( $document, 'get_main_id' ) ) {
 			return $url;
 		}

--- a/classes/Builders/Elementor.php
+++ b/classes/Builders/Elementor.php
@@ -44,6 +44,25 @@ class Elementor extends PageBuilder {
 	public function register_hooks() {
 		add_post_type_support( 'popup', 'elementor' );
 		add_filter( 'elementor/document/urls/wp_preview', [ $this, 'filter_preview_url' ], 10, 2 );
+		add_action( 'elementor/editor/after_save', [ $this, 'remember_saved_document' ], 10, 2 );
+	}
+
+	/**
+	 * Remember Elementor after its authenticated editor save completes.
+	 *
+	 * @param mixed $post_id     Saved post ID.
+	 * @param mixed $editor_data Saved editor data.
+	 *
+	 * @return void
+	 */
+	public function remember_saved_document( $post_id, $editor_data = null ) {
+		unset( $editor_data );
+
+		if ( ! is_numeric( $post_id ) ) {
+			return;
+		}
+
+		$this->remember_document_owner( absint( $post_id ) );
 	}
 
 	/**

--- a/classes/Builders/Elementor.php
+++ b/classes/Builders/Elementor.php
@@ -9,7 +9,7 @@
 namespace PopupMaker\Builders;
 
 use PopupMaker\Base\PageBuilder;
-use PopupMaker\Services\BuilderPreviewUrl;
+use PopupMaker\Controllers\Previews;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -19,13 +19,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.25.0
  */
 class Elementor extends PageBuilder {
-
-	/**
-	 * Stable builder key.
-	 *
-	 * @var string
-	 */
-	protected $key = 'elementor';
 
 	/**
 	 * Whether Elementor's document and rendering APIs are usable.
@@ -48,13 +41,13 @@ class Elementor extends PageBuilder {
 	 *
 	 * @return void
 	 */
-	protected function register_hooks() {
+	public function register_hooks() {
 		add_post_type_support( 'popup', 'elementor' );
 		add_filter( 'elementor/document/urls/wp_preview', [ $this, 'filter_preview_url' ], 10, 2 );
 	}
 
 	/**
-	 * Point Elementor's preview button at an authorized standalone preview.
+	 * Point Elementor's preview button at Popup Maker's real-page preview.
 	 *
 	 * @param mixed $url      WordPress preview URL.
 	 * @param mixed $document Elementor document.
@@ -68,15 +61,15 @@ class Elementor extends PageBuilder {
 
 		$popup_id = absint( $document->get_main_id() );
 
-		if (
-			! $popup_id ||
-			'popup' !== get_post_type( $popup_id ) ||
-			! current_user_can( 'edit_post', $popup_id )
-		) {
+		if ( ! $popup_id || 'popup' !== get_post_type( $popup_id ) ) {
 			return $url;
 		}
 
-		return BuilderPreviewUrl::create( $popup_id, $this->key() );
+		$previews = $this->container->get_controller( 'Previews' );
+
+		$preview_url = $previews instanceof Previews ? $previews->get_preview_url( $popup_id ) : '';
+
+		return $preview_url ?: $url;
 	}
 
 	/**
@@ -112,15 +105,6 @@ class Elementor extends PageBuilder {
 	}
 
 	/**
-	 * Elementor's front-end preview request is its editing canvas.
-	 *
-	 * @return bool
-	 */
-	public function is_canvas_request() {
-		return true;
-	}
-
-	/**
 	 * Whether a popup is built with Elementor.
 	 *
 	 * @param int $popup_id Popup ID.
@@ -144,25 +128,19 @@ class Elementor extends PageBuilder {
 	 * @return string|null
 	 */
 	public function render_document( $popup_id, $is_editor_canvas = false ) {
-		if ( ! $this->is_ready() ) {
+		if ( ! $this->is_available() ) {
 			return null;
 		}
 
-		$popup_id          = absint( $popup_id );
-		$frontend          = \Elementor\Plugin::$instance->frontend;
-		$is_signed_preview = absint( BuilderPreviewUrl::read_request( $this->key() ) ) === $popup_id;
+		$popup_id = absint( $popup_id );
+		$frontend = \Elementor\Plugin::$instance->frontend;
 
 		// Lets Elementor and third-party widgets register state for this
 		// secondary document before its markup is generated.
 		do_action( 'elementor/post/render', $popup_id );
 
-		if ( ( $is_editor_canvas || $is_signed_preview ) && method_exists( $frontend, 'get_builder_content' ) ) {
-			// Elementor's display helper intentionally returns empty when the
-			// requested document is also the current standalone preview document.
-			$rendered = $frontend->get_builder_content(
-				$popup_id,
-				$is_signed_preview && (bool) did_action( 'wp_head' )
-			);
+		if ( $is_editor_canvas && method_exists( $frontend, 'get_builder_content' ) ) {
+			$rendered = $frontend->get_builder_content( $popup_id );
 		} elseif ( method_exists( $frontend, 'get_builder_content_for_display' ) ) {
 			// Elementor enqueues document CSS before the head and prints it inline
 			// when Popup Maker discovers the document after the head has passed.
@@ -185,7 +163,7 @@ class Elementor extends PageBuilder {
 	 * @return object|null
 	 */
 	private function get_document( $popup_id ) {
-		if ( ! $this->is_ready() ) {
+		if ( ! $this->is_available() ) {
 			return null;
 		}
 

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -71,21 +71,30 @@ class Builders extends Controller {
 	}
 
 	/**
-	 * Builders bundled with the plugin.
+	 * Detected builder classes bundled with the plugin.
 	 *
-	 * Concrete integrations add only detected builders to this plain list, so
-	 * inactive integrations consume no request-time objects or hooks.
+	 * Class constants resolve to strings without autoloading. An adapter is only
+	 * loaded and constructed after its builder's cheap runtime signal appears.
 	 *
-	 * @return PageBuilder[]
+	 * @return class-string<PageBuilder>[]
 	 */
-	protected function default_builders() {
+	protected function detected_builder_classes() {
 		if ( ! defined( 'ELEMENTOR_VERSION' ) && ! did_action( 'elementor/loaded' ) ) {
 			return [];
 		}
 
-		return [
-			new \PopupMaker\Builders\Elementor( $this->container ),
-		];
+		return [ \PopupMaker\Builders\Elementor::class ];
+	}
+
+	/**
+	 * Construct a detected builder.
+	 *
+	 * @param class-string<PageBuilder> $builder_class Builder class.
+	 *
+	 * @return PageBuilder
+	 */
+	protected function instantiate_builder( $builder_class ) {
+		return new $builder_class( $this->container );
 	}
 
 	/**
@@ -94,7 +103,17 @@ class Builders extends Controller {
 	 * @return void
 	 */
 	public function boot_builders() {
-		foreach ( $this->default_builders() as $builder ) {
+		foreach ( $this->detected_builder_classes() as $builder_class ) {
+			if (
+				! is_string( $builder_class ) ||
+				isset( $this->builders[ $builder_class ] ) ||
+				! is_subclass_of( $builder_class, PageBuilder::class )
+			) {
+				continue;
+			}
+
+			$builder = $this->instantiate_builder( $builder_class );
+
 			if ( ! $builder instanceof PageBuilder || ! $builder->is_available() ) {
 				continue;
 			}

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -21,6 +21,13 @@ defined( 'ABSPATH' ) || exit;
 class Builders extends Controller {
 
 	/**
+	 * Popup meta containing the last builder that saved the document.
+	 *
+	 * @var string
+	 */
+	const OWNER_META_KEY = '_pum_page_builder';
+
+	/**
 	 * Available builders, keyed by class name.
 	 *
 	 * @var array<string,PageBuilder>
@@ -208,6 +215,43 @@ class Builders extends Controller {
 		$request = $this->get_edit_request();
 
 		return $request ? $request['popup_id'] : 0;
+	}
+
+	/**
+	 * Remember the builder selected by an authenticated native save.
+	 *
+	 * Builder adapters call this only from their own verified save lifecycle.
+	 * The controller repeats the common popup and permission checks before it
+	 * accepts the ownership hint.
+	 *
+	 * @param mixed $builder  Builder performing the save.
+	 * @param mixed $popup_id Popup ID.
+	 *
+	 * @return bool Whether the owner was accepted.
+	 */
+	public function remember_document_owner( $builder, $popup_id ) {
+		$popup_id = absint( $popup_id );
+
+		if (
+			! $builder instanceof PageBuilder ||
+			! in_array( $builder, $this->builders, true ) ||
+			! $popup_id ||
+			'popup' !== get_post_type( $popup_id ) ||
+			! current_user_can( 'edit_post', $popup_id ) ||
+			! $builder->can_edit_document( $popup_id )
+		) {
+			return false;
+		}
+
+		$builder_class = get_class( $builder );
+
+		if ( get_post_meta( $popup_id, self::OWNER_META_KEY, true ) !== $builder_class ) {
+			update_post_meta( $popup_id, self::OWNER_META_KEY, wp_slash( $builder_class ) );
+		}
+
+		unset( $this->owners[ $popup_id ] );
+
+		return true;
 	}
 
 	/**
@@ -459,12 +503,28 @@ class Builders extends Controller {
 	 */
 	protected function owner_for( $popup_id ) {
 		$popup_id = absint( $popup_id );
+		$request  = $this->get_edit_request();
+
+		// A verified editor request owns only this request. Persistence happens
+		// later, from the builder's authenticated save lifecycle.
+		if ( $request && $request['popup_id'] === $popup_id ) {
+			$this->owners[ $popup_id ] = $request['builder'];
+
+			return $request['builder'];
+		}
 
 		if ( array_key_exists( $popup_id, $this->owners ) ) {
 			return $this->owners[ $popup_id ];
 		}
 
 		$this->owners[ $popup_id ] = null;
+		$saved_owner               = get_post_meta( $popup_id, self::OWNER_META_KEY, true );
+
+		if ( is_string( $saved_owner ) && isset( $this->builders[ $saved_owner ] ) ) {
+			$this->owners[ $popup_id ] = $this->builders[ $saved_owner ];
+
+			return $this->owners[ $popup_id ];
+		}
 
 		foreach ( $this->builders as $builder ) {
 			if ( $builder->owns_document( $popup_id ) ) {

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -163,7 +163,8 @@ class Builders extends Controller {
 		add_filter( 'pum_popup_data_attr', [ $this, 'filter_canvas_data_attr' ], 1001, 2 );
 		add_filter( 'pum_popup_get_public_settings', [ $this, 'filter_canvas_settings' ], 1001, 2 );
 		add_filter( 'pum_popup_close_button_attributes', [ $this, 'filter_canvas_close_attributes' ], 1001, 2 );
-		add_filter( 'pum_popup_content', [ $this, 'render_popup_content' ], 1000, 2 );
+		// Insert builder markup while popup-scoped shortcode compatibility guards are active.
+		add_filter( 'pum_popup_content', [ $this, 'render_popup_content' ], 10, 2 );
 
 		// Draft canvases are absent from Popup Maker's normal preload query.
 		add_action( 'wp_enqueue_scripts', [ $this, 'preload_canvas_popup' ], 11 );

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -521,12 +521,22 @@ class Builders extends Controller {
 		$saved_owner               = get_post_meta( $popup_id, self::OWNER_META_KEY, true );
 
 		if ( is_string( $saved_owner ) && isset( $this->builders[ $saved_owner ] ) ) {
-			$this->owners[ $popup_id ] = $this->builders[ $saved_owner ];
+			$saved_builder = $this->builders[ $saved_owner ];
 
-			return $this->owners[ $popup_id ];
+			if ( $saved_builder->owns_document( $popup_id ) ) {
+				$this->owners[ $popup_id ] = $saved_builder;
+
+				return $this->owners[ $popup_id ];
+			}
+
+			delete_post_meta( $popup_id, self::OWNER_META_KEY );
 		}
 
-		foreach ( $this->builders as $builder ) {
+		foreach ( $this->builders as $builder_class => $builder ) {
+			if ( $builder_class === $saved_owner ) {
+				continue;
+			}
+
 			if ( $builder->owns_document( $popup_id ) ) {
 				$this->owners[ $popup_id ] = $builder;
 				break;

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -79,7 +79,13 @@ class Builders extends Controller {
 	 * @return PageBuilder[]
 	 */
 	protected function default_builders() {
-		return [];
+		if ( ! defined( 'ELEMENTOR_VERSION' ) && ! did_action( 'elementor/loaded' ) ) {
+			return [];
+		}
+
+		return [
+			new \PopupMaker\Builders\Elementor( $this->container ),
+		];
 	}
 
 	/**

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -505,8 +505,8 @@ class Builders extends Controller {
 		$popup_id = absint( $popup_id );
 		$request  = $this->get_edit_request();
 
-		// A verified editor request owns only this request. Persistence happens
-		// later, from the builder's authenticated save lifecycle.
+		// A verified editor request owns only this request.
+		// The builder persists ownership later in its authenticated save lifecycle.
 		if ( $request && $request['popup_id'] === $popup_id ) {
 			$this->owners[ $popup_id ] = $request['builder'];
 

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -182,7 +182,8 @@ class Builders extends Controller {
 				! $popup_id ||
 				'popup' !== get_post_type( $popup_id ) ||
 				! is_user_logged_in() ||
-				! current_user_can( 'edit_post', $popup_id )
+				! current_user_can( 'edit_post', $popup_id ) ||
+				! $builder->can_edit_document( $popup_id )
 			) {
 				continue;
 			}

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -23,6 +23,9 @@ class Builders extends Controller {
 	/**
 	 * Popup meta containing the last builder that saved the document.
 	 *
+	 * This breaks ties when switching builders leaves more than one builder's
+	 * native ownership marker behind.
+	 *
 	 * @var string
 	 */
 	const OWNER_META_KEY = '_pum_page_builder';
@@ -521,6 +524,7 @@ class Builders extends Controller {
 		$this->owners[ $popup_id ] = null;
 		$saved_owner               = get_post_meta( $popup_id, self::OWNER_META_KEY, true );
 
+		// Treat the saved builder as a hint and revalidate its native marker.
 		if ( is_string( $saved_owner ) && isset( $this->builders[ $saved_owner ] ) ) {
 			$saved_builder = $this->builders[ $saved_owner ];
 

--- a/tests/php/tests/Elementor_Compatibility_Test.php
+++ b/tests/php/tests/Elementor_Compatibility_Test.php
@@ -197,7 +197,7 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 		$elementor->frontend         = $frontend;
 		\Elementor\Plugin::$instance = $elementor;
 
-		$builder = new class( \PopupMaker\plugin(), $popup_id ) extends Elementor {
+		$controller = new class( \PopupMaker\plugin(), $popup_id ) extends \PopupMaker\Controllers\Builders {
 
 			/** @var int */
 			private $canvas_popup_id;
@@ -213,10 +213,29 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 			}
 
 			/** @return int */
-			protected function get_canvas_popup_id() {
+			public function get_canvas_popup_id() {
 				return $this->canvas_popup_id;
 			}
 		};
+		$container  = new class( $controller ) {
+
+			/** @var \PopupMaker\Controllers\Builders */
+			private $builders;
+
+			/** @param \PopupMaker\Controllers\Builders $builders Builder controller. */
+			public function __construct( $builders ) {
+				$this->builders = $builders;
+			}
+
+			/**
+			 * @param string $controller Controller key.
+			 * @return object|null
+			 */
+			public function get_controller( $controller ) {
+				return 'Builders' === $controller ? $this->builders : null;
+			}
+		};
+		$builder    = new Elementor( $container );
 
 		add_filter( 'the_content', [ $frontend, 'apply_builder_in_content' ], 9 );
 

--- a/tests/php/tests/Elementor_Compatibility_Test.php
+++ b/tests/php/tests/Elementor_Compatibility_Test.php
@@ -1,0 +1,249 @@
+<?php
+/**
+ * Elementor builder compatibility tests.
+ *
+ * @package Popup_Maker
+ */
+
+use PopupMaker\Base\PageBuilder;
+use PopupMaker\Builders\Elementor;
+use PopupMaker\Services\BuilderPreviewUrl;
+
+/**
+ * Test Elementor popup preview requests without loading Elementor itself.
+ */
+class Elementor_Compatibility_Test extends WP_UnitTestCase {
+
+	/** @var array<string,mixed> */
+	private $original_get;
+
+	/** @return void */
+	public function setUp(): void {
+		parent::setUp();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test fixture preserves request globals.
+		$this->original_get = $_GET;
+	}
+
+	/** @return void */
+	public function tearDown(): void {
+		$_GET = $this->original_get;
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/** @return void */
+	public function test_authorized_elementor_request_restores_popup_query() {
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		$this->set_elementor_request( $popup_id );
+
+		$controller = $this->make_controller();
+		$query      = $controller->allow_builder_request( [] );
+
+		$this->assertSame( $popup_id, $query['p'] );
+		$this->assertSame( 'popup', $query['post_type'] );
+		$this->assertSame( 'draft', $query['post_status'] );
+	}
+
+	/** @return void */
+	public function test_elementor_request_requires_matching_ids_and_post_type() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$builder  = new Elementor( \PopupMaker\plugin() );
+
+		$this->set_elementor_request( $popup_id );
+		$this->assertSame( $popup_id, $builder->get_requested_popup_id() );
+
+		$_GET['p'] = (string) ( $popup_id + 1 );
+		$this->assertSame( 0, $builder->get_requested_popup_id() );
+
+		$_GET['p']         = (string) $popup_id;
+		$_GET['post_type'] = 'page';
+		$this->assertSame( 0, $builder->get_requested_popup_id() );
+	}
+
+	/** @return void */
+	public function test_elementor_request_requires_login_and_popup_permission() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$this->set_elementor_request( $popup_id );
+
+		wp_set_current_user( 0 );
+		$this->assertSame( 0, $this->make_controller()->get_edit_popup_id() );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'subscriber' ] ) );
+		$this->assertSame( 0, $this->make_controller()->get_edit_popup_id() );
+	}
+
+	/** @return void */
+	public function test_elementor_request_uses_isolated_popup_canvas() {
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		$this->set_elementor_request( $popup_id );
+		$this->go_to( add_query_arg( [
+			'post_type' => 'popup',
+			'p'         => $popup_id,
+		], home_url( '/' ) ) );
+		$this->set_elementor_request( $popup_id );
+
+		$controller = $this->make_controller();
+		$popups     = \PopupMaker\plugin()->get_controller( 'Frontend\Popups' );
+		add_action( 'wp_footer', [ $popups, 'render_popups' ] );
+
+		$this->assertSame( $popup_id, $controller->get_canvas_popup_id() );
+		$this->assertSame(
+			Popup_Maker::$DIR . 'templates/single-popup.php',
+			$controller->use_popup_canvas( 'theme-single.php' )
+		);
+		$this->assertFalse( has_action( 'wp_footer', [ $popups, 'render_popups' ] ) );
+	}
+
+	/** @return void */
+	public function test_elementor_preview_button_uses_signed_popup_url() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$builder  = new Elementor( \PopupMaker\plugin() );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$document    = new class( $popup_id ) {
+
+			/** @var int */
+			private $popup_id;
+
+			/** @param int $popup_id Popup ID. */
+			public function __construct( $popup_id ) {
+				$this->popup_id = $popup_id;
+			}
+
+			/** @return int */
+			public function get_main_id() {
+				return $this->popup_id;
+			}
+		};
+		$preview_url = $builder->filter_preview_url( '', $document );
+		$query       = [];
+		parse_str( (string) wp_parse_url( $preview_url, PHP_URL_QUERY ), $query );
+		$_GET = $query;
+
+		$this->assertSame( 'popup', $query['post_type'] );
+		$this->assertSame( (string) $popup_id, $query['p'] );
+		$this->assertSame( 'elementor', $query['pum-builder-preview'] );
+		$this->assertSame( $popup_id, BuilderPreviewUrl::read_request( 'elementor' ) );
+	}
+
+	/** @return void */
+	public function test_signed_elementor_preview_still_requires_valid_nonce() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->apply_request( BuilderPreviewUrl::create( $popup_id, 'elementor' ) );
+		$this->assertSame( $popup_id, $this->make_controller()->get_edit_popup_id() );
+
+		$_GET['_wpnonce'] = 'tampered';
+		$this->assertSame( 0, $this->make_controller()->get_edit_popup_id() );
+	}
+
+	/** @return void */
+	public function test_builder_preview_adds_canonical_toolbar_edit_link() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		$this->set_elementor_request( $popup_id );
+
+		$builders  = $this->make_controller();
+		$container = new class( $builders ) {
+
+			/** @var \PopupMaker\Controllers\Builders */
+			private $builders;
+
+			/** @param \PopupMaker\Controllers\Builders $builders Builder controller. */
+			public function __construct( $builders ) {
+				$this->builders = $builders;
+			}
+
+			/**
+			 * @param string $name Controller name.
+			 * @return \PopupMaker\Controllers\Builders|null
+			 */
+			public function get_controller( $name ) {
+				return 'Builders' === $name ? $this->builders : null;
+			}
+		};
+		$toolbar   = new \PopupMaker\Controllers\Admin\Toolbar( $container );
+
+		if ( ! class_exists( 'WP_Admin_Bar' ) ) {
+			require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
+		}
+
+		$admin_bar = new WP_Admin_Bar();
+		$toolbar->add_preview_edit_link( $admin_bar );
+		$edit_node = $admin_bar->get_node( 'edit' );
+
+		$this->assertInstanceOf( stdClass::class, $edit_node );
+		$this->assertSame( get_edit_post_link( $popup_id, 'raw' ), $edit_node->href );
+	}
+
+	/**
+	 * @return \PopupMaker\Controllers\Builders
+	 */
+	private function make_controller() {
+		$builder    = new Elementor( \PopupMaker\plugin() );
+		$controller = new class( \PopupMaker\plugin(), $builder ) extends \PopupMaker\Controllers\Builders {
+
+			/** @var PageBuilder */
+			private $test_builder;
+
+			/**
+			 * @param \PopupMaker\Plugin\Core $container Plugin container.
+			 * @param PageBuilder             $builder Builder integration.
+			 */
+			public function __construct( $container, PageBuilder $builder ) {
+				$this->test_builder = $builder;
+
+				parent::__construct( $container );
+			}
+
+			/** @return PageBuilder[] */
+			protected function default_builders() {
+				return [ $this->test_builder ];
+			}
+		};
+		$controller->init();
+
+		return $controller;
+	}
+
+	/**
+	 * @param int $popup_id Popup ID.
+	 * @return void
+	 */
+	private function set_elementor_request( $popup_id ) {
+		$_GET = [
+			'elementor-preview' => (string) $popup_id,
+			'p'                 => (string) $popup_id,
+			'post_type'         => 'popup',
+		];
+	}
+
+	/**
+	 * @param string $url Preview URL.
+	 * @return void
+	 */
+	private function apply_request( $url ) {
+		$query = [];
+		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query );
+
+		$_GET = $query;
+	}
+}

--- a/tests/php/tests/Elementor_Compatibility_Test.php
+++ b/tests/php/tests/Elementor_Compatibility_Test.php
@@ -7,7 +7,6 @@
 
 use PopupMaker\Base\PageBuilder;
 use PopupMaker\Builders\Elementor;
-use PopupMaker\Services\BuilderPreviewUrl;
 
 /**
  * Test Elementor popup preview requests without loading Elementor itself.
@@ -82,7 +81,7 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 	}
 
 	/** @return void */
-	public function test_elementor_request_uses_isolated_popup_canvas() {
+	public function test_elementor_request_uses_theme_popup_canvas() {
 		$popup_id = $this->factory->post->create(
 			[
 				'post_type'   => 'popup',
@@ -101,17 +100,15 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 		$controller = $this->make_controller();
 		$popups     = \PopupMaker\plugin()->get_controller( 'Frontend\Popups' );
 		add_action( 'wp_footer', [ $popups, 'render_popups' ] );
+		$GLOBALS['wp_query']->in_the_loop = true;
 
 		$this->assertSame( $popup_id, $controller->get_canvas_popup_id() );
-		$this->assertSame(
-			Popup_Maker::$DIR . 'templates/single-popup.php',
-			$controller->use_popup_canvas( 'theme-single.php' )
-		);
-		$this->assertFalse( has_action( 'wp_footer', [ $popups, 'render_popups' ] ) );
+		$this->assertSame( '', $controller->suppress_canvas_content( 'duplicate document' ) );
+		$this->assertNotFalse( has_action( 'wp_footer', [ $popups, 'render_popups' ] ) );
 	}
 
 	/** @return void */
-	public function test_elementor_preview_button_uses_signed_popup_url() {
+	public function test_elementor_preview_button_uses_real_page_preview_url() {
 		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
 		$builder  = new Elementor( \PopupMaker\plugin() );
 
@@ -137,61 +134,13 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 		parse_str( (string) wp_parse_url( $preview_url, PHP_URL_QUERY ), $query );
 		$_GET = $query;
 
-		$this->assertSame( 'popup', $query['post_type'] );
-		$this->assertSame( (string) $popup_id, $query['p'] );
-		$this->assertSame( 'elementor', $query['pum-builder-preview'] );
-		$this->assertSame( $popup_id, BuilderPreviewUrl::read_request( 'elementor' ) );
-	}
+		$previews = \PopupMaker\plugin()->get_controller( 'Previews' );
 
-	/** @return void */
-	public function test_signed_elementor_preview_still_requires_valid_nonce() {
-		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
-		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
-
-		$this->apply_request( BuilderPreviewUrl::create( $popup_id, 'elementor' ) );
-		$this->assertSame( $popup_id, $this->make_controller()->get_edit_popup_id() );
-
-		$_GET['_wpnonce'] = 'tampered';
+		$this->assertSame( home_url( '/' ), strtok( $preview_url, '?' ) );
+		$this->assertSame( (string) $popup_id, $query['popup'] );
+		$this->assertSame( 'true', $query['preview'] );
+		$this->assertSame( $popup_id, $previews->get_popup_preview() );
 		$this->assertSame( 0, $this->make_controller()->get_edit_popup_id() );
-	}
-
-	/** @return void */
-	public function test_builder_preview_adds_canonical_toolbar_edit_link() {
-		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
-		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
-		$this->set_elementor_request( $popup_id );
-
-		$builders  = $this->make_controller();
-		$container = new class( $builders ) {
-
-			/** @var \PopupMaker\Controllers\Builders */
-			private $builders;
-
-			/** @param \PopupMaker\Controllers\Builders $builders Builder controller. */
-			public function __construct( $builders ) {
-				$this->builders = $builders;
-			}
-
-			/**
-			 * @param string $name Controller name.
-			 * @return \PopupMaker\Controllers\Builders|null
-			 */
-			public function get_controller( $name ) {
-				return 'Builders' === $name ? $this->builders : null;
-			}
-		};
-		$toolbar   = new \PopupMaker\Controllers\Admin\Toolbar( $container );
-
-		if ( ! class_exists( 'WP_Admin_Bar' ) ) {
-			require_once ABSPATH . WPINC . '/class-wp-admin-bar.php';
-		}
-
-		$admin_bar = new WP_Admin_Bar();
-		$toolbar->add_preview_edit_link( $admin_bar );
-		$edit_node = $admin_bar->get_node( 'edit' );
-
-		$this->assertInstanceOf( stdClass::class, $edit_node );
-		$this->assertSame( get_edit_post_link( $popup_id, 'raw' ), $edit_node->href );
 	}
 
 	/**
@@ -240,16 +189,5 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 			'p'                 => (string) $popup_id,
 			'post_type'         => 'popup',
 		];
-	}
-
-	/**
-	 * @param string $url Preview URL.
-	 * @return void
-	 */
-	private function apply_request( $url ) {
-		$query = [];
-		parse_str( (string) wp_parse_url( $url, PHP_URL_QUERY ), $query );
-
-		$_GET = $query;
 	}
 }

--- a/tests/php/tests/Elementor_Compatibility_Test.php
+++ b/tests/php/tests/Elementor_Compatibility_Test.php
@@ -143,6 +143,13 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 		$this->assertSame( 0, $this->make_controller()->get_edit_popup_id() );
 	}
 
+	/** @return void */
+	public function test_preview_filter_tolerates_a_missing_document_argument() {
+		$builder = new Elementor( \PopupMaker\plugin() );
+
+		$this->assertSame( 'https://example.com/preview', $builder->filter_preview_url( 'https://example.com/preview' ) );
+	}
+
 	/**
 	 * @return \PopupMaker\Controllers\Builders
 	 */
@@ -169,9 +176,19 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 				parent::__construct( $container );
 			}
 
-			/** @return PageBuilder[] */
-			protected function default_builders() {
-				return [ $this->test_builder ];
+			/** @return string[] */
+			protected function detected_builder_classes() {
+				return [ get_class( $this->test_builder ) ];
+			}
+
+			/**
+			 * @param string $builder_class Builder class.
+			 * @return PageBuilder
+			 */
+			protected function instantiate_builder( $builder_class ) {
+				unset( $builder_class );
+
+				return $this->test_builder;
 			}
 		};
 		$controller->init();

--- a/tests/php/tests/Elementor_Compatibility_Test.php
+++ b/tests/php/tests/Elementor_Compatibility_Test.php
@@ -160,6 +160,16 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 			public function is_available() {
 				return true;
 			}
+
+			/**
+			 * @param int $popup_id Popup ID.
+			 * @return bool
+			 */
+			public function can_edit_document( $popup_id ) {
+				unset( $popup_id );
+
+				return true;
+			}
 		};
 		$controller = new class( \PopupMaker\plugin(), $builder ) extends \PopupMaker\Controllers\Builders {
 

--- a/tests/php/tests/Elementor_Compatibility_Test.php
+++ b/tests/php/tests/Elementor_Compatibility_Test.php
@@ -150,6 +150,18 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 		$this->assertSame( 'https://example.com/preview', $builder->filter_preview_url( 'https://example.com/preview' ) );
 	}
 
+	/** @return void */
+	public function test_elementor_registers_its_authenticated_save_hook() {
+		$builder = new Elementor( \PopupMaker\plugin() );
+
+		$builder->register_hooks();
+
+		$this->assertSame( 10, has_action( 'elementor/editor/after_save', [ $builder, 'remember_saved_document' ] ) );
+
+		remove_action( 'elementor/editor/after_save', [ $builder, 'remember_saved_document' ], 10 );
+		remove_filter( 'elementor/document/urls/wp_preview', [ $builder, 'filter_preview_url' ], 10 );
+	}
+
 	/**
 	 * @return \PopupMaker\Controllers\Builders
 	 */

--- a/tests/php/tests/Elementor_Compatibility_Test.php
+++ b/tests/php/tests/Elementor_Compatibility_Test.php
@@ -8,6 +8,8 @@
 use PopupMaker\Base\PageBuilder;
 use PopupMaker\Builders\Elementor;
 
+require_once __DIR__ . '/fixtures/class-elementor-plugin.php';
+
 /**
  * Test Elementor popup preview requests without loading Elementor itself.
  */
@@ -26,7 +28,8 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 
 	/** @return void */
 	public function tearDown(): void {
-		$_GET = $this->original_get;
+		$_GET                        = $this->original_get;
+		\Elementor\Plugin::$instance = null;
 		wp_set_current_user( 0 );
 
 		parent::tearDown();
@@ -157,9 +160,70 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 		$builder->register_hooks();
 
 		$this->assertSame( 10, has_action( 'elementor/editor/after_save', [ $builder, 'remember_saved_document' ] ) );
+		$this->assertSame( 11, has_action( 'template_redirect', [ $builder, 'disable_canvas_content_filter' ] ) );
 
 		remove_action( 'elementor/editor/after_save', [ $builder, 'remember_saved_document' ], 10 );
+		remove_action( 'template_redirect', [ $builder, 'disable_canvas_content_filter' ], 11 );
 		remove_filter( 'elementor/document/urls/wp_preview', [ $builder, 'filter_preview_url' ], 10 );
+	}
+
+	/** @return void */
+	public function test_elementor_canvas_skips_its_native_content_render() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$this->set_elementor_request( $popup_id );
+
+		$frontend  = new class() {
+
+			/** @var int */
+			public $render_count = 0;
+
+			/** @return void */
+			public function remove_content_filter() {
+				remove_filter( 'the_content', [ $this, 'apply_builder_in_content' ], 9 );
+			}
+
+			/**
+			 * @param mixed $content Post content.
+			 * @return mixed
+			 */
+			public function apply_builder_in_content( $content ) {
+				++$this->render_count;
+
+				return $content;
+			}
+		};
+		$elementor = new \Elementor\Plugin();
+
+		$elementor->frontend         = $frontend;
+		\Elementor\Plugin::$instance = $elementor;
+
+		$builder = new class( \PopupMaker\plugin(), $popup_id ) extends Elementor {
+
+			/** @var int */
+			private $canvas_popup_id;
+
+			/**
+			 * @param \PopupMaker\Plugin\Core $container Plugin container.
+			 * @param int                     $popup_id  Canvas popup ID.
+			 */
+			public function __construct( $container, $popup_id ) {
+				parent::__construct( $container );
+
+				$this->canvas_popup_id = $popup_id;
+			}
+
+			/** @return int */
+			protected function get_canvas_popup_id() {
+				return $this->canvas_popup_id;
+			}
+		};
+
+		add_filter( 'the_content', [ $frontend, 'apply_builder_in_content' ], 9 );
+
+		$builder->disable_canvas_content_filter();
+		apply_filters( 'the_content', 'Theme loop content.' );
+
+		$this->assertSame( 0, $frontend->render_count );
 	}
 
 	/**

--- a/tests/php/tests/Elementor_Compatibility_Test.php
+++ b/tests/php/tests/Elementor_Compatibility_Test.php
@@ -198,7 +198,13 @@ class Elementor_Compatibility_Test extends WP_UnitTestCase {
 	 * @return \PopupMaker\Controllers\Builders
 	 */
 	private function make_controller() {
-		$builder    = new Elementor( \PopupMaker\plugin() );
+		$builder    = new class( \PopupMaker\plugin() ) extends Elementor {
+
+			/** @return bool */
+			public function is_available() {
+				return true;
+			}
+		};
 		$controller = new class( \PopupMaker\plugin(), $builder ) extends \PopupMaker\Controllers\Builders {
 
 			/** @var PageBuilder */

--- a/tests/php/tests/Page_Builders_Test.php
+++ b/tests/php/tests/Page_Builders_Test.php
@@ -134,6 +134,7 @@ class Page_Builders_Test extends WP_UnitTestCase {
 		$this->assertSame( 1, $builder->hooks_registered );
 		$this->assertSame( 10, has_filter( 'request', [ $controller, 'allow_builder_request' ] ) );
 		$this->assertSame( PHP_INT_MAX, has_filter( 'the_content', [ $controller, 'suppress_canvas_content' ] ) );
+		$this->assertSame( 10, has_filter( 'pum_popup_content', [ $controller, 'render_popup_content' ] ) );
 	}
 
 	/** @return void */

--- a/tests/php/tests/Page_Builders_Test.php
+++ b/tests/php/tests/Page_Builders_Test.php
@@ -61,6 +61,17 @@ class Page_Builders_Test extends WP_UnitTestCase {
 	}
 
 	/** @return void */
+	public function test_builder_specific_permission_can_reject_request() {
+		$popup_id                    = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$builder                     = $this->make_builder();
+		$builder->requested_popup_id = $popup_id;
+		$builder->can_edit           = false;
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->assertSame( 0, $this->make_controller( $builder )->get_edit_popup_id() );
+	}
+
+	/** @return void */
 	public function test_builder_boot_retries_without_registering_twice() {
 		$builder            = $this->make_builder();
 		$builder->available = false;
@@ -325,6 +336,9 @@ class Page_Builders_Test extends WP_UnitTestCase {
 			/** @var bool */
 			public $canvas = true;
 
+			/** @var bool */
+			public $can_edit = true;
+
 			/** @var string|null */
 			public $rendered = null;
 
@@ -353,6 +367,16 @@ class Page_Builders_Test extends WP_UnitTestCase {
 			/** @return int */
 			public function get_requested_popup_id() {
 				return $this->requested_popup_id;
+			}
+
+			/**
+			 * @param int $popup_id Popup ID.
+			 * @return bool
+			 */
+			public function can_edit_document( $popup_id ) {
+				unset( $popup_id );
+
+				return $this->can_edit;
 			}
 
 			/** @return bool */

--- a/tests/php/tests/Page_Builders_Test.php
+++ b/tests/php/tests/Page_Builders_Test.php
@@ -79,6 +79,35 @@ class Page_Builders_Test extends WP_UnitTestCase {
 	}
 
 	/** @return void */
+	public function test_inactive_bundled_builders_are_not_loaded_or_constructed() {
+		if ( defined( 'ELEMENTOR_VERSION' ) || did_action( 'elementor/loaded' ) ) {
+			$this->markTestSkipped( 'Elementor is active in this test environment.' );
+		}
+
+		$elementor_loaded = class_exists( \PopupMaker\Builders\Elementor::class, false );
+		$controller       = new class( \PopupMaker\plugin() ) extends \PopupMaker\Controllers\Builders {
+
+			/** @var int */
+			public $builders_constructed = 0;
+
+			/**
+			 * @param string $builder_class Builder class.
+			 * @return PageBuilder
+			 */
+			protected function instantiate_builder( $builder_class ) {
+				++$this->builders_constructed;
+
+				return parent::instantiate_builder( $builder_class );
+			}
+		};
+
+		$controller->init();
+
+		$this->assertSame( 0, $controller->builders_constructed );
+		$this->assertSame( $elementor_loaded, class_exists( \PopupMaker\Builders\Elementor::class, false ) );
+	}
+
+	/** @return void */
 	public function test_canvas_reuses_theme_and_disables_live_popup_behavior() {
 		$popup_id                    = $this->factory->post->create( [ 'post_type' => 'popup' ] );
 		$builder                     = $this->make_builder();
@@ -260,9 +289,19 @@ class Page_Builders_Test extends WP_UnitTestCase {
 				parent::__construct( $container );
 			}
 
-			/** @return PageBuilder[] */
-			protected function default_builders() {
-				return [ $this->test_builder ];
+			/** @return string[] */
+			protected function detected_builder_classes() {
+				return [ get_class( $this->test_builder ) ];
+			}
+
+			/**
+			 * @param string $builder_class Builder class.
+			 * @return PageBuilder
+			 */
+			protected function instantiate_builder( $builder_class ) {
+				unset( $builder_class );
+
+				return $this->test_builder;
 			}
 		};
 		$controller->init();

--- a/tests/php/tests/Page_Builders_Test.php
+++ b/tests/php/tests/Page_Builders_Test.php
@@ -72,6 +72,52 @@ class Page_Builders_Test extends WP_UnitTestCase {
 	}
 
 	/** @return void */
+	public function test_authorized_editor_request_temporarily_owns_an_unbuilt_document() {
+		$popup_id                    = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$builder                     = $this->make_builder();
+		$builder->requested_popup_id = $popup_id;
+		$builder->owns               = false;
+		$builder->rendered           = 'builder content';
+		$controller                  = $this->make_controller( $builder );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->assertSame( 'builder content', $controller->render_popup_content( 'original', $popup_id ) );
+		$this->assertSame( '', get_post_meta( $popup_id, $controller::OWNER_META_KEY, true ) );
+		$this->assertSame( 0, $builder->ownership_checks );
+	}
+
+	/** @return void */
+	public function test_authenticated_builder_save_persists_document_owner() {
+		$popup_id   = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$builder    = $this->make_builder();
+		$controller = $this->make_controller( $builder );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->assertTrue( $controller->remember_document_owner( $builder, $popup_id ) );
+		$this->assertSame( get_class( $builder ), get_post_meta( $popup_id, $controller::OWNER_META_KEY, true ) );
+
+		$builder->owns     = false;
+		$builder->rendered = 'saved builder content';
+
+		$this->assertSame( 'saved builder content', $controller->render_popup_content( 'original', $popup_id ) );
+		$this->assertSame( 0, $builder->ownership_checks );
+	}
+
+	/** @return void */
+	public function test_document_owner_rejects_an_unauthorized_save() {
+		$popup_id   = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$builder    = $this->make_builder();
+		$controller = $this->make_controller( $builder );
+
+		wp_set_current_user( 0 );
+
+		$this->assertFalse( $controller->remember_document_owner( $builder, $popup_id ) );
+		$this->assertSame( '', get_post_meta( $popup_id, $controller::OWNER_META_KEY, true ) );
+	}
+
+	/** @return void */
 	public function test_builder_boot_retries_without_registering_twice() {
 		$builder            = $this->make_builder();
 		$builder->available = false;
@@ -232,7 +278,7 @@ class Page_Builders_Test extends WP_UnitTestCase {
 	}
 
 	/** @return void */
-	public function test_owner_is_cached_and_native_requests_use_editor_rendering() {
+	public function test_native_request_owner_is_cached_and_uses_editor_rendering() {
 		$popup_id                    = $this->factory->post->create( [ 'post_type' => 'popup' ] );
 		$builder                     = $this->make_builder();
 		$builder->requested_popup_id = $popup_id;
@@ -246,7 +292,7 @@ class Page_Builders_Test extends WP_UnitTestCase {
 
 		$this->assertSame( 'builder content', $controller->render_popup_content( 'original', $popup_id ) );
 		$this->assertSame( 'builder content', $controller->render_popup_content( 'original', $popup_id ) );
-		$this->assertSame( 1, $builder->ownership_checks );
+		$this->assertSame( 0, $builder->ownership_checks );
 		$this->assertTrue( $builder->last_editor_canvas );
 	}
 

--- a/tests/php/tests/Page_Builders_Test.php
+++ b/tests/php/tests/Page_Builders_Test.php
@@ -88,7 +88,7 @@ class Page_Builders_Test extends WP_UnitTestCase {
 	}
 
 	/** @return void */
-	public function test_authenticated_builder_save_persists_document_owner() {
+	public function test_authenticated_builder_save_persists_and_revalidates_document_owner() {
 		$popup_id   = $this->factory->post->create( [ 'post_type' => 'popup' ] );
 		$builder    = $this->make_builder();
 		$controller = $this->make_controller( $builder );
@@ -101,8 +101,9 @@ class Page_Builders_Test extends WP_UnitTestCase {
 		$builder->owns     = false;
 		$builder->rendered = 'saved builder content';
 
-		$this->assertSame( 'saved builder content', $controller->render_popup_content( 'original', $popup_id ) );
-		$this->assertSame( 0, $builder->ownership_checks );
+		$this->assertSame( 'original', $controller->render_popup_content( 'original', $popup_id ) );
+		$this->assertSame( '', get_post_meta( $popup_id, $controller::OWNER_META_KEY, true ) );
+		$this->assertSame( 1, $builder->ownership_checks );
 	}
 
 	/** @return void */

--- a/tests/php/tests/fixtures/class-elementor-plugin.php
+++ b/tests/php/tests/fixtures/class-elementor-plugin.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Minimal Elementor plugin test double.
+ *
+ * @package Popup_Maker
+ */
+
+namespace Elementor;
+
+if ( ! class_exists( Plugin::class, false ) ) {
+	/**
+	 * Elementor plugin singleton test double.
+	 */
+	class Plugin {
+
+		/**
+		 * Frontend test double.
+		 *
+		 * @var object|null
+		 */
+		public $frontend;
+
+		/**
+		 * Active test instance.
+		 *
+		 * @var object|null
+		 */
+		public static $instance;
+	}
+}


### PR DESCRIPTION
## Summary

Adds complete Elementor support on top of #1300's minimal page-builder foundation.

- Enables Elementor documents for the private `popup` post type when Elementor is active.
- Opens Elementor's real editor iframe against the active site theme and Popup Maker's real theme, overlay, container, title, and inert close button.
- Renders popup documents through Elementor's public frontend APIs on ordinary visitor pages.
- Fires Elementor's native render lifecycle so document/atomic CSS and third-party widget state are registered at the correct boundary.
- Makes Elementor's Preview button open Popup Maker's authorized real-page preview.
- Preserves the existing Elementor Forms conversion integration.
- Adds no custom widget sweep or Elementor-specific reinitialization loop.

The shared controller handles only request authorization and Popup Maker orchestration. The adapter translates Elementor's document/rendering APIs; Elementor remains responsible for its native frontend asset output.

## Verification

- Full Popup Maker PHP suite passes; the large test count is the whole plugin suite, not Elementor-only tests.
- Focused request, ownership, rendering, preview URL, and inactive-overhead tests pass.
- PHPCS, PHPStan, JS/TS checks, and production build pass.
- Live-tested with a real Elementor page and Elementor popup on the same request.
- Confirmed editor controls, responsive sizing/positioning, overlay-disabled canvases, late document CSS, working tabs, repeated open cycles, and the real Preview button.

## Stack

Base: `fix/page-builder-foundation` (#1300).
Next: Bricks in #1294.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added complete Elementor support for Popup Maker popups.
  * Added editor previews, frontend styling, and support for interactive Elementor widgets.
  * Popup previews now integrate with Elementor’s editing experience.

* **Bug Fixes**
  * Improved builder detection so inactive integrations are not loaded or initialized.
  * Added permission checks and validation to prevent unauthorized popup editing and previews.

* **Tests**
  * Added coverage for Elementor previews, permissions, popup validation, and builder compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->