### PR TITLE
Performance: reduce memory and TTFB on Popup Maker admin pages

### DIFF
--- a/classes/Controllers/Assets.php
+++ b/classes/Controllers/Assets.php
@@ -28,6 +28,13 @@ class Assets extends Controller {
 	private $should_print_global_vars = false;
 
 	/**
+	 * Packages whose variables have already been localized this request.
+	 *
+	 * @var array<string,bool>
+	 */
+	private $localized_packages = [];
+
+	/**
 	 * Initialize the assets controller.
 	 */
 	public function init() {
@@ -139,7 +146,8 @@ class Assets extends Controller {
 				'varsName' => 'popupMakerComponents',
 				'vars'     => function () {
 					return [
-						'popups' => \pum_get_all_popups(),
+						// Preserve the original models for extensions that filter these variables.
+						'popups' => false !== has_filter( 'popup_maker/components_localized_vars' ) ? \pum_get_all_popups() : $this->get_popup_choices(),
 					];
 				},
 			],
@@ -598,7 +606,7 @@ class Assets extends Controller {
 					}
 				}
 
-				if ( isset( $package_data['varsName'] ) && ! empty( $package_data['vars'] ) ) {
+				if ( isset( $package_data['varsName'] ) && ! empty( $package_data['vars'] ) && ! isset( $this->localized_packages[ $package ] ) && 'admin_print_scripts' !== current_filter() ) {
 					$localized_vars = is_callable( $package_data['vars'] ) ?
 					call_user_func( $package_data['vars'] ) :
 					$package_data['vars'];
@@ -611,9 +619,29 @@ class Assets extends Controller {
 						// Though pum_* asset functions pass through to wp_* automatically when disabled, admin packages should never be bundled.
 						wp_localize_script( $handle, $package_data['varsName'], $localized_vars );
 					}
+
+					$this->localized_packages[ $package ] = true;
 				}
 			}
 		}
+	}
+
+	/**
+	 * Get the minimal popup data consumed by PopupSelectControl.
+	 *
+	 * @return array<int,array{ID:int,post_title:string}>
+	 */
+	private function get_popup_choices() {
+		$choices = [];
+
+		foreach ( \PUM_Helpers::popup_selectlist( [ 'post_status' => [ 'publish', 'private' ] ] ) as $popup_id => $popup_title ) {
+			$choices[] = [
+				'ID'         => (int) $popup_id,
+				'post_title' => (string) $popup_title,
+			];
+		}
+
+		return $choices;
 	}
 
 	/**

--- a/tests/php/tests/Assets_Controller_Test.php
+++ b/tests/php/tests/Assets_Controller_Test.php
@@ -27,4 +27,239 @@ class Assets_Controller_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'previewNonce', $vars );
 		$this->assertArrayHasKey( 'popupTriggerExcludedBlocks', $vars );
 	}
+
+	/**
+	 * @return void
+	 */
+	public function test_components_localize_only_popup_ids_and_titles() {
+		$published_id = self::factory()->post->create(
+			[
+				'post_type'    => 'popup',
+				'post_status'  => 'publish',
+				'post_title'   => 'Published popup',
+				'post_content' => 'Content must not be localized.',
+			]
+		);
+
+		$draft_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+				'post_title'  => 'Draft popup',
+			]
+		);
+
+		$assets   = \PopupMaker\plugin()->get_controller( 'Assets' );
+		$packages = $assets->get_packages();
+		$vars     = call_user_func( $packages['components']['vars'] );
+
+		$this->assertContains(
+			[
+				'ID'         => $published_id,
+				'post_title' => 'Published popup',
+			],
+			$vars['popups']
+		);
+
+		$this->assertNotContains(
+			[
+				'ID'         => $draft_id,
+				'post_title' => 'Draft popup',
+			],
+			$vars['popups']
+		);
+
+		foreach ( $vars['popups'] as $popup ) {
+			$this->assertSame( [ 'ID', 'post_title' ], array_keys( $popup ) );
+		}
+	}
+
+	/**
+	 * Authorized admins retain private popups that are valid on the frontend.
+	 *
+	 * @return void
+	 */
+	public function test_components_preserve_private_popup_choices_for_authorized_admins() {
+		$previous_user_id = get_current_user_id();
+		$admin_user_id    = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$private_id       = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'private',
+				'post_title'  => 'Private popup',
+			]
+		);
+
+		wp_set_current_user( $admin_user_id );
+
+		try {
+			$assets   = \PopupMaker\plugin()->get_controller( 'Assets' );
+			$packages = $assets->get_packages();
+			$vars     = call_user_func( $packages['components']['vars'] );
+		} finally {
+			wp_set_current_user( $previous_user_id );
+		}
+
+		$this->assertContains(
+			[
+				'ID'         => $private_id,
+				'post_title' => 'Private popup',
+			],
+			$vars['popups']
+		);
+	}
+
+	/**
+	 * Existing localized-variable filters retain the original popup models.
+	 *
+	 * @return void
+	 */
+	public function test_components_preserve_popup_models_for_existing_filters() {
+		self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		$expected = pum_get_all_popups();
+		$filter   = function ( $vars ) {
+			return $vars;
+		};
+
+		add_filter( 'popup_maker/components_localized_vars', $filter, 0 );
+
+		$assets   = \PopupMaker\plugin()->get_controller( 'Assets' );
+		$packages = $assets->get_packages();
+		$vars     = call_user_func( $packages['components']['vars'] );
+
+		remove_filter( 'popup_maker/components_localized_vars', $filter, 0 );
+
+		$this->assertSame( $expected, $vars['popups'] );
+	}
+
+	/**
+	 * Query-level title filters are retained in lightweight popup choices.
+	 *
+	 * @return void
+	 */
+	public function test_components_preserve_filtered_popup_titles() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Stored popup title',
+			]
+		);
+
+		$filter = function ( $posts ) use ( $popup_id ) {
+			foreach ( $posts as $post ) {
+				if ( $post instanceof WP_Post && $popup_id === (int) $post->ID ) {
+					$post->post_title = 'Filtered popup title';
+				}
+			}
+
+			return $posts;
+		};
+
+		add_filter( 'posts_results', $filter );
+
+		$assets   = \PopupMaker\plugin()->get_controller( 'Assets' );
+		$packages = $assets->get_packages();
+		$vars     = call_user_func( $packages['components']['vars'] );
+
+		remove_filter( 'posts_results', $filter );
+
+		$this->assertContains(
+			[
+				'ID'         => $popup_id,
+				'post_title' => 'Filtered popup title',
+			],
+			$vars['popups']
+		);
+	}
+
+	/**
+	 * Shared popup-title filters reach the components payload.
+	 *
+	 * @return void
+	 */
+	public function test_components_preserve_shared_popup_title_filters() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Original popup title',
+			]
+		);
+
+		$title_filter = static function ( $titles ) use ( $popup_id ) {
+			$titles[ $popup_id ] = 'Translated popup title';
+
+			return $titles;
+		};
+		$query_filter = static function ( $posts ) {
+			return $posts;
+		};
+
+		add_filter( 'popup_maker/popup_title_choices', $title_filter );
+		add_filter( 'posts_results', $query_filter );
+
+		try {
+			$assets   = \PopupMaker\plugin()->get_controller( 'Assets' );
+			$packages = $assets->get_packages();
+			$vars     = call_user_func( $packages['components']['vars'] );
+		} finally {
+			remove_filter( 'posts_results', $query_filter );
+			remove_filter( 'popup_maker/popup_title_choices', $title_filter );
+		}
+
+		$this->assertContains(
+			[
+				'ID'         => $popup_id,
+				'post_title' => 'Translated popup title',
+			],
+			$vars['popups']
+		);
+	}
+
+	/**
+	 * @return void
+	 */
+	public function test_package_vars_are_localized_once_after_late_admin_filters() {
+		$filter_calls = 0;
+		$assets       = \PopupMaker\plugin()->get_controller( 'Assets' );
+
+		wp_deregister_script( 'popup-maker-components' );
+		wp_register_script( 'popup-maker-components', 'https://example.com/components.js', [], '1.0.0', true );
+		wp_enqueue_script( 'popup-maker-components' );
+		$this->assertFalse( wp_scripts()->get_data( 'popup-maker-components', 'data' ) );
+
+		$filter = function ( $vars ) use ( &$filter_calls ) {
+			++$filter_calls;
+
+			return $vars;
+		};
+
+		$register_filter = function () use ( $filter ) {
+			add_filter( 'popup_maker/components_localized_vars', $filter );
+		};
+
+		$this->assertSame( 1, has_action( 'admin_print_scripts', [ $assets, 'autoload_styles_for_scripts' ] ) );
+		$this->assertSame( 1, has_action( 'wp_print_scripts', [ $assets, 'autoload_styles_for_scripts' ] ) );
+
+		add_action( 'admin_print_scripts', $register_filter, 10 );
+		do_action( 'admin_print_scripts' );
+		do_action( 'wp_print_scripts' );
+		remove_action( 'admin_print_scripts', $register_filter, 10 );
+
+		remove_filter( 'popup_maker/components_localized_vars', $filter );
+
+		$this->assertSame( 1, $filter_calls );
+
+		$localized_data = wp_scripts()->get_data( 'popup-maker-components', 'data' );
+
+		$this->assertIsString( $localized_data );
+		$this->assertSame( 1, substr_count( $localized_data, 'var popupMakerComponents' ) );
+	}
 }


### PR DESCRIPTION
## Summary

Standalone admin Components localization optimization based directly on the shared popup-query foundation merged in #1356.

- Localizes lightweight `{ ID, post_title }` choices for the Components package instead of complete Popup Maker models.
- Adapts `PUM_Helpers::popup_selectlist()` with published + readable-private status selection; it owns no direct popup query or duplicate per-ID validation.
- Preserves complete popup models whenever an extension registers `popup_maker/components_localized_vars`, including priority-`0` registrations.
- Defers admin localization until the later script-print pass so late filters are visible, then de-duplicates localization per package/request.
- Inherits all shared helper hardening and helper tests from merged #1356; none is duplicated in this PR.

## Exact scope

- Base: `develop@c972387c2b5fb5e76ba8467cf9d6c34127b9d9b6`
- Head: `e2a13182caf988073225f63c20ca683cfd485133`
- History: one commit, no merge commits
- Files: `classes/Controllers/Assets.php` and its focused controller tests only

## Verification

- PHP syntax: passed for both changed files.
- Changed-file PHPCS: passed.
- Focused production PHPStan: passed.
- `git diff --check`: passed.
- Query audit: no `get_posts()`, direct `WP_Query`, or `$wpdb` in this PR.
- Focused local PHPUnit was attempted but the local WordPress test database reports unavailable tables; exact-head GitHub CI is the full matrix authority.

## Ablation retained

Focused regressions preserve the independently necessary behaviors: lightweight shaping, readable private choices, query/title filter propagation, full-model extension fallback, late-filter visibility, and localization de-duplication.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved component package localization to provide streamlined popup choices.
  * Preserved authorized access to valid private popups and existing popup filters.
  * Excluded invalid popup types and statuses from localized results.
  * Prevented duplicate localization and avoided unnecessary script localization during admin script loading.
* **Tests**
  * Added coverage for popup filtering, access controls, deferred values, and one-time localization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->