### PR TITLE
Reduce frontend PHP bootstrap memory further

### DIFF
--- a/classes/Admin.php
+++ b/classes/Admin.php
@@ -19,16 +19,20 @@ class PUM_Admin {
 			PUM_Admin_Notices::init();
 		}
 
-		PUM_Admin_Popups::init();
-		PUM_Admin_Themes::init();
-
 		if ( is_admin() ) {
+			PUM_Admin_Popups::init();
+			PUM_Admin_Themes::init();
 			PUM_Admin_Subscribers::init();
 			PUM_Admin_Settings::init();
 			PUM_Admin_Tools::init();
 			PUM_Admin_Shortcode_UI::init();
 			PUM_Upsell::init();
 			PUM_Admin_Onboarding::init();
+		} else {
+			// Preserve programmatic saves without loading the editor classes on every frontend request.
+			add_action( 'save_post', [ 'PUM_Admin_Popups', 'save' ], 10, 2 );
+			add_filter( 'wp_insert_post_data', [ 'PUM_Admin_Popups', 'set_slug' ], 99, 2 );
+			add_action( 'save_post', [ 'PUM_Admin_Themes', 'save' ], 10, 2 );
 		}
 
 		add_filter( 'user_has_cap', [ __CLASS__, 'prevent_default_theme_deletion' ], 10, 3 );

--- a/classes/Plugin/Core.php
+++ b/classes/Plugin/Core.php
@@ -21,27 +21,6 @@ defined( 'ABSPATH' ) || exit;
 final class Core extends \PopupMaker\Plugin\Container {
 
 	/**
-	 * Events that require notification providers on frontend requests.
-	 *
-	 * @var string[]
-	 */
-	private const DEFERRED_NOTIFICATION_HOOKS = [
-		'popup_maker/update_version',
-		'pum_alert_list',
-		'pum_alert_dismissed',
-		'save_post_popup',
-		'save_post_pum_cta',
-		'deleted_post',
-		'trashed_post',
-		'untrashed_post',
-		'update_option_pum_form_conversion_count',
-		'update_option_pum_total_conversion_count',
-		'update_option_pum_bypass_adblockers',
-		'activated_plugin',
-		'deactivated_plugin',
-	];
-
-	/**
 	 * Initiate the plugin.
 	 *
 	 * @param array<string,string|bool> $config Configuration variables passed from main plugin file.
@@ -369,34 +348,15 @@ final class Core extends \PopupMaker\Plugin\Container {
 		$form_conversion_tracking->init();
 
 		/*
-		 * Defer notifications orchestrator init until WordPress's `init`
+		 * Defer notification bootstrap until WordPress's `init`
 		 * action. Core loads on plugins_loaded@11, but addons (Pro, Pro+,
 		 * integrations) load at priority 12+ and need a window to register
-		 * their own providers via the `popup_maker/notification_providers`
-		 * filter before the Manager resolves the provider list.
+		 * their own providers and deferred trigger hooks before the Manager
+		 * resolves the provider list or registers frontend lazy boot hooks.
 		 */
 		add_action( 'init', function () {
-			if ( is_admin() ) {
-				$this->get( 'notifications' )->init();
-				return;
-			}
-
-			foreach ( self::DEFERRED_NOTIFICATION_HOOKS as $hook ) {
-				add_filter( $hook, [ $this, 'init_notifications_on_demand' ], PHP_INT_MIN );
-			}
+			$this->get( 'notifications' )->register_lazy_boot();
 		}, 5 );
-	}
-
-	/**
-	 * Boot notification providers when a frontend request reaches a relevant event.
-	 *
-	 * @param mixed $value Current filter value, if any.
-	 * @return mixed
-	 */
-	public function init_notifications_on_demand( $value = null ) {
-		$this->get( 'notifications' )->init();
-
-		return $value;
 	}
 
 	/**

--- a/classes/Plugin/Core.php
+++ b/classes/Plugin/Core.php
@@ -21,6 +21,27 @@ defined( 'ABSPATH' ) || exit;
 final class Core extends \PopupMaker\Plugin\Container {
 
 	/**
+	 * Events that require notification providers on frontend requests.
+	 *
+	 * @var string[]
+	 */
+	private const DEFERRED_NOTIFICATION_HOOKS = [
+		'popup_maker/update_version',
+		'pum_alert_list',
+		'pum_alert_dismissed',
+		'save_post_popup',
+		'save_post_pum_cta',
+		'deleted_post',
+		'trashed_post',
+		'untrashed_post',
+		'update_option_pum_form_conversion_count',
+		'update_option_pum_total_conversion_count',
+		'update_option_pum_bypass_adblockers',
+		'activated_plugin',
+		'deactivated_plugin',
+	];
+
+	/**
 	 * Initiate the plugin.
 	 *
 	 * @param array<string,string|bool> $config Configuration variables passed from main plugin file.
@@ -355,8 +376,27 @@ final class Core extends \PopupMaker\Plugin\Container {
 		 * filter before the Manager resolves the provider list.
 		 */
 		add_action( 'init', function () {
-			$this->get( 'notifications' )->init();
+			if ( is_admin() ) {
+				$this->get( 'notifications' )->init();
+				return;
+			}
+
+			foreach ( self::DEFERRED_NOTIFICATION_HOOKS as $hook ) {
+				add_filter( $hook, [ $this, 'init_notifications_on_demand' ], PHP_INT_MIN );
+			}
 		}, 5 );
+	}
+
+	/**
+	 * Boot notification providers when a frontend request reaches a relevant event.
+	 *
+	 * @param mixed $value Current filter value, if any.
+	 * @return mixed
+	 */
+	public function init_notifications_on_demand( $value = null ) {
+		$this->get( 'notifications' )->init();
+
+		return $value;
 	}
 
 	/**

--- a/classes/Services/Notifications/Manager.php
+++ b/classes/Services/Notifications/Manager.php
@@ -67,6 +67,7 @@ class Manager extends Service {
 		if ( $this->booted ) {
 			return;
 		}
+
 		$this->booted = true;
 
 		$this->providers = $this->resolve_providers();
@@ -87,6 +88,8 @@ class Manager extends Service {
 	 * @return array<int,Provider>
 	 */
 	public function get_providers() {
+		$this->init();
+
 		return $this->providers;
 	}
 

--- a/classes/Services/Notifications/Manager.php
+++ b/classes/Services/Notifications/Manager.php
@@ -91,6 +91,14 @@ class Manager extends Service {
 		}
 
 		foreach ( $this->get_deferred_boot_hooks() as $hook ) {
+			if ( did_action( $hook ) || did_filter( $hook ) ) {
+				// The event already fired earlier in this request — e.g. an
+				// upgrade dispatches popup_maker/update_version during
+				// plugins_loaded, before this registration runs on init.
+				$this->init();
+				return;
+			}
+
 			add_filter( $hook, [ $this, 'boot_on_demand' ], PHP_INT_MIN );
 		}
 	}

--- a/classes/Services/Notifications/Manager.php
+++ b/classes/Services/Notifications/Manager.php
@@ -80,6 +80,64 @@ class Manager extends Service {
 	}
 
 	/**
+	 * Boot notifications immediately in wp-admin or defer them to relevant frontend hooks.
+	 *
+	 * @return void
+	 */
+	public function register_lazy_boot() {
+		if ( is_admin() ) {
+			$this->init();
+			return;
+		}
+
+		foreach ( $this->get_deferred_boot_hooks() as $hook ) {
+			add_filter( $hook, [ $this, 'boot_on_demand' ], PHP_INT_MIN );
+		}
+	}
+
+	/**
+	 * Get hooks that can trigger lazy notification boot on frontend requests.
+	 *
+	 * Extensions (Pro, Pro+, legacy) can append their own trigger hooks via the
+	 * `popup_maker/notifications/deferred_boot_hooks` filter. Any consumer that
+	 * calls get_providers() boots the manager regardless, so this filter is an
+	 * optimization and not a correctness requirement.
+	 *
+	 * @return string[]
+	 */
+	protected function get_deferred_boot_hooks() {
+		$defaults = [
+			'popup_maker/update_version',
+			'pum_alert_list',
+			'pum_alert_dismissed',
+			'save_post_popup',
+			'save_post_pum_cta',
+			'deleted_post',
+			'trashed_post',
+			'untrashed_post',
+			'update_option_pum_form_conversion_count',
+			'update_option_pum_total_conversion_count',
+			'update_option_pum_bypass_adblockers',
+			'activated_plugin',
+			'deactivated_plugin',
+		];
+
+		return apply_filters( 'popup_maker/notifications/deferred_boot_hooks', $defaults );
+	}
+
+	/**
+	 * Boot notification providers when a frontend request reaches a relevant hook.
+	 *
+	 * @param mixed $value Current filter value, if any.
+	 * @return mixed
+	 */
+	public function boot_on_demand( $value = null ) {
+		$this->init();
+
+		return $value;
+	}
+
+	/**
 	 * Currently booted providers.
 	 *
 	 * Useful for debugging and for addons that want to swap or decorate

--- a/classes/Services/Notifications/Provider.php
+++ b/classes/Services/Notifications/Provider.php
@@ -16,9 +16,9 @@ defined( 'ABSPATH' ) || exit;
  * entries to the `pum_alert_list` filter and optionally reacts to
  * dismissals, version changes, or other plugin events.
  *
- * Providers are booted once during plugin load via
- * `Notifications::init()` — each is given the opportunity to wire its own
- * hooks inside its `init()` method.
+ * Providers are booted once via `Notifications::init()` — each is given the
+ * opportunity to wire its own hooks inside its `init()` method. Frontend
+ * requests may defer that boot until a notification-related event.
  *
  * @since 1.23.0
  */

--- a/includes/legacy/class-popup-maker.php
+++ b/includes/legacy/class-popup-maker.php
@@ -169,9 +169,7 @@ class Popup_Maker {
 		PUM_Utils_Upgrades::instance();
 		PUM_Newsletters::init();
 		PUM_Integrations::init();
-		PUM_Privacy::init();
-
-		PUM_Utils_Alerts::init();
+		$this->register_deferred_hooks();
 
 		PUM_Shortcode_Popup::init();
 		PUM_Shortcode_PopupTrigger::init();
@@ -179,9 +177,32 @@ class Popup_Maker {
 		PUM_Shortcode_PopupCookie::init();
 		PUM_Shortcode_CallToAction::init();
 
-		PUM_Telemetry::init();
-
 		new PUM_Extensions();
+	}
+
+	/**
+	 * Register hooks whose handlers are not needed during normal frontend bootstrap.
+	 *
+	 * String callbacks preserve the existing hooks while allowing WordPress to
+	 * autoload each implementation only when its hook runs.
+	 *
+	 * @return void
+	 */
+	private function register_deferred_hooks() {
+		add_filter( 'wp_privacy_personal_data_exporters', [ 'PUM_Privacy', 'register_exporter' ], 10 );
+		add_filter( 'wp_privacy_personal_data_erasers', [ 'PUM_Privacy', 'register_erasers' ], 10 );
+		add_action( 'admin_init', [ 'PUM_Privacy', 'privacy_policy_content' ], 20 );
+		add_action( 'pum_save_popup', [ 'PUM_Privacy', 'clear_cookie_list' ] );
+
+		add_action( 'admin_init', [ 'PUM_Utils_Alerts', 'hooks' ] );
+		add_action( 'admin_init', [ 'PUM_Utils_Alerts', 'php_handler' ] );
+		add_action( 'wp_ajax_pum_alerts_action', [ 'PUM_Utils_Alerts', 'ajax_handler' ] );
+		add_filter( 'pum_alert_list', [ 'PUM_Utils_Alerts', 'translation_request' ], 10 );
+		add_action( 'admin_menu', [ 'PUM_Utils_Alerts', 'append_alert_count' ], 999 );
+
+		add_action( 'pum_daily_scheduled_events', [ 'PUM_Telemetry', 'track_check' ] );
+		add_filter( 'pum_alert_list', [ 'PUM_Telemetry', 'optin_alert' ] );
+		add_action( 'pum_alert_dismissed', [ 'PUM_Telemetry', 'optin_alert_check' ], 10, 2 );
 	}
 
 	/**

--- a/tests/php/fixtures/class-pum-test-deferred-notification-provider.php
+++ b/tests/php/fixtures/class-pum-test-deferred-notification-provider.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Test provider used to verify hooks added during an active filter still run.
+ *
+ * @package Popup_Maker
+ */
+
+class PUM_Test_Deferred_Notification_Provider implements \PopupMaker\Services\Notifications\Provider {
+
+	/**
+	 * @return void
+	 */
+	public function init() {
+		add_filter( 'pum_alert_list', [ $this, 'add_alert' ], PHP_INT_MIN + 1 );
+	}
+
+	/**
+	 * @param array $alerts Registered alerts.
+	 * @return array
+	 */
+	public function add_alert( $alerts ) {
+		$alerts[] = [ 'code' => 'deferred_test_provider' ];
+
+		return $alerts;
+	}
+}

--- a/tests/php/tests/Notification_Manager_Loader_Test.php
+++ b/tests/php/tests/Notification_Manager_Loader_Test.php
@@ -75,4 +75,60 @@ class Notification_Manager_Loader_Test extends WP_UnitTestCase {
 		$this->assertSame( PHP_INT_MIN + 1, has_filter( 'pum_alert_list', [ $provider, 'add_alert' ] ) );
 		$this->assertContains( $provider, $manager->get_providers() );
 	}
+
+	/**
+	 * An upgrade fires popup_maker/update_version during plugins_loaded,
+	 * before init@5 registers lazy boot — the manager must boot immediately
+	 * when a deferred hook already fired earlier in the request.
+	 *
+	 * @return void
+	 */
+	public function test_lazy_boot_inits_immediately_when_deferred_hook_already_fired() {
+		$manager  = new \PopupMaker\Services\Notifications\Manager( \PopupMaker\plugin() );
+		$provider = new PUM_Test_Deferred_Notification_Provider();
+
+		$this->assertFalse( is_admin() );
+
+		add_filter(
+			'popup_maker/notification_providers',
+			static function ( $providers ) use ( $provider ) {
+				$providers[] = $provider;
+				return $providers;
+			}
+		);
+
+		// Simulate the upgrade action firing before register_lazy_boot runs.
+		do_action( 'popup_maker/update_version', '1.0.0', '0.9.0' );
+
+		$manager->register_lazy_boot();
+
+		$this->assertContains( $provider, $manager->get_providers() );
+	}
+
+	/**
+	 * Core must wire the Manager's lazy boot on init — verify through the
+	 * real booted plugin rather than a locally constructed manager.
+	 *
+	 * @return void
+	 */
+	public function test_core_registers_manager_lazy_boot_on_init() {
+		$manager = \PopupMaker\plugin( 'notifications' );
+
+		// Core's wiring results in one of two valid states: deferred boot
+		// filters registered, or an immediate boot because a deferred hook
+		// (e.g. popup_maker/update_version on a fresh install) already fired.
+		$deferred = false !== has_filter( 'pum_alert_list', [ $manager, 'boot_on_demand' ] );
+
+		$booted_prop = new ReflectionProperty( $manager, 'booted' );
+
+		if ( PHP_VERSION_ID < 80100 ) {
+			// Required before PHP 8.1, deprecated no-op on PHP 8.5+.
+			$booted_prop->setAccessible( true );
+		}
+
+		$this->assertTrue(
+			$deferred || $booted_prop->getValue( $manager ),
+			'Core should register the real manager for deferred boot on frontend requests.'
+		);
+	}
 }

--- a/tests/php/tests/Notification_Manager_Loader_Test.php
+++ b/tests/php/tests/Notification_Manager_Loader_Test.php
@@ -21,13 +21,37 @@ class Notification_Manager_Loader_Test extends WP_UnitTestCase {
 	public function test_alert_filter_boots_deferred_providers_in_current_iteration() {
 		$manager  = new \PopupMaker\Services\Notifications\Manager( \PopupMaker\plugin() );
 		$provider = new PUM_Test_Deferred_Notification_Provider();
-		$loader   = static function ( $alerts ) use ( $manager ) {
-			$manager->init();
-			return $alerts;
-		};
 
 		$this->assertFalse( is_admin() );
-		add_filter( 'pum_alert_list', $loader, PHP_INT_MIN );
+
+		add_filter(
+			'popup_maker/notification_providers',
+			static function ( $providers ) use ( $provider ) {
+				$providers[] = $provider;
+				return $providers;
+			}
+		);
+		$manager->register_lazy_boot();
+
+		$alerts = apply_filters( 'pum_alert_list', [] );
+		$codes  = wp_list_pluck( $alerts, 'code' );
+
+		$this->assertContains( 'deferred_test_provider', $codes );
+		$this->assertContains( $provider, $manager->get_providers() );
+	}
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_custom_deferred_boot_hook_boots_the_manager_on_frontend() {
+		$manager     = new \PopupMaker\Services\Notifications\Manager( \PopupMaker\plugin() );
+		$provider    = new PUM_Test_Deferred_Notification_Provider();
+		$custom_hook = 'pum_test_custom_deferred_notification_boot';
+
+		$this->assertFalse( is_admin() );
 
 		add_filter(
 			'popup_maker/notification_providers',
@@ -37,10 +61,18 @@ class Notification_Manager_Loader_Test extends WP_UnitTestCase {
 			}
 		);
 
-		$alerts = apply_filters( 'pum_alert_list', [] );
-		$codes  = wp_list_pluck( $alerts, 'code' );
+		add_filter(
+			'popup_maker/notifications/deferred_boot_hooks',
+			static function ( $hooks ) use ( $custom_hook ) {
+				$hooks[] = $custom_hook;
+				return $hooks;
+			}
+		);
 
-		$this->assertContains( 'deferred_test_provider', $codes );
+		$manager->register_lazy_boot();
+
+		$this->assertSame( 'original-value', apply_filters( $custom_hook, 'original-value' ) );
+		$this->assertSame( PHP_INT_MIN + 1, has_filter( 'pum_alert_list', [ $provider, 'add_alert' ] ) );
 		$this->assertContains( $provider, $manager->get_providers() );
 	}
 }

--- a/tests/php/tests/Notification_Manager_Loader_Test.php
+++ b/tests/php/tests/Notification_Manager_Loader_Test.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Tests for on-demand notification provider loading.
+ *
+ * @package Popup_Maker
+ */
+
+require_once dirname( __DIR__ ) . '/fixtures/class-pum-test-deferred-notification-provider.php';
+
+/**
+ * Verify frontend requests load notification providers when needed.
+ */
+class Notification_Manager_Loader_Test extends WP_UnitTestCase {
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_alert_filter_boots_deferred_providers_in_current_iteration() {
+		$manager  = new \PopupMaker\Services\Notifications\Manager( \PopupMaker\plugin() );
+		$provider = new PUM_Test_Deferred_Notification_Provider();
+		$loader   = static function ( $alerts ) use ( $manager ) {
+			$manager->init();
+			return $alerts;
+		};
+
+		$this->assertFalse( is_admin() );
+		add_filter( 'pum_alert_list', $loader, PHP_INT_MIN );
+
+		add_filter(
+			'popup_maker/notification_providers',
+			static function ( $providers ) use ( $provider ) {
+				$providers[] = $provider;
+				return $providers;
+			}
+		);
+
+		$alerts = apply_filters( 'pum_alert_list', [] );
+		$codes  = wp_list_pluck( $alerts, 'code' );
+
+		$this->assertContains( 'deferred_test_provider', $codes );
+		$this->assertContains( $provider, $manager->get_providers() );
+	}
+}

--- a/tests/php/tests/PUM_Admin_Loader_Test.php
+++ b/tests/php/tests/PUM_Admin_Loader_Test.php
@@ -50,12 +50,18 @@ class PUM_Admin_Loader_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Frontend bootstrap defers the heavy editor classes until their save hooks run.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
 	 * @return void
 	 */
 	public function test_frontend_loads_only_cross_context_admin_hooks() {
 		$this->assertFalse( is_admin() );
 		$this->assertSame( 10, has_action( 'save_post', [ 'PUM_Admin_Popups', 'save' ] ) );
 		$this->assertSame( 10, has_action( 'save_post', [ 'PUM_Admin_Themes', 'save' ] ) );
+		$this->assertSame( 99, has_filter( 'wp_insert_post_data', [ 'PUM_Admin_Popups', 'set_slug' ] ) );
 		$this->assertSame( 10, has_action( 'enqueue_block_assets', [ 'PUM_Admin_BlockEditor', 'register_block_assets' ] ) );
 		$this->assertFalse( has_action( 'admin_menu', [ 'PUM_Admin_Pages', 'register_pages' ] ) );
 		$this->assertFalse( has_action( 'wp_ajax_pum_object_search', [ 'PUM_Admin_Ajax', 'object_search' ] ) );

--- a/tests/php/tests/PUM_Deferred_Hooks_Test.php
+++ b/tests/php/tests/PUM_Deferred_Hooks_Test.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Tests for deferred legacy hook handlers.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Verify legacy services keep their public hooks without eager class loading.
+ */
+class PUM_Deferred_Hooks_Test extends WP_UnitTestCase {
+
+	/**
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_frontend_registers_legacy_hooks_without_loading_handlers() {
+		$this->assertFalse( class_exists( 'PUM_Privacy', false ) );
+		$this->assertFalse( class_exists( 'PUM_Utils_Alerts', false ) );
+		$this->assertFalse( class_exists( 'PUM_Telemetry', false ) );
+
+		$this->assertSame( 10, has_filter( 'wp_privacy_personal_data_exporters', [ 'PUM_Privacy', 'register_exporter' ] ) );
+		$this->assertSame( 10, has_filter( 'wp_privacy_personal_data_erasers', [ 'PUM_Privacy', 'register_erasers' ] ) );
+		$this->assertSame( 20, has_action( 'admin_init', [ 'PUM_Privacy', 'privacy_policy_content' ] ) );
+		$this->assertSame( 10, has_action( 'pum_save_popup', [ 'PUM_Privacy', 'clear_cookie_list' ] ) );
+
+		$this->assertSame( 10, has_action( 'admin_init', [ 'PUM_Utils_Alerts', 'hooks' ] ) );
+		$this->assertSame( 10, has_action( 'admin_init', [ 'PUM_Utils_Alerts', 'php_handler' ] ) );
+		$this->assertSame( 10, has_action( 'wp_ajax_pum_alerts_action', [ 'PUM_Utils_Alerts', 'ajax_handler' ] ) );
+		$this->assertSame( 10, has_filter( 'pum_alert_list', [ 'PUM_Utils_Alerts', 'translation_request' ] ) );
+		$this->assertSame( 999, has_action( 'admin_menu', [ 'PUM_Utils_Alerts', 'append_alert_count' ] ) );
+
+		$this->assertSame( 10, has_action( 'pum_daily_scheduled_events', [ 'PUM_Telemetry', 'track_check' ] ) );
+		$this->assertSame( 10, has_filter( 'pum_alert_list', [ 'PUM_Telemetry', 'optin_alert' ] ) );
+		$this->assertSame( 10, has_action( 'pum_alert_dismissed', [ 'PUM_Telemetry', 'optin_alert_check' ] ) );
+	}
+}


### PR DESCRIPTION
## Stack

Builds on #1302 and can be reviewed/skipped as a separate layer. Retarget to `develop` after #1302 merges.

## TL;DR

Removes another **124,616 B (-28.4%)** from Popup Maker's retained frontend footprint and **131,344 B (-41.6%)** from its peak footprint versus #1302. Cumulatively, the first two PRs reduce retained Popup Maker bootstrap overhead from about 1.45 MB on `develop` to 0.314 MB, or roughly **78%**.

## Measurement definitions

- **Popup Maker memory footprint** = PHP request memory with Popup Maker enabled minus the matched WordPress request with Popup Maker unavailable. Memory percentages use this incremental footprint, not the entire WordPress/PHP process.
- **Whole-process memory** is retained as a secondary audit metric.
- **Overall TTFB** means full HTTP response `time_starttransfer`. It was not benchmarked for this PR.

## Issues and gains

### Legacy handler classes are compiled before their hooks run

Privacy, alerts, telemetry, and the popup/theme editor handlers were loaded on every frontend request just to register WordPress callbacks. The bootstrap now registers the same class-string callbacks without autoloading their implementations; frontend programmatic saves and the full eager admin bootstrap remain intact.

**Isolated gain:** 25,384 B retained, 32,112 B peak, 5 files, and 5 classes.

### Notification providers boot when no notification API is used

The notification manager constructed `WhatsNew` and `FeatureAnnouncements` during `init`, even when no alert, dismissal, save, option-change, or plugin lifecycle event occurred. Priority-`PHP_INT_MIN` loaders now boot providers on the relevant event early enough to participate in that same hook; admin requests and explicit `get_providers()` calls stay eager.

**Isolated gain:** 4 files and 3 classes. Its direct byte delta is allocator-masked (~0.5 KB), but combining it with the handler deferral releases another PHP allocator slab.

## Popup Maker footprint: before / after

Matched core-only WordPress bootstrap, theme skipped, other active plugins skipped, five stable runs.

| Metric | #1302 | This PR | Gain |
|---|---:|---:|---:|
| Popup Maker incremental retained memory | 439,040 B | 314,424 B | **-124,616 B (-28.4%)** |
| Popup Maker incremental peak memory | 316,072 B | 184,728 B | **-131,344 B (-41.6%)** |
| Included files | 842 | 833 | **-9** |
| Declared classes | 744 | 736 | **-8** |

## Secondary whole-process measurements

| Metric | #1302 | This PR | Gain |
|---|---:|---:|---:|
| Retained PHP memory | 17,374,568 B | 17,249,952 B | -124,616 B (-0.7%) |
| Peak PHP memory | 18,317,736 B | 18,186,392 B | -131,344 B (-0.7%) |

PHP's allocator makes the two ablations non-additive; the combined process measurement is the number that matters.

## Functional verification

- Frontend popup/theme save hooks and popup slug filtering retain their original priorities and accepted argument counts.
- Providers registered during the active `pum_alert_list` filter execute during that same iteration.
- Deferred feature-announcement cache invalidation executes during the same option-update action.
- Alert discovery loads both core providers at priorities 12 and 15.
- Admin bootstrap remains eager for editor and notification UI behavior.

## Validation

- `composer run tests`: 910 tests, 1,918 assertions; 29 skipped.
- Changed-file PHPCS: passed.
- Full PHPCS and PHPStan retain the parent branch's existing baselines; no new findings.
- PHP 7.4-compatible syntax only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Performance**
  - Reduced unnecessary frontend loading by deferring admin editors, notifications, privacy, alerts, and telemetry until needed.
  - Preserved popup and theme saves, notification alerts, and related integrations during frontend requests.

- **Bug Fixes**
  - Ensured deferred notification providers initialize correctly when notification events are triggered.
  - Improved handling when notification events occur before deferred services are registered.

- **Tests**
  - Added coverage for deferred loading, event registration, provider discovery, and alert behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->