### PR TITLE
Performance: reduce frontend TTFB and popup model duplication

### DIFF
--- a/classes/Base/Service/Repository.php
+++ b/classes/Base/Service/Repository.php
@@ -40,9 +40,20 @@ abstract class Repository extends Service {
 	/**
 	 * Cache of instantiated items indexed by post ID.
 	 *
-	 * @var array<int, TPost>
+	 * @var array<int|string, TPost>
 	 */
 	protected $items_by_id = [];
+
+	/**
+	 * Get the cache key for an item ID.
+	 *
+	 * @param int|numeric-string $item_id Item ID.
+	 *
+	 * @return int|string
+	 */
+	protected function get_item_cache_key( $item_id ) {
+		return (int) $item_id;
+	}
 
 	/**
 	 * Initialize the service.
@@ -70,7 +81,7 @@ abstract class Repository extends Service {
 	 * @return void
 	 */
 	protected function cache_item( $item ) {
-		$this->items_by_id[ $item->ID ] = $item;
+		$this->items_by_id[ $this->get_item_cache_key( $item->ID ) ] = $item;
 	}
 
 	/**
@@ -175,11 +186,12 @@ abstract class Repository extends Service {
 	 */
 	public function get_by_id( $item_id = 0 ) {
 		// Convert to integer for consistent handling.
-		$item_id = (int) $item_id;
+		$item_id   = (int) $item_id;
+		$cache_key = $this->get_item_cache_key( $item_id );
 
 		// If item is cached, get the object.
-		if ( isset( $this->items_by_id[ $item_id ] ) ) {
-			return $this->items_by_id[ $item_id ];
+		if ( isset( $this->items_by_id[ $cache_key ] ) ) {
+			return $this->items_by_id[ $cache_key ];
 		}
 
 		// Query for a post by ID.

--- a/classes/Controllers/Frontend/Popups.php
+++ b/classes/Controllers/Frontend/Popups.php
@@ -30,6 +30,13 @@ class Popups extends Controller {
 	private $popups;
 
 	/**
+	 * All popup models queried for this request.
+	 *
+	 * @var array<string,Popup>
+	 */
+	private $queried_popups = [];
+
+	/**
 	 * Enqueued popup ids.
 	 *
 	 * @var int[]
@@ -88,6 +95,10 @@ class Popups extends Controller {
 		 * - No later than `wp_enqueue_scripts:15` as some content processing may have already occurred.
 		 */
 		add_action( 'wp_enqueue_scripts', [ $this, 'preload_popups' ], 11 );
+		add_action( 'clean_post_cache', [ $this, 'invalidate_queried_popup' ], PHP_INT_MIN, 2 );
+		add_action( 'added_post_meta', [ $this, 'invalidate_queried_popup_settings' ], PHP_INT_MIN, 3 );
+		add_action( 'updated_post_meta', [ $this, 'invalidate_queried_popup_settings' ], PHP_INT_MIN, 3 );
+		add_action( 'deleted_post_meta', [ $this, 'invalidate_queried_popup_settings' ], PHP_INT_MIN, 3 );
 
 		// Check content for popup triggers used, enqueue if enabled.
 		add_filter( 'the_content', [ $this, 'check_content_for_popups' ] );
@@ -102,11 +113,22 @@ class Popups extends Controller {
 	 * @return void
 	 */
 	public function preload_popups() {
-		$popups = $this->container->get( 'popups' )->query( [
+		$popup_repository = $this->container->get( 'popups' );
+		$popups           = $popup_repository->query( [
 			'post_status' => [ 'publish', 'private' ],
 		] );
 
 		foreach ( $popups as $popup ) {
+			$queried_popup = $this->get_queried_popup( $popup->ID );
+
+			if ( pum_is_popup( $queried_popup ) ) {
+				$popup = $queried_popup;
+			} else {
+				$this->cache_queried_popup( $popup );
+			}
+
+			$popup_repository->replace_cached_item( $popup );
+
 			set_current_popup( $popup );
 
 			if ( pum_is_popup_loadable( $popup->ID ) ) {
@@ -115,6 +137,102 @@ class Popups extends Controller {
 		}
 
 		set_current_popup( null );
+	}
+
+	/**
+	 * Get a popup model already queried during frontend preloading.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return Popup|null
+	 */
+	public function get_queried_popup( $popup_id ) {
+		$cache_key = $this->popup_cache_key( $popup_id );
+		$popup     = isset( $this->queried_popups[ $cache_key ] ) ? $this->queried_popups[ $cache_key ] : null;
+
+		if ( ! pum_is_popup( $popup ) ) {
+			return null;
+		}
+
+		$current_post = get_post( $popup_id );
+
+		if ( ! $current_post instanceof \WP_Post || 'popup' !== $current_post->post_type || get_object_vars( $current_post ) !== get_object_vars( $popup->post ) ) {
+			$this->invalidate_queried_popup( $popup_id );
+
+			return null;
+		}
+
+		return $popup;
+	}
+
+	/**
+	 * Cache a popup model as the canonical frontend instance for this request.
+	 *
+	 * @param Popup $popup Popup model.
+	 *
+	 * @return void
+	 */
+	public function cache_queried_popup( $popup ) {
+		if ( pum_is_popup( $popup ) ) {
+			$this->queried_popups[ $this->popup_cache_key( $popup->ID ) ] = $popup;
+		}
+	}
+
+	/**
+	 * Discard a canonical popup after WordPress changes its native post data.
+	 *
+	 * @param int      $post_id Post ID.
+	 * @param \WP_Post $post    Post object before its cache was cleared.
+	 *
+	 * @return void
+	 */
+	public function invalidate_queried_popup( $post_id, $post = null ) {
+		if ( ! is_numeric( $post_id ) || ( $post instanceof \WP_Post && 'popup' !== $post->post_type ) ) {
+			return;
+		}
+
+		unset( $this->queried_popups[ $this->popup_cache_key( $post_id ) ] );
+		$this->container->get( 'popups' )->forget_item( $post_id );
+		pum()->popups->forget_item( $post_id );
+	}
+
+	/**
+	 * Refresh settings on a canonical popup after native WordPress meta changes.
+	 *
+	 * @param int    $meta_id   Meta ID.
+	 * @param int    $object_id Post ID.
+	 * @param string $meta_key  Meta key.
+	 *
+	 * @return void
+	 */
+	public function invalidate_queried_popup_settings( $meta_id, $object_id, $meta_key ) {
+		if ( ! is_numeric( $object_id ) || 'popup_settings' !== $meta_key ) {
+			return;
+		}
+
+		$popup = $this->get_queried_popup( $object_id );
+
+		$popup_repository = $this->container->get( 'popups' );
+
+		pum()->popups->forget_item( $object_id );
+
+		if ( pum_is_popup( $popup ) ) {
+			$popup->settings = null;
+			$popup_repository->replace_cached_item( $popup );
+		} else {
+			$popup_repository->forget_item( $object_id );
+		}
+	}
+
+	/**
+	 * Get the site-specific cache key for a popup.
+	 *
+	 * @param int $popup_id Popup ID.
+	 *
+	 * @return string
+	 */
+	private function popup_cache_key( $popup_id ) {
+		return get_current_blog_id() . ':' . (int) $popup_id;
 	}
 
 	/**

--- a/classes/Model/Popup.php
+++ b/classes/Model/Popup.php
@@ -97,6 +97,100 @@ class PUM_Model_Popup extends PUM_Abstract_Model_Post {
 	public $settings = null;
 
 	/**
+	 * Whether the current settings were loaded from WordPress metadata.
+	 *
+	 * @var bool
+	 */
+	private $settings_loaded_from_meta = false;
+
+	/**
+	 * Hash of the popup settings entry in the WordPress metadata cache.
+	 *
+	 * @var string
+	 */
+	private $settings_meta_cache_hash = '';
+
+	/**
+	 * Last filtered settings value loaded from WordPress metadata.
+	 *
+	 * @var mixed
+	 */
+	private $settings_loaded_value;
+
+	/**
+	 * Hash the current popup settings metadata cache state.
+	 *
+	 * @return string
+	 */
+	private function get_settings_meta_cache_hash() {
+		$meta_cache = wp_cache_get( $this->ID, 'post_meta' );
+
+		if ( ! is_array( $meta_cache ) ) {
+			update_meta_cache( 'post', [ $this->ID ] );
+			$meta_cache = wp_cache_get( $this->ID, 'post_meta' );
+		}
+
+		$cache_data = [
+			'loaded'   => is_array( $meta_cache ),
+			'settings' => is_array( $meta_cache ) && isset( $meta_cache['popup_settings'] ) ? $meta_cache['popup_settings'] : null,
+		];
+
+		return hash( 'sha256', maybe_serialize( $cache_data ) );
+	}
+
+	/**
+	 * Resolve popup settings with the same precedence as WordPress metadata.
+	 *
+	 * @return array{settings: mixed, from_metadata: bool}
+	 */
+	private function get_settings_metadata() {
+		if ( $this->mock ) {
+			return [
+				'settings'      => false,
+				'from_metadata' => false,
+			];
+		}
+
+		if ( __CLASS__ !== get_class( $this ) ) {
+			return [
+				'settings'      => $this->get_meta( 'popup_settings' ),
+				'from_metadata' => false,
+			];
+		}
+
+		$settings = apply_filters( 'get_post_metadata', null, $this->ID, 'popup_settings', true, 'post' );
+
+		if ( null !== $settings ) {
+			if ( is_array( $settings ) ) {
+				$settings = isset( $settings[0] ) ? $settings[0] : null;
+			}
+
+			return [
+				'settings'      => $settings,
+				'from_metadata' => false,
+			];
+		}
+
+		$meta_cache = wp_cache_get( $this->ID, 'post_meta' );
+
+		if ( ! is_array( $meta_cache ) ) {
+			update_meta_cache( 'post', [ $this->ID ] );
+			$meta_cache = wp_cache_get( $this->ID, 'post_meta' );
+		}
+
+		if ( is_array( $meta_cache ) && isset( $meta_cache['popup_settings'][0] ) ) {
+			$settings = maybe_unserialize( $meta_cache['popup_settings'][0] );
+		} else {
+			$settings = get_metadata_default( 'post', $this->ID, 'popup_settings', true );
+		}
+
+		return [
+			'settings'      => $settings,
+			'from_metadata' => true,
+		];
+	}
+
+	/**
 	 * Used to hackishly insert title for generated popups not stored in DB. (Shortcodes).
 	 *
 	 * @var string
@@ -165,16 +259,25 @@ class PUM_Model_Popup extends PUM_Abstract_Model_Post {
 	 * @return array
 	 */
 	public function get_settings() {
+		if ( isset( $this->settings ) && $this->settings_loaded_from_meta && $this->settings === $this->settings_loaded_value && $this->settings_meta_cache_hash !== $this->get_settings_meta_cache_hash() ) {
+			$this->settings = null;
+		}
+
 		if ( ! isset( $this->settings ) ) {
 			// This hack is here to allow creating popups on the fly without saved meta.
-			$settings = isset( $this->settings ) ? $this->settings : $this->get_meta( 'popup_settings' );
+			$settings_metadata         = $this->get_settings_metadata();
+			$settings                  = $settings_metadata['settings'];
+			$settings_loaded_from_meta = $settings_metadata['from_metadata'];
 
 			if ( ! is_array( $settings ) ) {
 				$settings = [];
 			}
 
 			// Review: the above should be removed and replaced with a hooked filter here to supply defaults when $settings === false.
-			$this->settings = apply_filters( 'pum_popup_settings', $settings, $this->ID );
+			$this->settings                  = apply_filters( 'pum_popup_settings', $settings, $this->ID );
+			$this->settings_loaded_from_meta = $settings_loaded_from_meta;
+			$this->settings_loaded_value     = $this->settings;
+			$this->settings_meta_cache_hash  = $this->get_settings_meta_cache_hash();
 		}
 
 		return $this->settings;
@@ -308,10 +411,14 @@ class PUM_Model_Popup extends PUM_Abstract_Model_Post {
 			);
 		}
 
-		// Keep the in-memory cache consistent with what we just persisted.
-		$this->settings = $settings;
+		$updated = $this->update_meta( 'popup_settings', $settings );
 
-		return $this->update_meta( 'popup_settings', $settings );
+		// Re-read the normalized stored value and refresh its cache provenance.
+		$this->settings                  = null;
+		$this->settings_loaded_from_meta = false;
+		$this->get_settings();
+
+		return $updated;
 	}
 
 	/**

--- a/classes/Model/Theme.php
+++ b/classes/Model/Theme.php
@@ -23,8 +23,67 @@ class PUM_Model_Theme extends PUM_Abstract_Model_Post {
 	/** @var array */
 	public $settings;
 
+	/** @var array|null */
+	private $stored_settings;
+
+	/** @var bool|null */
+	private $settings_meta_exists;
+
+	/** @var string|null */
+	private $settings_meta_cache_hash;
+
 	/** @var bool */
 	public $doing_passive_migration = false;
+
+	/**
+	 * Hash the popup theme settings entry in the WordPress metadata cache.
+	 *
+	 * @param array<string,mixed>|false $meta_cache Current WordPress metadata cache.
+	 *
+	 * @return string
+	 */
+	private function get_settings_meta_cache_hash( $meta_cache ) {
+		$cache_data = [
+			'loaded'   => is_array( $meta_cache ),
+			'settings' => is_array( $meta_cache ) && isset( $meta_cache['popup_theme_settings'] ) ? $meta_cache['popup_theme_settings'] : null,
+		];
+
+		return hash( 'sha256', maybe_serialize( $cache_data ) );
+	}
+
+	/**
+	 * Read stored theme settings without retaining dynamic metadata overrides.
+	 *
+	 * WordPress stores raw metadata in the object cache after applying write-time
+	 * normalization. Reading that cache directly lets get_settings() reapply the
+	 * get_post_metadata short-circuit on every call while caching only storage.
+	 *
+	 * @param array<string,mixed>|false $meta_cache Current WordPress metadata cache.
+	 *
+	 * @return array{exists: bool, settings: array|null, cache_hash: string}
+	 */
+	private function get_stored_settings( $meta_cache ) {
+		if ( ! is_array( $meta_cache ) ) {
+			$updated_cache = update_meta_cache( 'post', [ $this->ID ] );
+			$meta_cache    = isset( $updated_cache[ $this->ID ] ) && is_array( $updated_cache[ $this->ID ] ) ? $updated_cache[ $this->ID ] : [];
+		}
+
+		if ( ! isset( $meta_cache['popup_theme_settings'][0] ) ) {
+			return [
+				'exists'     => false,
+				'settings'   => null,
+				'cache_hash' => $this->get_settings_meta_cache_hash( $meta_cache ),
+			];
+		}
+
+		$settings = maybe_unserialize( $meta_cache['popup_theme_settings'][0] );
+
+		return [
+			'exists'     => true,
+			'settings'   => is_array( $settings ) ? $settings : null,
+			'cache_hash' => $this->get_settings_meta_cache_hash( $meta_cache ),
+		];
+	}
 
 	/**
 	 * The current model version.
@@ -54,11 +113,47 @@ class PUM_Model_Theme extends PUM_Abstract_Model_Post {
 	 * @return array
 	 */
 	public function get_settings() {
-		$this->settings = $this->get_meta( 'popup_theme_settings' );
+		if ( __CLASS__ !== get_class( $this ) ) {
+			// Extension subclasses may remap or override metadata resolution.
+			$this->settings = $this->get_meta( 'popup_theme_settings' );
+			$this->settings = is_array( $this->settings ) ? $this->settings : [];
 
-		if ( ! is_array( $this->settings ) ) {
-			$this->settings = [];
+			return apply_filters( 'pum_theme_settings', $this->settings, $this->ID );
 		}
+
+		$metadata_value = apply_filters( 'get_post_metadata', null, $this->ID, 'popup_theme_settings', true, 'post' );
+
+		if ( null !== $metadata_value ) {
+			if ( is_array( $metadata_value ) ) {
+				$metadata_value = isset( $metadata_value[0] ) ? $metadata_value[0] : null;
+			}
+
+			$this->settings = is_array( $metadata_value ) ? $metadata_value : [];
+
+			return apply_filters( 'pum_theme_settings', $this->settings, $this->ID );
+		}
+
+		$meta_cache = wp_cache_get( $this->ID, 'post_meta' );
+
+		if ( ! isset( $this->stored_settings ) || ! is_array( $meta_cache ) || $this->settings_meta_cache_hash !== $this->get_settings_meta_cache_hash( $meta_cache ) ) {
+			$stored_settings                = $this->get_stored_settings( $meta_cache );
+			$this->stored_settings          = $stored_settings['settings'];
+			$this->settings_meta_exists     = $stored_settings['exists'];
+			$this->settings_meta_cache_hash = $stored_settings['cache_hash'];
+
+			if ( ! is_array( $this->stored_settings ) ) {
+				$this->stored_settings = [];
+			}
+		}
+
+		if ( false === $this->settings_meta_exists ) {
+			$this->settings = get_metadata_default( 'post', $this->ID, 'popup_theme_settings', true );
+			$this->settings = is_array( $this->settings ) ? $this->settings : [];
+
+			return apply_filters( 'pum_theme_settings', $this->settings, $this->ID );
+		}
+
+		$this->settings = $this->stored_settings;
 
 		return apply_filters( 'pum_theme_settings', $this->settings, $this->ID );
 	}

--- a/classes/Repository/Popups.php
+++ b/classes/Repository/Popups.php
@@ -21,6 +21,17 @@ class PUM_Repository_Popups extends PUM_Abstract_Repository_Posts {
 	protected $model = 'PUM_Model_Popup';
 
 	/**
+	 * Include the current site in cached popup model hashes.
+	 *
+	 * @param WP_Post $post Post object.
+	 *
+	 * @return string
+	 */
+	protected function get_post_hash( $post ) {
+		return md5( get_current_blog_id() . ':' . parent::get_post_hash( $post ) );
+	}
+
+	/**
 	 * @return string
 	 */
 	protected function get_post_type() {
@@ -107,6 +118,17 @@ class PUM_Repository_Popups extends PUM_Abstract_Repository_Posts {
 	 */
 	public function get_items( $args = [] ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found
 		return parent::get_items( $args );
+	}
+
+	/**
+	 * Discard a cached popup model.
+	 *
+	 * @param int|numeric-string $item_id Popup ID.
+	 *
+	 * @return void
+	 */
+	public function forget_item( $item_id ) {
+		unset( $this->cache['objects'][ (int) $item_id ] );
 	}
 
 	/**

--- a/classes/Services/Repository/Popups.php
+++ b/classes/Services/Repository/Popups.php
@@ -32,6 +32,17 @@ class Popups extends Repository {
 	protected $post_type_key = 'popup';
 
 	/**
+	 * Partition cached popup models by site.
+	 *
+	 * @param int|numeric-string $item_id Popup ID.
+	 *
+	 * @return string
+	 */
+	protected function get_item_cache_key( $item_id ) {
+		return get_current_blog_id() . ':' . (int) $item_id;
+	}
+
+	/**
 	 * Initialize the service.
 	 *
 	 * @param \PopupMaker\Plugin\Core $container Container.
@@ -66,6 +77,20 @@ class Popups extends Repository {
 	 */
 	protected function cache_item( $item ) {
 		parent::cache_item( $item );
+	}
+
+	/**
+	 * Replace the cached popup model for the current site.
+	 *
+	 * This public operation intentionally delegates to the protected cache hook
+	 * so extension subclasses can retain protected cache_item() overrides.
+	 *
+	 * @param Popup $item Popup model to cache.
+	 *
+	 * @return void
+	 */
+	public function replace_cached_item( $item ) {
+		$this->cache_item( $item );
 	}
 
 	/**
@@ -136,6 +161,17 @@ class Popups extends Repository {
 		$filtered = apply_filters( 'popup_maker/popup_title_choices', $title_choices );
 
 		return is_array( $filtered ) ? $filtered : $title_choices;
+	}
+
+	/**
+	 * Discard a cached popup model for the current site.
+	 *
+	 * @param int|numeric-string $item_id Popup ID.
+	 *
+	 * @return void
+	 */
+	public function forget_item( $item_id ) {
+		unset( $this->items_by_id[ $this->get_item_cache_key( $item_id ) ] );
 	}
 
 	/**

--- a/includes/functions/popups/queries.php
+++ b/includes/functions/popups/queries.php
@@ -23,14 +23,30 @@ function pum_get_popup( $popup_id = null ) {
 	}
 
 	/** @var int $popup_id filtered $popup_id */
-	$popup_id = pum_get_popup_id( $popup_id );
+	$popup_id         = pum_get_popup_id( $popup_id );
+	$popup_controller = null;
+
+	if ( ! is_admin() ) {
+		$popup_controller = \PopupMaker\plugin()->get_controller( 'Frontend\\Popups' );
+		$queried_popup    = $popup_controller ? $popup_controller->get_queried_popup( $popup_id ) : null;
+
+		if ( pum_is_popup( $queried_popup ) ) {
+			return $queried_popup;
+		}
+	}
 
 	try {
-		return pum()->popups->get_item( $popup_id );
+		$popup = pum()->popups->get_item( $popup_id );
 	} catch ( InvalidArgumentException $e ) {
 		// Return empty object
-		return new PUM_Model_Popup( $popup_id );
+		$popup = new PUM_Model_Popup( $popup_id );
 	}
+
+	if ( ! is_admin() && $popup_controller && pum_is_popup( $popup ) ) {
+		$popup_controller->cache_queried_popup( $popup );
+	}
+
+	return $popup;
 }
 
 /**

--- a/tests/php/tests/Frontend_Popups_Controller_Test.php
+++ b/tests/php/tests/Frontend_Popups_Controller_Test.php
@@ -1,0 +1,651 @@
+<?php
+/**
+ * Tests for the frontend popups controller.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Test frontend popup model reuse.
+ */
+class Frontend_Popups_Controller_Test extends WP_UnitTestCase {
+
+	/**
+	 * Legacy getters reuse models already queried by the frontend controller.
+	 */
+	public function test_legacy_getter_reuses_queried_popup_model() {
+		$popup_id = self::factory()->post->create( [
+			'post_type'   => 'popup',
+			'post_status' => 'publish',
+		] );
+
+		$controller = \PopupMaker\plugin()->get_controller( 'Frontend\\Popups' );
+		$controller->preload_popups();
+		$queried_popup = $controller->get_queried_popup( $popup_id );
+
+		$this->assertInstanceOf( PUM_Model_Popup::class, $queried_popup );
+		$this->assertSame( $queried_popup, pum_get_popup( $popup_id ) );
+	}
+
+	/**
+	 * Models requested before preloading remain canonical afterward.
+	 *
+	 * @return void
+	 */
+	public function test_preload_preserves_model_requested_by_legacy_getter() {
+		$popup_id = self::factory()->post->create( [
+			'post_type'   => 'popup',
+			'post_status' => 'publish',
+		] );
+
+		$popup           = pum_get_popup( $popup_id );
+		$popup->settings = [ 'custom_request_value' => 'preserved' ];
+
+		$controller = \PopupMaker\plugin()->get_controller( 'Frontend\\Popups' );
+		$controller->preload_popups();
+
+		$this->assertSame( $popup, $controller->get_queried_popup( $popup_id ) );
+		$this->assertSame( $popup, pum_get_popup( $popup_id ) );
+		$this->assertSame( $popup, \PopupMaker\plugin()->get( 'popups' )->get_by_id( $popup_id ) );
+		$this->assertSame( 'preserved', pum_get_popup( $popup_id )->settings['custom_request_value'] );
+	}
+
+	/**
+	 * Extensions may retain the original protected cache hook visibility.
+	 *
+	 * @return void
+	 */
+	public function test_extension_repository_can_override_protected_cache_item() {
+		$repository = new class( \PopupMaker\plugin() ) extends \PopupMaker\Services\Repository\Popups {
+
+			/**
+			 * @param PUM_Model_Popup $item Popup model.
+			 *
+			 * @return void
+			 */
+			protected function cache_item( $item ) { // phpcs:ignore Generic.CodeAnalysis.UselessOverridingMethod.Found -- Proves protected visibility remains compatible.
+				parent::cache_item( $item );
+			}
+		};
+		$popup_id   = self::factory()->post->create( [ 'post_type' => 'popup' ] );
+		$popup      = new PUM_Model_Popup( $popup_id );
+
+		$repository->replace_cached_item( $popup );
+
+		$this->assertSame( $popup, $repository->get_by_id( $popup_id ) );
+	}
+
+	/**
+	 * Modern repository popup models are isolated by site.
+	 *
+	 * @return void
+	 */
+	public function test_modern_repository_popup_models_are_partitioned_by_blog() {
+		$popup_id   = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+		$blog_id    = get_current_blog_id();
+		$repository = \PopupMaker\plugin()->get( 'popups' );
+
+		$metadata_filter = function ( $value, $object_id, $meta_key ) use ( $popup_id, $blog_id ) {
+			if ( $popup_id !== $object_id || 'popup_settings' !== $meta_key ) {
+				return $value;
+			}
+
+			return [ [ 'animation_speed' => get_current_blog_id() === $blog_id ? 200 : 400 ] ];
+		};
+
+		add_filter( 'get_post_metadata', $metadata_filter, 10, 3 );
+
+		$first = $repository->get_by_id( $popup_id );
+		$this->assertSame( 200, $first->get_setting( 'animation_speed' ) );
+
+		try {
+			$GLOBALS['blog_id'] = $blog_id + 1;
+
+			$second = $repository->get_by_id( $popup_id );
+
+			$this->assertNotSame( $first, $second );
+			$this->assertSame( 400, $second->get_setting( 'animation_speed' ) );
+		} finally {
+			$GLOBALS['blog_id'] = $blog_id;
+			remove_filter( 'get_post_metadata', $metadata_filter, 10 );
+		}
+
+		$this->assertSame( $first, $repository->get_by_id( $popup_id ) );
+	}
+
+	/**
+	 * Canonical popup models are isolated by site in multisite requests.
+	 *
+	 * @return void
+	 */
+	public function test_queried_popup_cache_is_partitioned_by_blog() {
+		$controller = \PopupMaker\plugin()->get_controller( 'Frontend\\Popups' );
+		$popup_id   = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+		$first      = new PUM_Model_Popup( $popup_id );
+		$second     = new PUM_Model_Popup( $popup_id );
+		$blog_id    = get_current_blog_id();
+
+		$controller->cache_queried_popup( $first );
+
+		try {
+			$GLOBALS['blog_id'] = $blog_id + 1;
+
+			$this->assertNull( $controller->get_queried_popup( $popup_id ) );
+
+			$controller->cache_queried_popup( $second );
+
+			$this->assertSame( $second, $controller->get_queried_popup( $popup_id ) );
+		} finally {
+			$GLOBALS['blog_id'] = $blog_id;
+		}
+
+		$this->assertSame( $first, $controller->get_queried_popup( $popup_id ) );
+	}
+
+	/**
+	 * Legacy repository models cannot carry settings between sites.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_repository_popup_models_are_partitioned_by_blog() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+		$blog_id  = get_current_blog_id();
+
+		$metadata_filter = function ( $value, $object_id, $meta_key ) use ( $popup_id, $blog_id ) {
+			if ( $popup_id !== $object_id || 'popup_settings' !== $meta_key ) {
+				return $value;
+			}
+
+			return [ [ 'animation_speed' => get_current_blog_id() === $blog_id ? 200 : 400 ] ];
+		};
+
+		add_filter( 'get_post_metadata', $metadata_filter, 10, 3 );
+
+		$first = pum_get_popup( $popup_id );
+		$this->assertSame( 200, $first->get_setting( 'animation_speed' ) );
+
+		try {
+			$GLOBALS['blog_id'] = $blog_id + 1;
+
+			$second = pum_get_popup( $popup_id );
+
+			$this->assertNotSame( $first, $second );
+			$this->assertSame( 400, $second->get_setting( 'animation_speed' ) );
+		} finally {
+			$GLOBALS['blog_id'] = $blog_id;
+			remove_filter( 'get_post_metadata', $metadata_filter, 10 );
+		}
+
+		$this->assertSame( $first, pum_get_popup( $popup_id ) );
+		$this->assertSame( 200, $first->get_setting( 'animation_speed' ) );
+	}
+
+	/**
+	 * Native post changes discard stale canonical popup post data.
+	 *
+	 * @return void
+	 */
+	public function test_native_post_changes_invalidate_queried_popup() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Original title',
+			]
+		);
+
+		$original = pum_get_popup( $popup_id );
+
+		wp_update_post(
+			[
+				'ID'         => $popup_id,
+				'post_title' => 'Updated title',
+			]
+		);
+
+		$updated = pum_get_popup( $popup_id );
+
+		$this->assertNotSame( $original, $updated );
+		$this->assertSame( 'Updated title', $updated->post_title );
+	}
+
+	/**
+	 * Reprimed WordPress post caches cannot preserve stale canonical post data.
+	 *
+	 * @return void
+	 */
+	public function test_direct_post_write_and_cache_reprime_refreshes_canonical_popup() {
+		global $wpdb;
+
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Original title',
+			]
+		);
+		$original = pum_get_popup( $popup_id );
+
+		$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Simulates an importer writing before cache eviction.
+			$wpdb->posts,
+			[ 'post_title' => 'Imported title' ],
+			[ 'ID' => $popup_id ]
+		);
+		wp_cache_delete( $popup_id, 'posts' );
+		get_post( $popup_id );
+
+		$updated = pum_get_popup( $popup_id );
+
+		$this->assertNotSame( $original, $updated );
+		$this->assertSame( 'Imported title', $updated->post_title );
+	}
+
+	/**
+	 * Native cache cleaning evicts both repositories for the current site.
+	 *
+	 * @return void
+	 */
+	public function test_clean_post_cache_evicts_current_site_repository_models() {
+		$popup_id   = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+		$blog_id    = get_current_blog_id();
+		$repository = \PopupMaker\plugin()->get( 'popups' );
+		$first      = $repository->get_by_id( $popup_id );
+		$legacy     = pum()->popups->get_item( $popup_id );
+
+		try {
+			$GLOBALS['blog_id'] = $blog_id + 1;
+			$other_site         = $repository->get_by_id( $popup_id );
+		} finally {
+			$GLOBALS['blog_id'] = $blog_id;
+		}
+
+		clean_post_cache( $popup_id );
+
+		$this->assertNotSame( $first, $repository->get_by_id( $popup_id ) );
+		$this->assertNotSame( $legacy, pum()->popups->get_item( $popup_id ) );
+
+		try {
+			$GLOBALS['blog_id'] = $blog_id + 1;
+			$this->assertSame( $other_site, $repository->get_by_id( $popup_id ) );
+		} finally {
+			$GLOBALS['blog_id'] = $blog_id;
+		}
+	}
+
+	/**
+	 * Legacy popup lookup tolerates an unavailable frontend controller.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_getter_handles_missing_frontend_controller() {
+		$popup_id   = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+		$plugin     = \PopupMaker\plugin();
+		$controller = $plugin->get_controller( 'Frontend\\Popups' );
+
+		try {
+			unset( $plugin->controllers['Frontend\\Popups'] );
+
+			$this->assertNull( $plugin->get_controller( 'Frontend\\Popups' ) );
+			$this->assertInstanceOf( PUM_Model_Popup::class, pum_get_popup( $popup_id ) );
+		} finally {
+			$plugin->controllers['Frontend\\Popups'] = $controller;
+		}
+	}
+
+	/**
+	 * Native settings writes refresh the canonical model before preloading.
+	 *
+	 * @return void
+	 */
+	public function test_native_popup_settings_writes_refresh_canonical_model() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		update_post_meta( $popup_id, 'popup_settings', [ 'animation_speed' => 200 ] );
+
+		$popup = pum_get_popup( $popup_id );
+		$this->assertSame( 200, $popup->get_setting( 'animation_speed' ) );
+
+		update_post_meta( $popup_id, 'popup_settings', [ 'animation_speed' => 400 ] );
+
+		$controller = \PopupMaker\plugin()->get_controller( 'Frontend\\Popups' );
+		$controller->preload_popups();
+
+		$this->assertSame( $popup, $controller->get_queried_popup( $popup_id ) );
+		$this->assertSame( 400, $popup->get_setting( 'animation_speed' ) );
+	}
+
+	/**
+	 * Native settings writes evict modern models not cached by the controller.
+	 *
+	 * @return void
+	 */
+	public function test_native_popup_settings_writes_evict_repository_only_model() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		update_post_meta( $popup_id, 'popup_settings', [ 'animation_speed' => 200 ] );
+
+		$repository = \PopupMaker\plugin()->get( 'popups' );
+		$original   = $repository->get_by_id( $popup_id );
+
+		$this->assertSame( 200, $original->get_setting( 'animation_speed' ) );
+
+		update_post_meta( $popup_id, 'popup_settings', [ 'animation_speed' => 400 ] );
+
+		$updated = $repository->get_by_id( $popup_id );
+
+		$this->assertNotSame( $original, $updated );
+		$this->assertSame( 400, $updated->get_setting( 'animation_speed' ) );
+	}
+
+	/**
+	 * Native settings writes evict legacy models not cached by the controller.
+	 *
+	 * @return void
+	 */
+	public function test_native_popup_settings_writes_evict_legacy_repository_only_model() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		update_post_meta( $popup_id, 'popup_settings', [ 'animation_speed' => 200 ] );
+
+		$original = pum()->popups->get_item( $popup_id );
+
+		$this->assertSame( 200, $original->get_setting( 'animation_speed' ) );
+
+		update_post_meta( $popup_id, 'popup_settings', [ 'animation_speed' => 400 ] );
+
+		$updated = pum_get_popup( $popup_id );
+
+		$this->assertNotSame( $original, $updated );
+		$this->assertSame( 400, $updated->get_setting( 'animation_speed' ) );
+	}
+
+	/**
+	 * Reprimed WordPress metadata refreshes canonical popup settings.
+	 *
+	 * @return void
+	 */
+	public function test_preload_refreshes_canonical_settings_after_meta_cache_eviction() {
+		global $wpdb;
+
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		update_post_meta( $popup_id, 'popup_settings', [ 'animation_speed' => 200 ] );
+
+		$popup = pum_get_popup( $popup_id );
+		$this->assertSame( 200, $popup->get_setting( 'animation_speed' ) );
+
+		$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Simulates an importer writing before cache eviction.
+			$wpdb->postmeta,
+			[ 'meta_value' => maybe_serialize( [ 'animation_speed' => 400 ] ) ], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			[
+				'post_id'  => $popup_id,
+				'meta_key' => 'popup_settings', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			]
+		);
+		wp_cache_delete( $popup_id, 'post_meta' );
+
+		$controller = \PopupMaker\plugin()->get_controller( 'Frontend\\Popups' );
+		$controller->preload_popups();
+
+		$this->assertSame( $popup, $controller->get_queried_popup( $popup_id ) );
+		$this->assertSame( 400, $popup->get_setting( 'animation_speed' ) );
+	}
+
+	/**
+	 * A newly inserted settings row refreshes a model that first observed no row.
+	 *
+	 * @return void
+	 */
+	public function test_absent_settings_row_refreshes_after_direct_insert_and_cache_reprime() {
+		global $wpdb;
+
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+		$popup    = pum_get_popup( $popup_id );
+
+		$this->assertFalse( $popup->get_setting( 'animation_speed' ) );
+
+		$wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Simulates an importer creating metadata directly.
+			$wpdb->postmeta,
+			[
+				'post_id'    => $popup_id,
+				'meta_key'   => 'popup_settings', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				'meta_value' => maybe_serialize( [ 'animation_speed' => 400 ] ), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			]
+		);
+		wp_cache_delete( $popup_id, 'post_meta' );
+		update_meta_cache( 'post', [ $popup_id ] );
+
+		$this->assertSame( 400, $popup->get_setting( 'animation_speed' ) );
+	}
+
+	/**
+	 * Model writes refresh provenance before a later direct metadata update.
+	 *
+	 * @return void
+	 */
+	public function test_update_setting_refreshes_provenance_before_direct_write() {
+		global $wpdb;
+
+		$popup_id   = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+		$popup      = pum_get_popup( $popup_id );
+		$controller = \PopupMaker\plugin()->get_controller( 'Frontend\\Popups' );
+		$callback   = [ $controller, 'invalidate_queried_popup_settings' ];
+
+		remove_action( 'added_post_meta', $callback, PHP_INT_MIN );
+		remove_action( 'updated_post_meta', $callback, PHP_INT_MIN );
+
+		try {
+			$popup->update_setting( 'animation_speed', 300 );
+			$this->assertSame( 300, $popup->get_setting( 'animation_speed' ) );
+
+			$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Simulates an importer writing before cache eviction.
+				$wpdb->postmeta,
+				[ 'meta_value' => maybe_serialize( [ 'animation_speed' => 400 ] ) ], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				[
+					'post_id'  => $popup_id,
+					'meta_key' => 'popup_settings', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+				]
+			);
+			wp_cache_delete( $popup_id, 'post_meta' );
+
+			$this->assertSame( 400, $popup->get_setting( 'animation_speed' ) );
+		} finally {
+			add_action( 'added_post_meta', $callback, PHP_INT_MIN, 3 );
+			add_action( 'updated_post_meta', $callback, PHP_INT_MIN, 3 );
+		}
+	}
+
+	/**
+	 * Unrelated metadata writes preserve request-local popup settings.
+	 *
+	 * @return void
+	 */
+	public function test_unrelated_meta_writes_preserve_request_local_settings() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		update_post_meta( $popup_id, 'popup_settings', [ 'animation_speed' => 200 ] );
+
+		$popup = pum_get_popup( $popup_id );
+		$this->assertSame( 200, $popup->get_setting( 'animation_speed' ) );
+
+		$popup->settings = [ 'animation_speed' => 999 ];
+
+		update_post_meta( $popup_id, 'enabled', false );
+
+		$this->assertSame( 999, $popup->get_setting( 'animation_speed' ) );
+	}
+
+	/**
+	 * Unrelated metadata writes preserve filtered popup settings.
+	 *
+	 * @return void
+	 */
+	public function test_unrelated_meta_writes_preserve_filtered_settings() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		update_post_meta( $popup_id, 'popup_settings', [ 'animation_speed' => 200 ] );
+
+		$filter_calls    = 0;
+		$settings_filter = function ( $settings, $filtered_popup_id ) use ( $popup_id, &$filter_calls ) {
+			if ( $popup_id !== $filtered_popup_id ) {
+				return $settings;
+			}
+
+			++$filter_calls;
+			$settings['filter_call'] = $filter_calls;
+
+			return $settings;
+		};
+
+		add_filter( 'pum_popup_settings', $settings_filter, 10, 2 );
+
+		try {
+			$popup = pum_get_popup( $popup_id );
+			$this->assertSame( 1, $popup->get_setting( 'filter_call' ) );
+
+			update_post_meta( $popup_id, 'enabled', false );
+
+			$this->assertSame( 1, $popup->get_setting( 'filter_call' ) );
+			$this->assertSame( 1, $filter_calls );
+		} finally {
+			remove_filter( 'pum_popup_settings', $settings_filter, 10 );
+		}
+	}
+
+	/**
+	 * Metadata short-circuits do not invoke defaults or become stored provenance.
+	 *
+	 * @return void
+	 */
+	public function test_metadata_short_circuit_skips_default_and_remains_request_local() {
+		global $wpdb;
+
+		$popup_id      = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+		$filter_calls  = 0;
+		$default_calls = 0;
+
+		$metadata_filter = function ( $value, $object_id, $meta_key ) use ( $popup_id, &$filter_calls ) {
+			if ( $popup_id !== $object_id || 'popup_settings' !== $meta_key ) {
+				return $value;
+			}
+
+			++$filter_calls;
+
+			return [
+				[
+					'animation_speed' => 400,
+					'filter_call'     => $filter_calls,
+				],
+			];
+		};
+		$default_filter  = function ( $value, $object_id, $meta_key ) use ( $popup_id, &$default_calls ) {
+			if ( $popup_id !== $object_id || 'popup_settings' !== $meta_key ) {
+				return $value;
+			}
+
+			++$default_calls;
+
+			return [
+				'animation_speed' => 400,
+				'filter_call'     => 1,
+			];
+		};
+
+		add_filter( 'get_post_metadata', $metadata_filter, 10, 3 );
+		add_filter( 'default_post_metadata', $default_filter, 10, 3 );
+
+		try {
+			$popup = pum_get_popup( $popup_id );
+
+			$this->assertSame( 400, $popup->get_setting( 'animation_speed' ) );
+			$this->assertSame( 0, $default_calls );
+
+			$wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Simulates an importer writing beneath a dynamic metadata override.
+				$wpdb->postmeta,
+				[
+					'post_id'    => $popup_id,
+					'meta_key'   => 'popup_settings', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+					'meta_value' => maybe_serialize( [ 'animation_speed' => 200 ] ), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+				]
+			);
+			wp_cache_delete( $popup_id, 'post_meta' );
+			update_meta_cache( 'post', [ $popup_id ] );
+
+			$this->assertSame( 1, $popup->get_setting( 'filter_call' ) );
+			$this->assertSame( 1, $filter_calls );
+		} finally {
+			remove_filter( 'get_post_metadata', $metadata_filter, 10 );
+			remove_filter( 'default_post_metadata', $default_filter, 10 );
+		}
+	}
+}

--- a/tests/php/tests/PUM_Model_Theme_Test.php
+++ b/tests/php/tests/PUM_Model_Theme_Test.php
@@ -1,0 +1,357 @@
+<?php
+/**
+ * Tests for the popup theme model.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Test popup theme settings behavior.
+ */
+class PUM_Model_Theme_Test extends WP_UnitTestCase {
+
+	/**
+	 * Raw theme settings are read once while filters still run for every access.
+	 */
+	public function test_get_settings_caches_meta_and_reapplies_filter() {
+		$theme_id = self::factory()->post->create( [
+			'post_type'   => 'popup_theme',
+			'post_status' => 'publish',
+		] );
+
+		update_post_meta( $theme_id, 'popup_theme_settings', [ 'container_padding' => 20 ] );
+
+		$metadata_reads = 0;
+		$filter_calls   = 0;
+
+		$metadata_filter = function ( $value, $object_id, $meta_key ) use ( $theme_id, &$metadata_reads ) {
+			if ( $theme_id === $object_id && 'popup_theme_settings' === $meta_key ) {
+				++$metadata_reads;
+			}
+
+			return $value;
+		};
+
+		$settings_filter = function ( $settings ) use ( &$filter_calls ) {
+			++$filter_calls;
+			$settings['filter_call'] = $filter_calls;
+
+			return $settings;
+		};
+
+		add_filter( 'get_post_metadata', $metadata_filter, 10, 3 );
+		add_filter( 'pum_theme_settings', $settings_filter );
+
+		$theme  = new PUM_Model_Theme( $theme_id );
+		$first  = $theme->get_settings();
+		$second = $theme->get_settings();
+
+		remove_filter( 'get_post_metadata', $metadata_filter, 10 );
+		remove_filter( 'pum_theme_settings', $settings_filter );
+
+		$this->assertSame( 2, $metadata_reads );
+		$this->assertSame( 1, $first['filter_call'] );
+		$this->assertSame( 2, $second['filter_call'] );
+		$this->assertSame( 20, $second['container_padding'] );
+	}
+
+	/**
+	 * Updating one setting keeps the per-model cache synchronized.
+	 */
+	public function test_update_setting_refreshes_cached_settings() {
+		$theme_id = self::factory()->post->create( [
+			'post_type'   => 'popup_theme',
+			'post_status' => 'publish',
+		] );
+
+		update_post_meta( $theme_id, 'popup_theme_settings', [ 'container_padding' => 20 ] );
+
+		$theme = new PUM_Model_Theme( $theme_id );
+		$theme->get_settings();
+		$theme->update_setting( 'container_padding', 30 );
+
+		$this->assertSame( 30, $theme->get_setting( 'container_padding' ) );
+		$this->assertSame( 30, get_post_meta( $theme_id, 'popup_theme_settings', true )['container_padding'] );
+	}
+
+	/**
+	 * Passive migrations and extensions write popup_theme_settings via
+	 * update_meta() directly — the instance cache must not serve stale
+	 * pre-write settings afterward.
+	 *
+	 * @return void
+	 */
+	public function test_direct_update_meta_refreshes_cached_settings() {
+		$theme_id = self::factory()->post->create( [ 'post_type' => 'popup_theme' ] );
+
+		update_post_meta( $theme_id, 'popup_theme_settings', [ 'container_padding' => 20 ] );
+
+		$theme = new PUM_Model_Theme( $theme_id );
+		$theme->get_settings();
+
+		// Mirrors pum_theme_migration_2()'s write path.
+		$theme->update_meta( 'popup_theme_settings', [ 'container_padding' => 99 ] );
+
+		$this->assertSame( 99, $theme->get_setting( 'container_padding' ) );
+
+		$theme->delete_meta( 'popup_theme_settings' );
+
+		$this->assertSame( [], $theme->get_settings() );
+	}
+
+	/**
+	 * The settings cache reflects the value WordPress stores after unslashing.
+	 *
+	 * @return void
+	 */
+	public function test_update_settings_caches_stored_normalized_value() {
+		$theme_id = self::factory()->post->create( [ 'post_type' => 'popup_theme' ] );
+		$theme    = new PUM_Model_Theme( $theme_id );
+
+		$theme->update_settings( [ 'close_text' => "Don\\'t close" ] );
+
+		$stored_settings = get_post_meta( $theme_id, 'popup_theme_settings', true );
+
+		$this->assertSame( "Don't close", $stored_settings['close_text'] );
+		$this->assertSame( $stored_settings, $theme->get_settings() );
+	}
+
+	/**
+	 * Native metadata writes invalidate settings cached by an existing model.
+	 *
+	 * @return void
+	 */
+	public function test_native_meta_writes_invalidate_cached_settings() {
+		$theme_id = self::factory()->post->create( [ 'post_type' => 'popup_theme' ] );
+
+		update_post_meta( $theme_id, 'popup_theme_settings', [ 'container_padding' => 20 ] );
+
+		$theme = new PUM_Model_Theme( $theme_id );
+		$this->assertSame( 20, $theme->get_setting( 'container_padding' ) );
+
+		update_post_meta( $theme_id, 'popup_theme_settings', [ 'container_padding' => 40 ] );
+		$this->assertSame( 40, $theme->get_setting( 'container_padding' ) );
+
+		delete_post_meta( $theme_id, 'popup_theme_settings' );
+		$this->assertSame( [], $theme->get_settings() );
+	}
+
+	/**
+	 * External database writes become visible after metadata cache eviction.
+	 *
+	 * @return void
+	 */
+	public function test_object_cache_eviction_refreshes_cached_settings() {
+		global $wpdb;
+
+		$theme_id = self::factory()->post->create( [ 'post_type' => 'popup_theme' ] );
+
+		update_post_meta( $theme_id, 'popup_theme_settings', [ 'container_padding' => 20 ] );
+
+		$theme = new PUM_Model_Theme( $theme_id );
+		$this->assertSame( 20, $theme->get_setting( 'container_padding' ) );
+
+		$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Simulates an external database write before cache eviction.
+			$wpdb->postmeta,
+			[ 'meta_value' => maybe_serialize( [ 'container_padding' => 40 ] ) ], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			[
+				'post_id'  => $theme_id,
+				'meta_key' => 'popup_theme_settings', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			]
+		);
+		wp_cache_delete( $theme_id, 'post_meta' );
+		update_meta_cache( 'post', [ $theme_id ] );
+
+		$this->assertSame( 40, $theme->get_setting( 'container_padding' ) );
+
+		$wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Simulates an external database write before cache eviction.
+			$wpdb->postmeta,
+			[ 'meta_value' => maybe_serialize( [ 'container_padding' => 60 ] ) ], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value
+			[
+				'post_id'  => $theme_id,
+				'meta_key' => 'popup_theme_settings', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
+			]
+		);
+		clean_post_cache( $theme_id );
+
+		$this->assertSame( 60, $theme->get_setting( 'container_padding' ) );
+	}
+
+	/**
+	 * Extension theme subclasses retain remapped metadata behavior.
+	 *
+	 * @return void
+	 */
+	public function test_theme_subclasses_reapply_remapped_settings_metadata() {
+		$theme_id = self::factory()->post->create( [ 'post_type' => 'popup_theme' ] );
+		$theme    = new class( $theme_id ) extends PUM_Model_Theme {
+
+			/** @var int */
+			public $remapped_padding = 20;
+
+			/**
+			 * @param string $key Meta key.
+			 * @return array<string,int>|false
+			 */
+			public function remapped_meta( $key = '' ) {
+				if ( 'popup_theme_settings' === $key ) {
+					return [ 'container_padding' => $this->remapped_padding ];
+				}
+
+				return parent::remapped_meta( $key );
+			}
+		};
+
+		$this->assertSame( 20, $theme->get_setting( 'container_padding' ) );
+		$this->assertSame( [ 'container_padding' => 20 ], $theme->settings );
+
+		$theme->remapped_padding = 40;
+
+		$this->assertSame( 40, $theme->get_setting( 'container_padding' ) );
+		$this->assertSame( [ 'container_padding' => 40 ], $theme->settings );
+	}
+
+	/**
+	 * The same model does not reuse settings across multisite blog switches.
+	 *
+	 * @return void
+	 */
+	public function test_settings_cache_is_partitioned_by_blog() {
+		if ( ! is_multisite() ) {
+			$this->markTestSkipped( 'Stored multisite settings require the WordPress multisite test suite.' );
+		}
+
+		$theme_id = self::factory()->post->create( [ 'post_type' => 'popup_theme' ] );
+		$blog_id  = self::factory()->blog->create();
+
+		update_post_meta( $theme_id, 'popup_theme_settings', [ 'container_padding' => 20 ] );
+
+		$theme = new PUM_Model_Theme( $theme_id );
+		$this->assertSame( 20, $theme->get_setting( 'container_padding' ) );
+
+		try {
+			switch_to_blog( $blog_id );
+			update_post_meta( $theme_id, 'popup_theme_settings', [ 'container_padding' => 40 ] );
+			$this->assertSame( 40, $theme->get_setting( 'container_padding' ) );
+		} finally {
+			restore_current_blog();
+		}
+
+		$this->assertSame( 20, $theme->get_setting( 'container_padding' ) );
+	}
+
+	/**
+	 * Metadata observers see the stored value even when registered first.
+	 *
+	 * @return void
+	 */
+	public function test_native_meta_cache_invalidates_before_observers() {
+		$theme_id = self::factory()->post->create( [ 'post_type' => 'popup_theme' ] );
+		$theme    = null;
+		$observed = null;
+
+		update_post_meta( $theme_id, 'popup_theme_settings', [ 'container_padding' => 20 ] );
+
+		$observer = function ( $meta_id, $object_id, $meta_key ) use ( $theme_id, &$theme, &$observed ) {
+			if ( $theme_id === (int) $object_id && 'popup_theme_settings' === $meta_key ) {
+				$observed = $theme->get_setting( 'container_padding' );
+			}
+		};
+
+		add_action( 'updated_post_meta', $observer, -1000, 3 );
+
+		$theme = new PUM_Model_Theme( $theme_id );
+		$theme->get_settings();
+		update_post_meta( $theme_id, 'popup_theme_settings', [ 'container_padding' => 40 ] );
+
+		remove_action( 'updated_post_meta', $observer, -1000 );
+
+		$this->assertSame( 40, $observed );
+	}
+
+	/**
+	 * Dynamic WordPress metadata overrides are evaluated on every settings read.
+	 *
+	 * @return void
+	 */
+	public function test_get_settings_reapplies_dynamic_metadata_overrides() {
+		$theme_id = self::factory()->post->create( [ 'post_type' => 'popup_theme' ] );
+		$padding  = 20;
+
+		update_post_meta( $theme_id, 'popup_theme_settings', [ 'container_padding' => 10 ] );
+
+		$metadata_filter = function ( $value, $object_id, $meta_key ) use ( $theme_id, &$padding ) {
+			if ( $theme_id === $object_id && 'popup_theme_settings' === $meta_key ) {
+				return [ [ 'container_padding' => $padding ] ];
+			}
+
+			return $value;
+		};
+
+		$theme = new PUM_Model_Theme( $theme_id );
+		$this->assertSame( 10, $theme->get_setting( 'container_padding' ) );
+		$this->assertSame( [ 'container_padding' => 10 ], $theme->settings );
+
+		add_filter( 'get_post_metadata', $metadata_filter, 10, 3 );
+
+		$this->assertSame( 20, $theme->get_setting( 'container_padding' ) );
+		$this->assertSame( [ 'container_padding' => 20 ], $theme->settings );
+
+		$padding = 40;
+		$this->assertSame( 40, $theme->get_setting( 'container_padding' ) );
+		$this->assertSame( [ 'container_padding' => 40 ], $theme->settings );
+
+		remove_filter( 'get_post_metadata', $metadata_filter, 10 );
+
+		$this->assertSame( 10, $theme->get_setting( 'container_padding' ) );
+		$this->assertSame( [ 'container_padding' => 10 ], $theme->settings );
+	}
+
+	/**
+	 * WordPress metadata defaults are preserved when no settings row exists.
+	 *
+	 * @return void
+	 */
+	public function test_get_settings_reapplies_metadata_defaults() {
+		$theme_id = self::factory()->post->create( [ 'post_type' => 'popup_theme' ] );
+		$padding  = 20;
+
+		$default_filter = function ( $value, $object_id, $meta_key ) use ( $theme_id, &$padding ) {
+			if ( $theme_id === $object_id && 'popup_theme_settings' === $meta_key ) {
+				return [ 'container_padding' => $padding ];
+			}
+
+			return $value;
+		};
+
+		add_filter( 'default_post_metadata', $default_filter, 10, 3 );
+
+		$theme = new PUM_Model_Theme( $theme_id );
+
+		$this->assertSame( 20, $theme->get_setting( 'container_padding' ) );
+		$this->assertSame( [ 'container_padding' => 20 ], $theme->settings );
+
+		$padding = 40;
+		$this->assertSame( 40, $theme->get_setting( 'container_padding' ) );
+		$this->assertSame( [ 'container_padding' => 40 ], $theme->settings );
+
+		remove_filter( 'default_post_metadata', $default_filter, 10 );
+	}
+
+	/**
+	 * Metadata writes by meta ID fire the registered invalidation hooks.
+	 *
+	 * @return void
+	 */
+	public function test_by_mid_meta_writes_invalidate_cached_settings() {
+		$theme_id = self::factory()->post->create( [ 'post_type' => 'popup_theme' ] );
+		$meta_id  = add_post_meta( $theme_id, 'popup_theme_settings', [ 'container_padding' => 20 ] );
+		$theme    = new PUM_Model_Theme( $theme_id );
+
+		$this->assertSame( 20, $theme->get_setting( 'container_padding' ) );
+		$this->assertTrue( update_metadata_by_mid( 'post', $meta_id, [ 'container_padding' => 40 ] ) );
+		$this->assertSame( 40, $theme->get_setting( 'container_padding' ) );
+		$this->assertTrue( delete_metadata_by_mid( 'post', $meta_id ) );
+		$this->assertSame( [], $theme->get_settings() );
+	}
+}


### PR DESCRIPTION
## Summary

Standalone frontend performance change rebuilt as one commit directly on current `develop`.

- Reuses one canonical popup model across frontend preload, legacy getters, and the modern repository.
- Caches stored popup-theme settings while reapplying dynamic metadata, registered defaults, theme filters, and extension subclass behavior on every applicable read.
- Partitions modern and legacy popup caches by site and invalidates both repositories after native post/settings changes.
- Revalidates canonical popup posts and popup/theme settings after direct database writes plus WordPress object-cache eviction or reprime.
- Preserves protected `cache_item()` extension overrides through a separate public popup-cache replacement operation.
- Preserves request-local popup settings while refreshing values proven to have originated from stored metadata.

## Branch shape

- Base: `c972387c2b5fb5e76ba8467cf9d6c34127b9d9b6` (`develop`)
- Head: `63e1d034fde8e559b18ca1a8955e4c35b3c6357b`
- Divergence: 0 behind / 1 ahead
- Merge commits: none

## Review findings addressed

- Protected repository cache overrides retain their original visibility.
- Missing-to-present `popup_settings` transitions refresh correctly.
- Model settings writes refresh their cache provenance independently of frontend-controller hooks.
- Direct popup-row writes followed by posts-cache eviction/reprime cannot retain stale canonical post fields.
- `clean_post_cache` evicts both modern and legacy popup repositories.
- The multisite theme regression uses real stored metadata and `switch_to_blog()` rather than a metadata filter shortcut.

## Ablation evidence

| Candidate removed | Result | Classification |
|---|---|---|
| Separate public replacement API / protected cache hook | Extension-style protected override produced an access-level fatal | Required |
| Absent-row metadata provenance | Newly inserted settings remained absent after cache reprime | Required |
| Post-write provenance refresh without controller hooks | Direct follow-up write remained at the prior value | Required |
| Canonical `WP_Post` validation | Direct popup-row update returned the original stale model | Required |
| Legacy eviction on `clean_post_cache` | Legacy repository retained the original model | Required |
| Site-aware modern repository key | Cross-site lookup reused the first site's model | Required |
| Theme metadata-cache fingerprint | Reprimed raw metadata remained stale | Required |
| Dynamic metadata short-circuit | Dynamic theme override returned the stored value | Required |
| Theme subclass fallback | Remapped extension metadata was lost | Required |
| Metadata-cache reprime before settings-entry comparison | Unrelated metadata write reran a stateful settings filter | Required |
| Popup metadata short-circuit provenance | Registered-default callback ran and the dynamic value became stored provenance | Required |
| Theme subclass public settings assignment | Public settings remained `null` after a remapped read | Required |
| Theme override/default public synchronization | Public settings remained stored or `null` after dynamic reads | Required |
| Separate private theme storage cache | Removing a dynamic override left its value `40` instead of restoring stored value `10` | Required |
| Separate theme blog-ID field/condition | Real multisite storage test remained green | Redundant; removed |

## Validation

- Frontend regressions: 19 tests, 53 assertions.
- Theme regressions, single site: 12 tests, 38 assertions, one expected multisite skip.
- Theme regressions, multisite: 12 tests, 41 assertions.
- Full candidate suite: 1,110 tests, 2,585 assertions, 9 child-process harness failures, 17 skips.
- Full `develop` baseline: 1,079 tests, 2,486 assertions, the same 9 child-process harness failures, 18 skips; no candidate-only failure.
- Full PHPStan: same 28 existing findings on candidate and `develop`; no new finding.
- Changed-file PHPCS (including tests), PHP syntax, and `git diff --check`: clean.
- Release builder and artifact verifier: passed, 883 files copied.
- Exact-head GitHub CI, Codex, and CodeRabbit are being refreshed for `63e1d034f`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popup loading so displayed popups consistently reflect the latest saved settings.
  * Fixed stale popup data after edits, deletions, direct updates, and metadata changes.
  * Improved theme settings refresh behavior when values change or are removed.
  * Ensured popup and theme settings remain correctly separated across different sites in multisite installations.
  * Preserved temporary or filtered settings when unrelated metadata is updated.
* **Performance**
  * Reduced repeated popup and settings lookups during frontend requests through safer caching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->