### PR TITLE
Add complete Etch builder support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 -   Added complete Elementor support for building Popup Maker popups, including editor previews, frontend styling, and interactive widgets.
 -   Added complete SiteOrigin Page Builder support for building Popup Maker popups, including its Live Editor and properly styled frontend layouts.
 -   Added complete Visual Composer support for building Popup Maker popups, including visual editing, frontend styling, and interactive elements.
+-   Added complete Etch support for building Popup Maker popups, including its visual editor, selected popup theme, sizing, positioning, and overlay.
 
 **Improvements**
 

--- a/classes/Builders/Etch.php
+++ b/classes/Builders/Etch.php
@@ -23,6 +23,13 @@ defined( 'ABSPATH' ) || exit;
 class Etch extends PageBuilder {
 
 	/**
+	 * Marker confirming that Etch successfully saved this document.
+	 *
+	 * @var string
+	 */
+	const DOCUMENT_META_KEY = '_pum_etch_document';
+
+	/**
 	 * Whether Etch is active.
 	 *
 	 * @return bool
@@ -38,7 +45,62 @@ class Etch extends PageBuilder {
 	 */
 	public function register_hooks() {
 		add_filter( 'post_row_actions', [ $this, 'filter_row_actions' ], 10, 2 );
+		add_filter( 'rest_request_after_callbacks', [ $this, 'remember_rest_save' ], 10, 3 );
 		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_canvas_assets' ], 20 );
+	}
+
+	/**
+	 * Remember Etch after its authenticated block save succeeds.
+	 *
+	 * @param mixed $response REST response.
+	 * @param mixed $handler  Matched REST route handler.
+	 * @param mixed $request  REST request.
+	 *
+	 * @return mixed
+	 */
+	public function remember_rest_save( $response, $handler = null, $request = null ) {
+		if (
+			! $request instanceof \WP_REST_Request ||
+			'POST' !== $request->get_method() ||
+			is_wp_error( $response ) ||
+			( is_object( $response ) && method_exists( $response, 'get_status' ) && 400 <= absint( $response->get_status() ) )
+		) {
+			return $response;
+		}
+
+		$route = $request->get_route();
+
+		if ( ! is_string( $route ) || ! preg_match( '#^/etch-api/post/([\d]+)/blocks/?$#', $route, $matches ) ) {
+			return $response;
+		}
+
+		$popup_id = absint( $matches[1] );
+
+		if (
+			! $popup_id ||
+			'popup' !== get_post_type( $popup_id ) ||
+			! current_user_can( 'edit_post', $popup_id ) ||
+			! $this->can_edit_document( $popup_id )
+		) {
+			return $response;
+		}
+
+		update_post_meta( $popup_id, self::DOCUMENT_META_KEY, '1' );
+		$this->remember_document_owner( $popup_id );
+
+		return $response;
+	}
+
+	/**
+	 * Whether Etch last saved this popup through its native editor.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return bool
+	 */
+	public function owns_document( $popup_id ) {
+		return '1' === get_post_meta( $popup_id, self::DOCUMENT_META_KEY, true ) &&
+			get_class( $this ) === get_post_meta( $popup_id, \PopupMaker\Controllers\Builders::OWNER_META_KEY, true );
 	}
 
 	/**

--- a/classes/Builders/Etch.php
+++ b/classes/Builders/Etch.php
@@ -1,0 +1,158 @@
+<?php
+/**
+ * Etch page builder integration.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Builders;
+
+use PopupMaker\Base\PageBuilder;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Keeps Popup Maker out of Etch's front-page editor shell.
+ *
+ * Etch authors native WordPress blocks, so frontend rendering requires no
+ * custom document renderer. Its editor shell does need request isolation.
+ *
+ * @since 1.25.0
+ */
+class Etch extends PageBuilder {
+
+	/**
+	 * Whether Etch is active.
+	 *
+	 * @return bool
+	 */
+	public function is_available() {
+		return defined( 'ETCH_PLUGIN_FILE' ) || class_exists( '\\Etch\\Plugin', false );
+	}
+
+	/**
+	 * Add Etch's native launch action to popup rows.
+	 *
+	 * @return void
+	 */
+	public function register_hooks() {
+		add_filter( 'post_row_actions', [ $this, 'filter_row_actions' ], 10, 2 );
+		add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_canvas_assets' ], 20 );
+	}
+
+	/**
+	 * Read the popup ID from Etch's editor shell request.
+	 *
+	 * @return int
+	 */
+	public function get_requested_popup_id() {
+		// Etch's editor request has no nonce. The controller applies per-popup
+		// capability checks and can_edit_document() mirrors Etch's own gate.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		if (
+			! isset( $_GET['etch'], $_GET['post_id'] ) ||
+			! is_scalar( $_GET['etch'] ) ||
+			! is_scalar( $_GET['post_id'] )
+		) {
+			return 0;
+		}
+
+		$area     = sanitize_key( wp_unslash( $_GET['etch'] ) );
+		$popup_id = absint( wp_unslash( $_GET['post_id'] ) );
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		return 'magic' === $area ? $popup_id : 0;
+	}
+
+	/**
+	 * Match Etch's own editor permission requirement.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return bool
+	 */
+	public function can_edit_document( $popup_id ) {
+		return current_user_can( 'manage_options' );
+	}
+
+	/**
+	 * Etch renders its canvas inside a front-page application shell.
+	 *
+	 * @return bool
+	 */
+	public function is_canvas_request() {
+		return false;
+	}
+
+	/**
+	 * Show Popup Maker's frame around Etch's iframe-owned document.
+	 *
+	 * Etch mounts its block nodes directly into a same-origin blank iframe. The
+	 * shared preview helper styles that existing body as the popup container; it
+	 * does not wrap, move, or replace any Etch-owned nodes.
+	 *
+	 * @return void
+	 */
+	public function enqueue_canvas_assets() {
+		$builders = $this->container->get_controller( 'Builders' );
+
+		if ( ! $builders instanceof \PopupMaker\Controllers\Builders ) {
+			return;
+		}
+
+		$popup_id = $builders->get_edit_popup_id();
+
+		if ( ! $popup_id || $popup_id !== $this->get_requested_popup_id() ) {
+			return;
+		}
+
+		$this->enqueue_owned_canvas_preview(
+			$popup_id,
+			[
+				'iframe_selector' => '#etch-iframe',
+				'canvas_selector' => 'body',
+				'style_selectors' => [
+					'#popup-maker-site-css',
+					'#popup-maker-site-inline-css',
+				],
+			]
+		);
+	}
+
+	/**
+	 * Add an Edit with Etch link to popup list rows.
+	 *
+	 * @param mixed $actions Existing row actions.
+	 * @param mixed $post    Row post.
+	 *
+	 * @return mixed
+	 */
+	public function filter_row_actions( $actions, $post = null ) {
+		if (
+			! is_array( $actions ) ||
+			! $post instanceof \WP_Post ||
+			'popup' !== $post->post_type ||
+			! current_user_can( 'manage_options' ) ||
+			! current_user_can( 'edit_post', $post->ID )
+		) {
+			return $actions;
+		}
+
+		$url = add_query_arg(
+			[
+				'etch'    => 'magic',
+				'post_id' => $post->ID,
+			],
+			home_url( '/' )
+		);
+
+		$actions['edit_with_etch'] = sprintf(
+			'<a href="%s" target="_blank" rel="noopener noreferrer">%s</a>',
+			esc_url( $url ),
+			esc_html__( 'Edit with Etch', 'popup-maker' )
+		);
+
+		return $actions;
+	}
+}

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -126,6 +126,10 @@ class Builders extends Controller {
 			$builders[] = \PopupMaker\Builders\Bricks::class;
 		}
 
+		if ( defined( 'ETCH_PLUGIN_FILE' ) || class_exists( '\\Etch\\Plugin', false ) ) {
+			$builders[] = \PopupMaker\Builders\Etch::class;
+		}
+
 		return $builders;
 	}
 

--- a/classes/Controllers/PostTypes.php
+++ b/classes/Controllers/PostTypes.php
@@ -85,25 +85,25 @@ class PostTypes extends Controller {
 	private function full_capabilities( $permission, $singular ) {
 		return [
 			// Meta caps -> per-object singular primitives (resolved by map_meta_cap).
-			'edit_post'                    => 'edit_' . $singular,
-			'read_post'                    => 'read_' . $singular,
-			'delete_post'                  => 'delete_' . $singular,
+			'edit_post'              => 'edit_' . $singular,
+			'read_post'              => 'read_' . $singular,
+			'delete_post'            => 'delete_' . $singular,
 			// Singular primitives the meta caps resolve to -> the permission.
-			'edit_' . $singular            => $permission,
-			'read_' . $singular            => $permission,
-			'delete_' . $singular          => $permission,
+			'edit_' . $singular      => $permission,
+			'read_' . $singular      => $permission,
+			'delete_' . $singular    => $permission,
 			// Plural primitive caps -> the permission.
-			'create_posts'                 => $permission,
-			'edit_posts'                   => $permission,
-			'edit_others_posts'            => $permission,
-			'edit_published_posts'         => $permission,
-			'edit_private_posts'           => $permission,
-			'publish_posts'                => $permission,
-			'read_private_posts'           => $permission,
-			'delete_posts'                 => $permission,
-			'delete_others_posts'          => $permission,
-			'delete_published_posts'       => $permission,
-			'delete_private_posts'         => $permission,
+			'create_posts'           => $permission,
+			'edit_posts'             => $permission,
+			'edit_others_posts'      => $permission,
+			'edit_published_posts'   => $permission,
+			'edit_private_posts'     => $permission,
+			'publish_posts'          => $permission,
+			'read_private_posts'     => $permission,
+			'delete_posts'           => $permission,
+			'delete_others_posts'    => $permission,
+			'delete_published_posts' => $permission,
+			'delete_private_posts'   => $permission,
 		];
 	}
 
@@ -162,6 +162,42 @@ class PostTypes extends Controller {
 			};
 
 			$controller->register_routes();
+
+			if ( post_type_supports( $post_type, 'revisions' ) && class_exists( '\\WP_REST_Revisions_Controller' ) ) {
+				$revisions = new class( $post_type ) extends \WP_REST_Revisions_Controller {
+
+					/**
+					 * Set up standard WordPress revision routes for a Popup Maker post type.
+					 *
+					 * @param string $post_type Parent post type key.
+					 */
+					public function __construct( $post_type ) {
+						parent::__construct( $post_type );
+
+						$this->namespace = 'wp/v2';
+					}
+				};
+
+				$revisions->register_routes();
+			}
+
+			if ( class_exists( '\\WP_REST_Autosaves_Controller' ) ) {
+				$autosaves = new class( $post_type ) extends \WP_REST_Autosaves_Controller {
+
+					/**
+					 * Set up standard WordPress autosave routes for a Popup Maker post type.
+					 *
+					 * @param string $post_type Parent post type key.
+					 */
+					public function __construct( $post_type ) {
+						parent::__construct( $post_type );
+
+						$this->namespace = 'wp/v2';
+					}
+				};
+
+				$autosaves->register_routes();
+			}
 		}
 	}
 

--- a/classes/Controllers/PostTypes.php
+++ b/classes/Controllers/PostTypes.php
@@ -26,7 +26,8 @@ class PostTypes extends Controller {
 	 */
 	public function init() {
 		add_action( 'init', [ $this, 'register_post_types' ] );
-		add_action( 'rest_api_init', [ $this, 'register_standard_rest_routes' ] );
+		// Run after core creates its post, revision, and autosave controllers.
+		add_action( 'rest_api_init', [ $this, 'register_standard_rest_routes' ], 100 );
 		add_action( 'save_post_popup', [ $this, 'save_post' ], 10, 3 );
 		add_filter( 'post_updated_messages', [ $this, 'updated_messages' ] );
 

--- a/classes/Controllers/PostTypes.php
+++ b/classes/Controllers/PostTypes.php
@@ -164,6 +164,9 @@ class PostTypes extends Controller {
 
 			$controller->register_routes();
 
+			$original_rest_base          = $post_type_object->rest_base;
+			$post_type_object->rest_base = $rest_base;
+
 			if ( post_type_supports( $post_type, 'revisions' ) && class_exists( '\\WP_REST_Revisions_Controller' ) ) {
 				$revisions = new class( $post_type ) extends \WP_REST_Revisions_Controller {
 
@@ -199,6 +202,8 @@ class PostTypes extends Controller {
 
 				$autosaves->register_routes();
 			}
+
+			$post_type_object->rest_base = $original_rest_base;
 		}
 	}
 

--- a/tests/php/tests/Etch_Builder_Test.php
+++ b/tests/php/tests/Etch_Builder_Test.php
@@ -109,6 +109,56 @@ class Etch_Builder_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'post_id=' . $popup_id, $actions['edit_with_etch'] );
 	}
 
+	/** @return void */
+	public function test_successful_native_rest_save_records_etch_ownership() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$builder  = new class( \PopupMaker\plugin() ) extends Etch {
+
+			/**
+			 * @param int $popup_id Popup ID.
+			 * @return void
+			 */
+			protected function remember_document_owner( $popup_id ) {
+				update_post_meta(
+					$popup_id,
+					\PopupMaker\Controllers\Builders::OWNER_META_KEY,
+					wp_slash( get_class( $this ) )
+				);
+			}
+		};
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		update_post_meta(
+			$popup_id,
+			\PopupMaker\Controllers\Builders::OWNER_META_KEY,
+			\PopupMaker\Builders\Elementor::class
+		);
+
+		$request  = new WP_REST_Request( 'POST', '/etch-api/post/' . $popup_id . '/blocks' );
+		$response = new WP_REST_Response( [ 'post_id' => $popup_id ], 200 );
+
+		$this->assertSame( $response, $builder->remember_rest_save( $response, [], $request ) );
+		$this->assertSame(
+			get_class( $builder ),
+			get_post_meta( $popup_id, \PopupMaker\Controllers\Builders::OWNER_META_KEY, true )
+		);
+		$this->assertTrue( $builder->owns_document( $popup_id ) );
+	}
+
+	/** @return void */
+	public function test_failed_native_rest_save_does_not_record_etch_ownership() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$builder  = new Etch( \PopupMaker\plugin() );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$request  = new WP_REST_Request( 'POST', '/etch-api/post/' . $popup_id . '/blocks' );
+		$response = new WP_REST_Response( [ 'error' => 'Save failed.' ], 400 );
+
+		$this->assertSame( $response, $builder->remember_rest_save( $response, [], $request ) );
+		$this->assertFalse( $builder->owns_document( $popup_id ) );
+	}
+
 	/**
 	 * @return \PopupMaker\Controllers\Builders
 	 */

--- a/tests/php/tests/Etch_Builder_Test.php
+++ b/tests/php/tests/Etch_Builder_Test.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Etch builder shell compatibility tests.
+ *
+ * @package Popup_Maker
+ */
+
+use PopupMaker\Base\PageBuilder;
+use PopupMaker\Builders\Etch;
+
+/**
+ * Test Etch requests without loading Etch itself.
+ */
+class Etch_Builder_Test extends WP_UnitTestCase {
+
+	/** @var array<string,mixed> */
+	private $original_get;
+
+	/** @return void */
+	public function setUp(): void {
+		parent::setUp();
+
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Test fixture preserves request globals.
+		$this->original_get = $_GET;
+	}
+
+	/** @return void */
+	public function tearDown(): void {
+		$_GET = $this->original_get;
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/** @return void */
+	public function test_etch_request_requires_the_magic_area() {
+		$builder = new Etch( \PopupMaker\plugin() );
+
+		$_GET = [
+			'etch'    => 'magic',
+			'post_id' => '123',
+		];
+		$this->assertSame( 123, $builder->get_requested_popup_id() );
+
+		$_GET['etch'] = 'frontend';
+		$this->assertSame( 0, $builder->get_requested_popup_id() );
+
+		unset( $_GET['post_id'] );
+		$this->assertSame( 0, $builder->get_requested_popup_id() );
+	}
+
+	/** @return void */
+	public function test_etch_matches_its_administrator_permission_gate() {
+		$builder = new Etch( \PopupMaker\plugin() );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'editor' ] ) );
+		$this->assertFalse( $builder->can_edit_document( 123 ) );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		$this->assertTrue( $builder->can_edit_document( 123 ) );
+	}
+
+	/** @return void */
+	public function test_authorized_etch_shell_preserves_front_page_and_suppresses_popups() {
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+			]
+		);
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		$this->set_etch_request( $popup_id );
+
+		$controller = $this->make_controller();
+		$query      = [ 'page_id' => 2 ];
+
+		$this->assertSame( $query, $controller->allow_builder_request( $query ) );
+		$this->assertSame( $popup_id, $controller->get_edit_popup_id() );
+		$this->assertSame( 0, $controller->get_canvas_popup_id() );
+		$this->assertFalse( $controller->is_canvas_popup_loadable( true, $popup_id ) );
+		$this->assertFalse( $controller->is_canvas_popup_loadable( true, $popup_id + 1 ) );
+	}
+
+	/** @return void */
+	public function test_unauthorized_etch_request_does_not_change_popup_loading() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'subscriber' ] ) );
+		$this->set_etch_request( $popup_id );
+
+		$controller = $this->make_controller();
+
+		$this->assertSame( 0, $controller->get_edit_popup_id() );
+		$this->assertTrue( $controller->is_canvas_popup_loadable( true, $popup_id ) );
+	}
+
+	/** @return void */
+	public function test_popup_rows_include_an_etch_launch_action_for_administrators() {
+		$popup_id = $this->factory->post->create( [ 'post_type' => 'popup' ] );
+		$builder  = new Etch( \PopupMaker\plugin() );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$actions = $builder->filter_row_actions( [], get_post( $popup_id ) );
+
+		$this->assertArrayHasKey( 'edit_with_etch', $actions );
+		$this->assertStringContainsString( 'etch=magic', $actions['edit_with_etch'] );
+		$this->assertStringContainsString( 'post_id=' . $popup_id, $actions['edit_with_etch'] );
+	}
+
+	/**
+	 * @return \PopupMaker\Controllers\Builders
+	 */
+	private function make_controller() {
+		$builder    = new class( \PopupMaker\plugin() ) extends Etch {
+
+			/** @return bool */
+			public function is_available() {
+				return true;
+			}
+		};
+		$controller = new class( \PopupMaker\plugin(), $builder ) extends \PopupMaker\Controllers\Builders {
+
+			/** @var PageBuilder */
+			private $test_builder;
+
+			/**
+			 * @param \PopupMaker\Plugin\Core $container Plugin container.
+			 * @param PageBuilder             $builder Builder integration.
+			 */
+			public function __construct( $container, PageBuilder $builder ) {
+				$this->test_builder = $builder;
+
+				parent::__construct( $container );
+			}
+
+			/** @return string[] */
+			protected function detected_builder_classes() {
+				return [ get_class( $this->test_builder ) ];
+			}
+
+			/**
+			 * @param string $builder_class Builder class.
+			 * @return PageBuilder
+			 */
+			protected function instantiate_builder( $builder_class ) {
+				unset( $builder_class );
+
+				return $this->test_builder;
+			}
+		};
+		$controller->init();
+
+		return $controller;
+	}
+
+	/**
+	 * @param int $popup_id Popup ID.
+	 * @return void
+	 */
+	private function set_etch_request( $popup_id ) {
+		$_GET = [
+			'etch'    => 'magic',
+			'post_id' => (string) $popup_id,
+		];
+	}
+}

--- a/tests/php/tests/Etch_Compatibility_Test.php
+++ b/tests/php/tests/Etch_Compatibility_Test.php
@@ -1,0 +1,218 @@
+<?php
+/**
+ * Etch compatibility through WordPress-native blocks.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Test the generic contracts used by Etch-authored popup documents.
+ */
+class Etch_Compatibility_Test extends WP_UnitTestCase {
+
+	/**
+	 * Test block name.
+	 *
+	 * @var string
+	 */
+	const BLOCK_NAME = 'etch/popup-maker-test';
+
+	/**
+	 * Register an Etch-shaped dynamic block for each test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		wp_register_style( 'etch-popup-maker-test', false, [], 'test' );
+		wp_register_script( 'etch-popup-maker-test', false, [], 'test', true );
+
+		register_block_type(
+			self::BLOCK_NAME,
+			[
+				'attributes'      => [
+					'label' => [
+						'type'    => 'string',
+						'default' => '',
+					],
+				],
+				'style'           => 'etch-popup-maker-test',
+				'script'          => 'etch-popup-maker-test',
+				'render_callback' => static function ( $attributes ) {
+					$label = isset( $attributes['label'] ) && is_string( $attributes['label'] )
+						? $attributes['label']
+						: '';
+
+					return '<div data-etch-test="document">' . esc_html( $label ) . '</div>';
+				},
+			]
+		);
+	}
+
+	/**
+	 * Remove the test block and its assets.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		unregister_block_type( self::BLOCK_NAME );
+
+		wp_dequeue_style( 'etch-popup-maker-test' );
+		wp_deregister_style( 'etch-popup-maker-test' );
+		wp_dequeue_script( 'etch-popup-maker-test' );
+		wp_deregister_script( 'etch-popup-maker-test' );
+
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Popup Maker renders Etch-authored custom blocks through its native pipeline.
+	 *
+	 * @return void
+	 */
+	public function test_etch_authored_block_renders_in_popup_content() {
+		$popup_id = $this->create_popup( 'Popup document' );
+		$content  = pum_get_popup( $popup_id )->get_content();
+
+		$this->assertSame(
+			'<div data-etch-test="document">Popup document</div>',
+			$content
+		);
+		$this->assertTrue( wp_style_is( 'etch-popup-maker-test', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'etch-popup-maker-test', 'enqueued' ) );
+	}
+
+	/**
+	 * A normal page document and a popup document render independently.
+	 *
+	 * @return void
+	 */
+	public function test_page_and_popup_etch_documents_coexist() {
+		$page_content = $this->block_markup( 'Main page document' );
+		$popup_id     = $this->create_popup( 'Popup document' );
+
+		$page_output  = do_blocks( $page_content );
+		$popup_output = pum_get_popup( $popup_id )->get_content();
+
+		$this->assertStringContainsString( 'Main page document', $page_output );
+		$this->assertStringNotContainsString( 'Popup document', $page_output );
+		$this->assertStringContainsString( 'Popup document', $popup_output );
+		$this->assertStringNotContainsString( 'Main page document', $popup_output );
+	}
+
+	/**
+	 * Preloading renders blocks early enough to discover their frontend assets.
+	 *
+	 * @return void
+	 */
+	public function test_popup_preload_discovers_etch_block_assets_before_render() {
+		$popup_id = $this->create_popup( 'Preloaded document' );
+		$popup    = pum_get_popup( $popup_id );
+		$popups   = PopupMaker\plugin()->get_controller( 'Frontend\\Popups' );
+
+		$this->assertInstanceOf( PopupMaker\Controllers\Frontend\Popups::class, $popups );
+		$this->assertFalse( wp_style_is( 'etch-popup-maker-test', 'enqueued' ) );
+		$this->assertFalse( wp_script_is( 'etch-popup-maker-test', 'enqueued' ) );
+
+		$popups->preload_popup( $popup );
+
+		$this->assertTrue( wp_style_is( 'etch-popup-maker-test', 'enqueued' ) );
+		$this->assertTrue( wp_script_is( 'etch-popup-maker-test', 'enqueued' ) );
+		$this->assertStringContainsString(
+			'Preloaded document',
+			$popups->get_content_cache( $popup_id )
+		);
+	}
+
+	/**
+	 * Etch can read and update popup block content through core REST semantics.
+	 *
+	 * @return void
+	 */
+	public function test_standard_rest_route_reads_and_updates_etch_block_content() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->create_popup( 'Initial document', 'draft' );
+		$updated  = $this->block_markup( 'Updated through REST' );
+
+		wp_set_current_user( $admin_id );
+
+		$request = new WP_REST_Request( 'POST', '/wp/v2/popups/' . $popup_id );
+		$request->set_param( 'content', $updated );
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame( $updated, get_post_field( 'post_content', $popup_id ) );
+		$this->assertSame( $updated, $response->get_data()['content']['raw'] );
+	}
+
+	/**
+	 * Private popup documents remain unavailable to anonymous REST requests.
+	 *
+	 * @return void
+	 */
+	public function test_standard_rest_route_keeps_draft_popup_private() {
+		$popup_id = $this->create_popup( 'Private document', 'draft' );
+
+		wp_set_current_user( 0 );
+
+		$response = rest_do_request( new WP_REST_Request( 'GET', '/wp/v2/popups/' . $popup_id ) );
+
+		$this->assertSame( 401, $response->get_status() );
+	}
+
+	/**
+	 * Core revision and autosave endpoints exist for Etch's editing lifecycle.
+	 *
+	 * @return void
+	 */
+	public function test_standard_rest_route_exposes_revision_and_autosave_controllers() {
+		global $wp_rest_server;
+
+		$wp_rest_server = null;
+		$routes         = rest_get_server()->get_routes();
+
+		$this->assertArrayHasKey( '/wp/v2/popups/(?P<parent>[\\d]+)/revisions', $routes );
+		$this->assertArrayHasKey( '/wp/v2/popups/(?P<id>[\\d]+)/autosaves', $routes );
+	}
+
+	/**
+	 * Create a popup containing a serialized test block.
+	 *
+	 * @param string $label  Block label.
+	 * @param string $status Post status.
+	 *
+	 * @return int
+	 */
+	private function create_popup( $label, $status = 'publish' ) {
+		return $this->factory->post->create(
+			[
+				'post_type'    => 'popup',
+				'post_status'  => $status,
+				'post_title'   => $label,
+				'post_content' => $this->block_markup( $label ),
+			]
+		);
+	}
+
+	/**
+	 * Serialize an Etch-shaped custom block.
+	 *
+	 * @param string $label Block label.
+	 *
+	 * @return string
+	 */
+	private function block_markup( $label ) {
+		return serialize_block(
+			[
+				'blockName'    => self::BLOCK_NAME,
+				'attrs'        => [ 'label' => $label ],
+				'innerBlocks'  => [],
+				'innerHTML'    => '',
+				'innerContent' => [],
+			]
+		);
+	}
+}

--- a/tests/php/tests/Etch_Compatibility_Test.php
+++ b/tests/php/tests/Etch_Compatibility_Test.php
@@ -179,6 +179,35 @@ class Etch_Compatibility_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Child routes follow Popup Maker's alias when another integration changes the native base.
+	 *
+	 * @return void
+	 */
+	public function test_standard_rest_child_routes_follow_the_alias_base() {
+		global $wp_rest_server;
+
+		$post_type = get_post_type_object( 'popup' );
+
+		if ( ! $post_type ) {
+			$this->fail( 'Popup post type was not registered.' );
+		}
+
+		$original_rest_base   = $post_type->rest_base;
+		$post_type->rest_base = 'third-party-popups';
+		$wp_rest_server       = null;
+
+		try {
+			$routes = rest_get_server()->get_routes();
+		} finally {
+			$post_type->rest_base = $original_rest_base;
+			$wp_rest_server       = null;
+		}
+
+		$this->assertArrayHasKey( '/wp/v2/popups/(?P<parent>[\\d]+)/revisions', $routes );
+		$this->assertArrayHasKey( '/wp/v2/popups/(?P<id>[\\d]+)/autosaves', $routes );
+	}
+
+	/**
 	 * Create a popup containing a serialized test block.
 	 *
 	 * @param string $label  Block label.

--- a/tests/php/tests/Page_Builders_Test.php
+++ b/tests/php/tests/Page_Builders_Test.php
@@ -202,7 +202,9 @@ class Page_Builders_Test extends WP_UnitTestCase {
 			function_exists( 'et_setup_builder' ) ||
 			class_exists( 'ET_Builder_Plugin' ) ||
 			defined( 'BRICKS_VERSION' ) ||
-			class_exists( '\\Bricks\\Database', false )
+			class_exists( '\\Bricks\\Database', false ) ||
+			defined( 'ETCH_PLUGIN_FILE' ) ||
+			class_exists( '\\Etch\\Plugin', false )
 		) {
 			$this->markTestSkipped( 'A bundled builder is active in this test environment.' );
 		}
@@ -214,6 +216,7 @@ class Page_Builders_Test extends WP_UnitTestCase {
 		$visual_composer_loaded = class_exists( \PopupMaker\Builders\VisualComposer::class, false );
 		$divi_loaded            = class_exists( \PopupMaker\Builders\Divi::class, false );
 		$bricks_loaded          = class_exists( \PopupMaker\Builders\Bricks::class, false );
+		$etch_loaded            = class_exists( \PopupMaker\Builders\Etch::class, false );
 		$controller             = new class( \PopupMaker\plugin() ) extends \PopupMaker\Controllers\Builders {
 
 			/** @var int */
@@ -240,6 +243,7 @@ class Page_Builders_Test extends WP_UnitTestCase {
 		$this->assertSame( $visual_composer_loaded, class_exists( \PopupMaker\Builders\VisualComposer::class, false ) );
 		$this->assertSame( $divi_loaded, class_exists( \PopupMaker\Builders\Divi::class, false ) );
 		$this->assertSame( $bricks_loaded, class_exists( \PopupMaker\Builders\Bricks::class, false ) );
+		$this->assertSame( $etch_loaded, class_exists( \PopupMaker\Builders\Etch::class, false ) );
 	}
 
 	/** @return void */


### PR DESCRIPTION
## Summary

Adds complete Etch support for building Popup Maker popups with Etch-native WordPress blocks.

- Recognizes the front-page Etch editor shell and adds an Edit with Etch row action.
- Uses the shared builder-owned canvas primitive from #1335 to show the selected Popup Maker theme, size, position, overlay, title, and inert close control inside the Etch iframe without moving block nodes.
- Preserves the Etch editor shell while suppressing unrelated live popup output.
- Keeps frontend rendering on the native WordPress block and asset pipeline.
- Exposes the standard post, revision, and autosave REST routes Etch expects after WordPress initializes their core controllers.
- Adds an Unreleased changelog entry for Etch support.

This is the thin Etch adapter and REST compatibility layer; the reusable canvas implementation and its JavaScript tests live in #1335.

## Verification

- Full combined-branch PHPUnit: 980 tests, 2,273 assertions, 2 environment-dependent skips.
- Focused PHPUnit: 33 tests, 134 assertions.
- Full combined-branch JavaScript suite: 29 suites, 407 tests.
- Full plugin build, TypeScript build, JavaScript lint, PHPCS, targeted PHPStan, and git diff check passed.
- Previously live-tested in an isolated WordPress environment with Etch 1.5.4 and Etch Theme 0.0.7.
- Live browser coverage included themed responsive and fixed popups, overlay enabled and disabled, narrow-canvas clamping, title, close button, scrolling, and block selection.
- Verified Etch-authored blocks render through Popup Maker's normal frontend pipeline.

Depends on #1335. Closes #1305



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added complete Etch support for creating and editing Popup Maker popups.
  * Edit eligible popups directly with Etch from the popup list.
  * Configure popup themes, sizing, positioning, and overlays through the visual editor.

* **Compatibility**
  * Improved rendering and asset loading for Etch-authored content inside popups.
  * Added support for editing and saving popup content through standard WordPress editor routes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->