### PR TITLE
Performance: reduce analytics counter queries

### DIFF
--- a/classes/Services/FormConversionTracking.php
+++ b/classes/Services/FormConversionTracking.php
@@ -11,6 +11,7 @@
 namespace PopupMaker\Services;
 
 use PopupMaker\Base\Service;
+use PopupMaker\Utils\AnalyticsCounter;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -63,6 +64,7 @@ class FormConversionTracking extends Service {
 	 *     @type string|null $form_id       Form ID from the provider.
 	 *     @type bool        $tracked       Whether already tracked by other systems.
 	 * }
+	 * @return void
 	 */
 	public function track_form_conversion( $args ) {
 		// Defensive validation for third-party hook callers.
@@ -92,11 +94,21 @@ class FormConversionTracking extends Service {
 			return;
 		}
 
-		// Increment site-wide form conversion count.
-		$this->increment_site_count();
-
 		// Increment per-popup count.
-		$this->increment_popup_count( $popup_id );
+		$popup_count = $this->increment_popup_count( $popup_id );
+
+		if ( is_wp_error( $popup_count ) ) {
+			AnalyticsCounter::report_failure( $popup_count, $popup_id, $args );
+			return;
+		}
+
+		// Increment site-wide form conversion count.
+		$site_count = $this->increment_site_count();
+
+		if ( is_wp_error( $site_count ) ) {
+			AnalyticsCounter::report_failure( $site_count, $popup_id, $args );
+			return;
+		}
 
 		/**
 		 * Fires after a form conversion is tracked (non-AJAX).
@@ -118,6 +130,7 @@ class FormConversionTracking extends Service {
 	 *
 	 * @param int   $popup_id Popup ID from analytics beacon.
 	 * @param array $args     Additional arguments from beacon.
+	 * @return void
 	 */
 	public function track_ajax_conversion( $popup_id, $args = [] ) {
 		// Defensive validation for third-party hook callers.
@@ -156,11 +169,21 @@ class FormConversionTracking extends Service {
 			return;
 		}
 
-		// Increment site-wide form conversion count.
-		$this->increment_site_count();
-
 		// Increment per-popup count.
-		$this->increment_popup_count( $popup_id );
+		$popup_count = $this->increment_popup_count( $popup_id );
+
+		if ( is_wp_error( $popup_count ) ) {
+			AnalyticsCounter::report_failure( $popup_count, $popup_id, $event_data );
+			return;
+		}
+
+		// Increment site-wide form conversion count.
+		$site_count = $this->increment_site_count();
+
+		if ( is_wp_error( $site_count ) ) {
+			AnalyticsCounter::report_failure( $site_count, $popup_id, $event_data );
+			return;
+		}
 
 		/**
 		 * Fires after an AJAX form conversion is tracked.
@@ -181,39 +204,10 @@ class FormConversionTracking extends Service {
 	 *
 	 * @since 1.22.0
 	 *
-	 * @return int New count after increment.
+	 * @return int|\WP_Error New count or an explicit failure.
 	 */
 	protected function increment_site_count() {
-		global $wpdb;
-
-		// Check if option exists; if not, create it with autoload disabled.
-		$exists = $wpdb->get_var(
-			$wpdb->prepare(
-				'SELECT option_id FROM %i WHERE option_name = %s LIMIT 1',
-				$wpdb->options,
-				self::SITE_COUNT_KEY
-			)
-		);
-
-		if ( ! $exists ) {
-			// Initialize with autoload=no (analytical data doesn't need to load on every request).
-			add_option( self::SITE_COUNT_KEY, 0, '', false );
-		}
-
-		// Atomic increment (prevents race condition).
-		$wpdb->query(
-			$wpdb->prepare(
-				'UPDATE %i SET option_value = option_value + 1 WHERE option_name = %s',
-				$wpdb->options,
-				self::SITE_COUNT_KEY
-			)
-		);
-
-		// Clear cache since we bypassed WordPress's caching layer.
-		wp_cache_delete( self::SITE_COUNT_KEY, 'options' );
-
-		// Return updated count.
-		return (int) get_option( self::SITE_COUNT_KEY, 0 );
+		return AnalyticsCounter::increment_option( self::SITE_COUNT_KEY );
 	}
 
 	/**
@@ -225,40 +219,10 @@ class FormConversionTracking extends Service {
 	 * @since 1.22.0
 	 *
 	 * @param int $popup_id Popup post ID.
-	 * @return int New count after increment.
+	 * @return int|\WP_Error New count or an explicit retryable failure.
 	 */
 	protected function increment_popup_count( $popup_id ) {
-		global $wpdb;
-
-		// Check if meta exists; if not, create it.
-		$exists = $wpdb->get_var(
-			$wpdb->prepare(
-				'SELECT meta_id FROM %i WHERE post_id = %d AND meta_key = %s LIMIT 1',
-				$wpdb->postmeta,
-				$popup_id,
-				self::POPUP_META_KEY
-			)
-		);
-
-		if ( ! $exists ) {
-			add_post_meta( $popup_id, self::POPUP_META_KEY, 0, true );
-		}
-
-		// Atomic increment (prevents race condition).
-		$wpdb->query(
-			$wpdb->prepare(
-				'UPDATE %i SET meta_value = meta_value + 1 WHERE post_id = %d AND meta_key = %s',
-				$wpdb->postmeta,
-				$popup_id,
-				self::POPUP_META_KEY
-			)
-		);
-
-		// Clear cache since we bypassed WordPress's caching layer.
-		wp_cache_delete( $popup_id, 'post_meta' );
-
-		// Return updated count.
-		return (int) get_post_meta( $popup_id, self::POPUP_META_KEY, true );
+		return AnalyticsCounter::increment_post_meta( $popup_id, self::POPUP_META_KEY );
 	}
 
 	/**

--- a/classes/Services/LinkClickTracking.php
+++ b/classes/Services/LinkClickTracking.php
@@ -11,6 +11,7 @@
 namespace PopupMaker\Services;
 
 use PopupMaker\Base\Service;
+use PopupMaker\Utils\AnalyticsCounter;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -54,6 +55,7 @@ class LinkClickTracking extends Service {
 	 *
 	 * @param int   $popup_id Popup ID from analytics beacon.
 	 * @param array $args     Additional arguments from beacon.
+	 * @return void
 	 */
 	public function track_link_click( $popup_id, $args = [] ) {
 		// Defensive validation for third-party hook callers.
@@ -90,11 +92,21 @@ class LinkClickTracking extends Service {
 			return;
 		}
 
-		// Increment site-wide link click count.
-		$this->increment_site_count();
-
 		// Increment per-popup count.
-		$this->increment_popup_count( $popup_id );
+		$popup_count = $this->increment_popup_count( $popup_id );
+
+		if ( is_wp_error( $popup_count ) ) {
+			AnalyticsCounter::report_failure( $popup_count, $popup_id, $event_data );
+			return;
+		}
+
+		// Increment site-wide link click count.
+		$site_count = $this->increment_site_count();
+
+		if ( is_wp_error( $site_count ) ) {
+			AnalyticsCounter::report_failure( $site_count, $popup_id, $event_data );
+			return;
+		}
 
 		/**
 		 * Fires after a link click is tracked.
@@ -114,36 +126,10 @@ class LinkClickTracking extends Service {
 	 *
 	 * @since 1.22.0
 	 *
-	 * @return int New count after increment.
+	 * @return int|\WP_Error New count or an explicit failure.
 	 */
 	protected function increment_site_count() {
-		global $wpdb;
-
-		// Check if option exists; if not, create it with autoload disabled.
-		$exists = $wpdb->get_var(
-			$wpdb->prepare(
-				'SELECT option_id FROM %i WHERE option_name = %s LIMIT 1',
-				$wpdb->options,
-				self::SITE_COUNT_KEY
-			)
-		);
-
-		if ( ! $exists ) {
-			add_option( self::SITE_COUNT_KEY, 0, '', false );
-		}
-
-		// Atomic increment (prevents race condition).
-		$wpdb->query(
-			$wpdb->prepare(
-				'UPDATE %i SET option_value = option_value + 1 WHERE option_name = %s',
-				$wpdb->options,
-				self::SITE_COUNT_KEY
-			)
-		);
-
-		wp_cache_delete( self::SITE_COUNT_KEY, 'options' );
-
-		return (int) get_option( self::SITE_COUNT_KEY, 0 );
+		return AnalyticsCounter::increment_option( self::SITE_COUNT_KEY );
 	}
 
 	/**
@@ -154,37 +140,10 @@ class LinkClickTracking extends Service {
 	 * @since 1.22.0
 	 *
 	 * @param int $popup_id Popup post ID.
-	 * @return int New count after increment.
+	 * @return int|\WP_Error New count or an explicit retryable failure.
 	 */
 	protected function increment_popup_count( $popup_id ) {
-		global $wpdb;
-
-		$exists = $wpdb->get_var(
-			$wpdb->prepare(
-				'SELECT meta_id FROM %i WHERE post_id = %d AND meta_key = %s LIMIT 1',
-				$wpdb->postmeta,
-				$popup_id,
-				self::POPUP_META_KEY
-			)
-		);
-
-		if ( ! $exists ) {
-			add_post_meta( $popup_id, self::POPUP_META_KEY, 0, true );
-		}
-
-		// Atomic increment.
-		$wpdb->query(
-			$wpdb->prepare(
-				'UPDATE %i SET meta_value = meta_value + 1 WHERE post_id = %d AND meta_key = %s',
-				$wpdb->postmeta,
-				$popup_id,
-				self::POPUP_META_KEY
-			)
-		);
-
-		wp_cache_delete( $popup_id, 'post_meta' );
-
-		return (int) get_post_meta( $popup_id, self::POPUP_META_KEY, true );
+		return AnalyticsCounter::increment_post_meta( $popup_id, self::POPUP_META_KEY );
 	}
 
 	/**

--- a/classes/Utils/AnalyticsCounter.php
+++ b/classes/Utils/AnalyticsCounter.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Atomic analytics counter storage.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ *
+ * phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery
+ */
+
+namespace PopupMaker\Utils;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Efficiently increment option- and post-meta-backed counters.
+ */
+class AnalyticsCounter {
+
+	/**
+	 * Maximum number of one-second waits for a contended initialization lock.
+	 */
+	private const LOCK_ATTEMPTS = 3;
+
+	/**
+	 * Increment a non-autoloaded option counter.
+	 *
+	 * @param string $key Option key.
+	 * @return int|\WP_Error Updated count or an explicit failure.
+	 */
+	public static function increment_option( $key ) {
+		global $wpdb;
+
+		$rows_affected = $wpdb->query(
+			$wpdb->prepare(
+				"INSERT INTO %i (option_name, option_value, autoload) VALUES (%s, 1, 'off') ON DUPLICATE KEY UPDATE option_value = option_value + 1, autoload = 'off'",
+				$wpdb->options,
+				$key
+			)
+		);
+
+		if ( false === $rows_affected ) {
+			return self::database_error( $key );
+		}
+
+		wp_cache_delete( $key, 'options' );
+
+		$alloptions = wp_cache_get( 'alloptions', 'options' );
+		if ( is_array( $alloptions ) && isset( $alloptions[ $key ] ) ) {
+			wp_cache_delete( 'alloptions', 'options' );
+		}
+
+		$notoptions = wp_cache_get( 'notoptions', 'options' );
+		if ( 1 === $rows_affected || ( is_array( $notoptions ) && isset( $notoptions[ $key ] ) ) ) {
+			wp_cache_delete( 'notoptions', 'options' );
+		}
+
+		return (int) get_option( $key, 0 );
+	}
+
+	/**
+	 * Increment a post-meta counter.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $key Meta key.
+	 * @return int|\WP_Error Updated count or an explicit retryable failure.
+	 */
+	public static function increment_post_meta( $post_id, $key ) {
+		global $wpdb;
+
+		$updated = self::update_post_meta_counter( $post_id, $key );
+
+		if ( false === $updated ) {
+			return self::database_error( $key, $post_id );
+		}
+
+		if ( 0 === $updated ) {
+			$initialized = self::initialize_post_meta( $post_id, $key );
+
+			if ( is_wp_error( $initialized ) ) {
+				wp_cache_delete( $post_id, 'post_meta' );
+				return $initialized;
+			}
+		}
+
+		wp_cache_delete( $post_id, 'post_meta' );
+
+		return (int) get_post_meta( $post_id, $key, true );
+	}
+
+	/**
+	 * Surface a counter failure without breaking the tracking request.
+	 *
+	 * @param \WP_Error $error Counter failure.
+	 * @param int       $post_id Popup post ID.
+	 * @param array     $context Tracking context.
+	 * @return void
+	 */
+	public static function report_failure( $error, $post_id, $context ) {
+		/**
+		 * Fires when an analytics counter could not be stored. Consumers can
+		 * inspect the error data to decide whether and what to retry; a sibling
+		 * counter that was already stored is not rolled back.
+		 *
+		 * @param \WP_Error $error Counter failure.
+		 * @param int       $post_id Popup post ID.
+		 * @param array     $context Tracking context.
+		 */
+		do_action( 'popup_maker/analytics_counter_failed', $error, $post_id, $context );
+	}
+
+	/**
+	 * Initialize a missing post-meta counter without racing another request.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $key Meta key.
+	 * @return true|\WP_Error True when stored or an explicit failure.
+	 */
+	private static function initialize_post_meta( $post_id, $key ) {
+		global $wpdb;
+
+		$database  = defined( 'DB_NAME' ) ? DB_NAME : '';
+		$lock_name = 'pum_counter_' . md5( $database . ':' . $wpdb->postmeta . ':' . $key . ':' . $post_id );
+
+		for ( $attempt = 0; $attempt < self::LOCK_ATTEMPTS; $attempt++ ) {
+			// FOR UPDATE keeps named locks on the writer connection for split-read database drop-ins.
+			$lock_result = $wpdb->get_var( $wpdb->prepare( 'SELECT GET_LOCK(%s, 1) FOR UPDATE', $lock_name ) );
+
+			if ( 1 === (int) $lock_result ) {
+				try {
+					$updated = self::update_post_meta_counter( $post_id, $key );
+
+					if ( false === $updated ) {
+						return self::database_error( $key, $post_id );
+					}
+
+					if ( 0 === $updated ) {
+						$added = add_post_meta( $post_id, $key, 1, true );
+
+						if ( false === $added ) {
+							$updated = self::update_post_meta_counter( $post_id, $key );
+
+							if ( false === $updated || 0 === $updated ) {
+								return self::database_error( $key, $post_id );
+							}
+						}
+					}
+				} finally {
+					$wpdb->get_var( $wpdb->prepare( 'SELECT RELEASE_LOCK(%s) FOR UPDATE', $lock_name ) );
+				}
+
+				return true;
+			}
+
+			if ( null === $lock_result ) {
+				return self::initialize_post_meta_without_lock( $post_id, $key );
+			}
+
+			// The lock owner may have initialized the row while this request waited.
+			$updated = self::update_post_meta_counter( $post_id, $key );
+
+			if ( false === $updated ) {
+				return self::database_error( $key, $post_id );
+			}
+
+			if ( 0 < $updated ) {
+				return true;
+			}
+		}
+
+		return new \WP_Error(
+			'pum_analytics_counter_lock_timeout',
+			__( 'The analytics counter is busy. Retry this event.', 'popup-maker' ),
+			[
+				'post_id'     => (int) $post_id,
+				'counter_key' => (string) $key,
+				'retryable'   => true,
+			]
+		);
+	}
+
+	/**
+	 * Preserve baseline behavior when advisory locks are unavailable.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $key Meta key.
+	 * @return true|\WP_Error True when stored or an explicit failure.
+	 */
+	private static function initialize_post_meta_without_lock( $post_id, $key ) {
+		if ( ! get_post_meta( $post_id, $key, true ) ) {
+			$added = add_post_meta( $post_id, $key, 1, true );
+
+			if ( false !== $added ) {
+				return true;
+			}
+		}
+
+		$updated = self::update_post_meta_counter( $post_id, $key );
+
+		if ( false === $updated || 0 === $updated ) {
+			return self::database_error( $key, $post_id );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Increment an existing post-meta counter row.
+	 *
+	 * @param int    $post_id Post ID.
+	 * @param string $key Meta key.
+	 * @return int|false Number of affected rows or false on error.
+	 */
+	private static function update_post_meta_counter( $post_id, $key ) {
+		global $wpdb;
+
+		return $wpdb->query(
+			$wpdb->prepare(
+				'UPDATE %i SET meta_value = meta_value + 1 WHERE post_id = %d AND meta_key = %s',
+				$wpdb->postmeta,
+				$post_id,
+				$key
+			)
+		);
+	}
+
+	/**
+	 * Build a non-retryable database failure for a counter write.
+	 *
+	 * @param string   $key Counter key.
+	 * @param int|null $post_id Optional post ID.
+	 * @return \WP_Error Counter database error.
+	 */
+	private static function database_error( $key, $post_id = null ) {
+		$data = [
+			'counter_key' => (string) $key,
+			'retryable'   => false,
+		];
+
+		if ( null !== $post_id ) {
+			$data['post_id'] = (int) $post_id;
+		}
+
+		return new \WP_Error(
+			'pum_analytics_counter_database_error',
+			__( 'The analytics counter could not be updated.', 'popup-maker' ),
+			$data
+		);
+	}
+}

--- a/tests/php/tests/FormConversionTracking_Test.php
+++ b/tests/php/tests/FormConversionTracking_Test.php
@@ -6,6 +6,7 @@
  */
 
 use PopupMaker\Services\FormConversionTracking;
+use PopupMaker\Utils\AnalyticsCounter;
 
 /**
  * Test methods for FormConversionTracking service.
@@ -91,6 +92,305 @@ class FormConversionTracking_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * First writes invalidate the aggregate negative-option cache.
+	 */
+	public function test_missing_site_count_invalidates_aggregate_negative_cache() {
+		$this->service->reset_site_count();
+		$this->assertSame( 0, $this->service->get_site_count() );
+		$this->assertIsArray( wp_cache_get( 'notoptions', 'options' ) );
+
+		$this->service->track_form_conversion(
+			[
+				'popup_id' => $this->popup_id,
+			]
+		);
+
+		$notoptions = wp_cache_get( 'notoptions', 'options' );
+
+		$this->assertIsArray( $notoptions );
+		$this->assertArrayNotHasKey( FormConversionTracking::SITE_COUNT_KEY, $notoptions );
+		$this->assertSame( 1, $this->service->get_site_count() );
+	}
+
+	/**
+	 * Steady writes preserve negative cache entries for unrelated options.
+	 */
+	public function test_existing_site_count_preserves_unrelated_negative_cache() {
+		$missing_key = 'pum_test_missing_option';
+
+		add_option( FormConversionTracking::SITE_COUNT_KEY, 0, '', false );
+		$this->assertFalse( get_option( $missing_key ) );
+
+		$notoptions = wp_cache_get( 'notoptions', 'options' );
+		$this->assertIsArray( $notoptions );
+		$this->assertArrayHasKey( $missing_key, $notoptions );
+
+		$site_method = new ReflectionMethod( $this->service, 'increment_site_count' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$site_method->setAccessible( true );
+		}
+
+		$this->assertSame( 1, $site_method->invoke( $this->service ) );
+
+		$notoptions = wp_cache_get( 'notoptions', 'options' );
+		$this->assertIsArray( $notoptions );
+		$this->assertArrayHasKey( $missing_key, $notoptions );
+	}
+
+	/**
+	 * Existing autoloaded counters are updated without returning stale cache data.
+	 */
+	public function test_existing_autoloaded_site_count_is_updated_and_made_non_autoloaded() {
+		add_option( FormConversionTracking::SITE_COUNT_KEY, 3, '', true );
+
+		$alloptions = wp_load_alloptions();
+		$this->assertArrayHasKey( FormConversionTracking::SITE_COUNT_KEY, $alloptions );
+		$this->assertSame( '3', (string) $alloptions[ FormConversionTracking::SITE_COUNT_KEY ] );
+
+		$site_method = new ReflectionMethod( $this->service, 'increment_site_count' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$site_method->setAccessible( true );
+		}
+
+		$this->assertSame( 4, $site_method->invoke( $this->service ) );
+		$this->assertSame( 4, $this->service->get_site_count() );
+		$this->assertArrayNotHasKey( FormConversionTracking::SITE_COUNT_KEY, wp_load_alloptions( true ) );
+	}
+
+	/**
+	 * Named-lock queries stay on the writer connection and within this database.
+	 */
+	public function test_post_meta_lock_queries_use_writer_connection() {
+		delete_post_meta( $this->popup_id, FormConversionTracking::POPUP_META_KEY );
+		wp_cache_delete( $this->popup_id, 'post_meta' );
+
+		$lock_queries = [];
+		$query_filter = static function ( $query ) use ( &$lock_queries ) {
+			if ( false !== strpos( $query, 'GET_LOCK' ) || false !== strpos( $query, 'RELEASE_LOCK' ) ) {
+				$lock_queries[] = $query;
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $query_filter );
+
+		try {
+			$popup_method = new ReflectionMethod( $this->service, 'increment_popup_count' );
+			if ( PHP_VERSION_ID < 80100 ) {
+				$popup_method->setAccessible( true );
+			}
+
+			$this->assertSame( 1, $popup_method->invoke( $this->service, $this->popup_id ) );
+		} finally {
+			remove_filter( 'query', $query_filter );
+		}
+
+		$this->assertNotEmpty( $lock_queries );
+		$expected_lock = $this->popup_counter_lock_name( $this->popup_id );
+		foreach ( $lock_queries as $lock_query ) {
+			$this->assertStringContainsString( 'FOR UPDATE', $lock_query );
+			$this->assertStringContainsString( $expected_lock, $lock_query );
+		}
+	}
+
+	/**
+	 * Named locks are released when counter initialization fails.
+	 */
+	public function test_post_meta_lock_is_released_after_failure() {
+		global $wpdb;
+
+		delete_post_meta( $this->popup_id, FormConversionTracking::POPUP_META_KEY );
+		wp_cache_delete( $this->popup_id, 'post_meta' );
+
+		$lock_acquired = false;
+		$query_filter  = static function ( $query ) use ( &$lock_acquired ) {
+			if ( false !== strpos( $query, 'GET_LOCK' ) ) {
+				$lock_acquired = true;
+			} elseif ( $lock_acquired && false !== strpos( $query, 'UPDATE ' ) ) {
+				throw new RuntimeException( 'Simulated counter update failure.' );
+			}
+
+			return $query;
+		};
+
+		add_filter( 'query', $query_filter );
+
+		try {
+			$popup_method = new ReflectionMethod( $this->service, 'increment_popup_count' );
+			if ( PHP_VERSION_ID < 80100 ) {
+				$popup_method->setAccessible( true );
+			}
+
+			$popup_method->invoke( $this->service, $this->popup_id );
+			$this->fail( 'Expected the simulated counter failure.' );
+		} catch ( RuntimeException $exception ) {
+			$this->assertSame( 'Simulated counter update failure.', $exception->getMessage() );
+		} finally {
+			remove_filter( 'query', $query_filter );
+		}
+
+		$lock_name = $this->popup_counter_lock_name( $this->popup_id );
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- This assertion inspects the named lock on the current test connection.
+		$is_free = $wpdb->get_var( $wpdb->prepare( 'SELECT IS_FREE_LOCK(%s)', $lock_name ) );
+
+		$this->assertSame( '1', (string) $is_free );
+	}
+
+	/**
+	 * A real contending connection can outlive the old two-attempt window.
+	 */
+	public function test_post_meta_increment_waits_for_real_contending_connection() {
+		global $wpdb;
+
+		delete_post_meta( $this->popup_id, FormConversionTracking::POPUP_META_KEY );
+		wp_cache_delete( $this->popup_id, 'post_meta' );
+
+		if ( ! defined( 'MYSQLI_ASYNC' ) || ! function_exists( 'mysqli_reap_async_query' ) ) {
+			$this->markTestSkipped( 'The mysqli asynchronous-query API is unavailable.' );
+		}
+
+		$lock_name   = $this->popup_counter_lock_name( $this->popup_id );
+		$lock_holder = new wpdb( DB_USER, DB_PASSWORD, DB_NAME, DB_HOST );
+		$acquired    = $lock_holder->get_var( $lock_holder->prepare( 'SELECT GET_LOCK(%s, 0)', $lock_name ) );
+
+		if ( '1' !== (string) $acquired ) {
+			$this->markTestSkipped( 'A second database connection could not acquire a named lock.' );
+		}
+
+		$dbh_property = new ReflectionProperty( $lock_holder, 'dbh' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$dbh_property->setAccessible( true );
+		}
+		$dbh           = $dbh_property->getValue( $lock_holder );
+		$release_query = $lock_holder->prepare( 'SELECT SLEEP(2.2), RELEASE_LOCK(%s)', $lock_name );
+		// phpcs:ignore WordPress.DB.RestrictedFunctions.mysql_mysqli_query -- Async execution lets the second test connection release its held lock while the primary connection waits.
+		$async_query = mysqli_query( $dbh, $release_query, MYSQLI_ASYNC );
+
+		if ( false === $async_query ) {
+			$lock_holder->get_var( $lock_holder->prepare( 'SELECT RELEASE_LOCK(%s)', $lock_name ) );
+			$this->markTestSkipped( 'The second database connection could not schedule an asynchronous lock release.' );
+		}
+
+		try {
+			$result = AnalyticsCounter::increment_post_meta( $this->popup_id, FormConversionTracking::POPUP_META_KEY );
+		} finally {
+			// phpcs:ignore WordPress.DB.RestrictedFunctions.mysql_mysqli_reap_async_query -- Reap the isolated second connection's test-only asynchronous query.
+			mysqli_reap_async_query( $dbh );
+		}
+
+		$this->assertSame( 1, $result );
+		$this->assertSame( 1, $this->service->get_popup_count( $this->popup_id ) );
+		$this->assertSame(
+			'1',
+			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery -- Verify the isolated concurrency fixture created exactly one row.
+			(string) $wpdb->get_var(
+				$wpdb->prepare(
+					'SELECT COUNT(*) FROM %i WHERE post_id = %d AND meta_key = %s',
+					$wpdb->postmeta,
+					$this->popup_id,
+					FormConversionTracking::POPUP_META_KEY
+				)
+			)
+		);
+	}
+
+	/**
+	 * Exhausted contention is surfaced and does not partially increment totals.
+	 */
+	public function test_post_meta_lock_timeout_is_reported_to_tracking_consumers() {
+		delete_post_meta( $this->popup_id, FormConversionTracking::POPUP_META_KEY );
+		wp_cache_delete( $this->popup_id, 'post_meta' );
+
+		$lock_attempts  = 0;
+		$query_filter   = static function ( $query ) use ( &$lock_attempts ) {
+			if ( false !== strpos( $query, 'GET_LOCK' ) ) {
+				++$lock_attempts;
+				return 'SELECT 0';
+			}
+
+			return $query;
+		};
+		$reported_error = null;
+		$error_action   = static function ( $error ) use ( &$reported_error ) {
+			$reported_error = $error;
+		};
+
+		add_filter( 'query', $query_filter );
+		add_action( 'popup_maker/analytics_counter_failed', $error_action );
+
+		try {
+			$this->service->track_form_conversion( [ 'popup_id' => $this->popup_id ] );
+		} finally {
+			remove_filter( 'query', $query_filter );
+			remove_action( 'popup_maker/analytics_counter_failed', $error_action );
+		}
+
+		$this->assertWPError( $reported_error );
+		$this->assertSame( 'pum_analytics_counter_lock_timeout', $reported_error->get_error_code() );
+		$this->assertSame( 3, $lock_attempts );
+		$this->assertSame( 0, $this->service->get_popup_count( $this->popup_id ) );
+		$this->assertSame( 0, $this->service->get_site_count() );
+	}
+
+	/**
+	 * A failed site-counter upsert is reported and suppresses the success action.
+	 */
+	public function test_site_counter_database_failure_is_reported_without_success_action() {
+		global $wpdb;
+
+		$args = [
+			'popup_id'      => $this->popup_id,
+			'form_provider' => 'wpforms',
+		];
+
+		add_post_meta( $this->popup_id, FormConversionTracking::POPUP_META_KEY, 0, true );
+
+		$query_filter             = static function ( $query ) {
+			if ( false !== strpos( $query, 'INSERT INTO' ) && false !== strpos( $query, FormConversionTracking::SITE_COUNT_KEY ) ) {
+				return 'SELECT * FROM pum_missing_analytics_counter_table';
+			}
+
+			return $query;
+		};
+		$failure                  = null;
+		$error_action             = static function ( $error, $popup_id, $context ) use ( &$failure ) {
+			$failure = compact( 'error', 'popup_id', 'context' );
+		};
+		$success_fired            = false;
+		$success_action           = static function () use ( &$success_fired ) {
+			$success_fired = true;
+		};
+		$previous_suppress_errors = $wpdb->suppress_errors( true );
+
+		add_filter( 'query', $query_filter );
+		add_action( 'popup_maker/analytics_counter_failed', $error_action, 10, 3 );
+		add_action( 'popup_maker/form_conversion_tracked', $success_action );
+
+		try {
+			$this->service->track_form_conversion( $args );
+		} finally {
+			remove_filter( 'query', $query_filter );
+			remove_action( 'popup_maker/analytics_counter_failed', $error_action );
+			remove_action( 'popup_maker/form_conversion_tracked', $success_action );
+			$wpdb->suppress_errors( $previous_suppress_errors );
+		}
+
+		$this->assertIsArray( $failure );
+		$this->assertWPError( $failure['error'] );
+		$this->assertSame( 'pum_analytics_counter_database_error', $failure['error']->get_error_code() );
+		$error_data = $failure['error']->get_error_data();
+		$this->assertSame( FormConversionTracking::SITE_COUNT_KEY, $error_data['counter_key'] );
+		$this->assertFalse( $error_data['retryable'] );
+		$this->assertArrayNotHasKey( 'post_id', $error_data );
+		$this->assertSame( $this->popup_id, $failure['popup_id'] );
+		$this->assertSame( $args, $failure['context'] );
+		$this->assertFalse( $success_fired );
+		$this->assertSame( 1, $this->service->get_popup_count( $this->popup_id ) );
+		$this->assertSame( 0, $this->service->get_site_count() );
+	}
+
+	/**
 	 * Test track_form_conversion increments multiple times.
 	 */
 	public function test_track_form_conversion_increments_multiple() {
@@ -105,6 +405,31 @@ class FormConversionTracking_Test extends WP_UnitTestCase {
 
 		$this->assertEquals( 3, $this->service->get_site_count(), 'Site count should be 3 after three conversions.' );
 		$this->assertEquals( 3, $this->service->get_popup_count( $this->popup_id ), 'Popup count should be 3.' );
+	}
+
+	/**
+	 * Test steady-state counter increments avoid existence queries.
+	 */
+	public function test_existing_counters_use_four_queries() {
+		global $wpdb;
+
+		add_option( FormConversionTracking::SITE_COUNT_KEY, 0, '', false );
+		delete_post_meta( $this->popup_id, FormConversionTracking::POPUP_META_KEY );
+		add_post_meta( $this->popup_id, FormConversionTracking::POPUP_META_KEY, 0, true );
+		wp_cache_delete( FormConversionTracking::SITE_COUNT_KEY, 'options' );
+		wp_cache_delete( $this->popup_id, 'post_meta' );
+
+		$site_method  = new ReflectionMethod( $this->service, 'increment_site_count' );
+		$popup_method = new ReflectionMethod( $this->service, 'increment_popup_count' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$site_method->setAccessible( true );
+			$popup_method->setAccessible( true );
+		}
+		$query_count = $wpdb->num_queries;
+
+		$this->assertSame( 1, $site_method->invoke( $this->service ) );
+		$this->assertSame( 1, $popup_method->invoke( $this->service, $this->popup_id ) );
+		$this->assertSame( 4, $wpdb->num_queries - $query_count );
 	}
 
 	/**
@@ -273,5 +598,17 @@ class FormConversionTracking_Test extends WP_UnitTestCase {
 		$this->service->reset_popup_count( $this->popup_id );
 
 		$this->assertEquals( 0, $this->service->get_popup_count( $this->popup_id ), 'Popup count should be 0 after reset.' );
+	}
+
+	/**
+	 * Build the expected named lock for a popup counter.
+	 *
+	 * @param int $popup_id Popup ID.
+	 * @return string
+	 */
+	private function popup_counter_lock_name( $popup_id ) {
+		global $wpdb;
+
+		return 'pum_counter_' . md5( DB_NAME . ':' . $wpdb->postmeta . ':' . FormConversionTracking::POPUP_META_KEY . ':' . $popup_id );
 	}
 }

--- a/tests/php/tests/LinkClickTracking_Test.php
+++ b/tests/php/tests/LinkClickTracking_Test.php
@@ -88,6 +88,81 @@ class LinkClickTracking_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A cached missing option is invalidated when the counter is first created.
+	 */
+	public function test_track_link_click_after_missing_site_count_was_cached() {
+		$this->service->reset_site_count();
+		$this->assertSame( 0, $this->service->get_site_count() );
+
+		$this->service->track_link_click(
+			$this->popup_id,
+			[
+				'eventData' => [
+					'type' => 'link_click',
+				],
+			]
+		);
+
+		$this->assertSame( 1, $this->service->get_site_count() );
+	}
+
+	/**
+	 * A failed site-counter upsert is reported and suppresses the success action.
+	 */
+	public function test_site_counter_database_failure_is_reported_without_success_action() {
+		global $wpdb;
+
+		$args = [
+			'eventData' => [
+				'type' => 'link_click',
+				'url'  => 'https://example.com',
+			],
+		];
+
+		add_post_meta( $this->popup_id, LinkClickTracking::POPUP_META_KEY, 0, true );
+
+		$query_filter             = static function ( $query ) {
+			if ( false !== strpos( $query, 'INSERT INTO' ) && false !== strpos( $query, LinkClickTracking::SITE_COUNT_KEY ) ) {
+				return 'SELECT * FROM pum_missing_analytics_counter_table';
+			}
+
+			return $query;
+		};
+		$failure                  = null;
+		$error_action             = static function ( $error, $popup_id, $context ) use ( &$failure ) {
+			$failure = compact( 'error', 'popup_id', 'context' );
+		};
+		$success_fired            = false;
+		$success_action           = static function () use ( &$success_fired ) {
+			$success_fired = true;
+		};
+		$previous_suppress_errors = $wpdb->suppress_errors( true );
+
+		add_filter( 'query', $query_filter );
+		add_action( 'popup_maker/analytics_counter_failed', $error_action, 10, 3 );
+		add_action( 'popup_maker/link_click_tracked', $success_action );
+
+		try {
+			$this->service->track_link_click( $this->popup_id, $args );
+		} finally {
+			remove_filter( 'query', $query_filter );
+			remove_action( 'popup_maker/analytics_counter_failed', $error_action );
+			remove_action( 'popup_maker/link_click_tracked', $success_action );
+			$wpdb->suppress_errors( $previous_suppress_errors );
+		}
+
+		$this->assertIsArray( $failure );
+		$this->assertWPError( $failure['error'] );
+		$this->assertSame( 'pum_analytics_counter_database_error', $failure['error']->get_error_code() );
+		$this->assertSame( LinkClickTracking::SITE_COUNT_KEY, $failure['error']->get_error_data()['counter_key'] );
+		$this->assertSame( $this->popup_id, $failure['popup_id'] );
+		$this->assertSame( $args['eventData'], $failure['context'] );
+		$this->assertFalse( $success_fired );
+		$this->assertSame( 1, $this->service->get_popup_count( $this->popup_id ) );
+		$this->assertSame( 0, $this->service->get_site_count() );
+	}
+
+	/**
 	 * Test track_link_click increments multiple times.
 	 */
 	public function test_track_link_click_multiple_increments() {
@@ -102,6 +177,31 @@ class LinkClickTracking_Test extends WP_UnitTestCase {
 		$this->service->track_link_click( $this->popup_id, $args );
 
 		$this->assertEquals( 2, $this->service->get_site_count(), 'Site count should be 2 after two clicks.' );
+	}
+
+	/**
+	 * Test steady-state counter increments avoid existence queries.
+	 */
+	public function test_existing_counters_use_four_queries() {
+		global $wpdb;
+
+		add_option( LinkClickTracking::SITE_COUNT_KEY, 0, '', false );
+		delete_post_meta( $this->popup_id, LinkClickTracking::POPUP_META_KEY );
+		add_post_meta( $this->popup_id, LinkClickTracking::POPUP_META_KEY, 0, true );
+		wp_cache_delete( LinkClickTracking::SITE_COUNT_KEY, 'options' );
+		wp_cache_delete( $this->popup_id, 'post_meta' );
+
+		$site_method  = new ReflectionMethod( $this->service, 'increment_site_count' );
+		$popup_method = new ReflectionMethod( $this->service, 'increment_popup_count' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$site_method->setAccessible( true );
+			$popup_method->setAccessible( true );
+		}
+		$query_count = $wpdb->num_queries;
+
+		$this->assertSame( 1, $site_method->invoke( $this->service ) );
+		$this->assertSame( 1, $popup_method->invoke( $this->service, $this->popup_id ) );
+		$this->assertSame( 4, $wpdb->num_queries - $query_count );
 	}
 
 	/**
@@ -181,13 +281,13 @@ class LinkClickTracking_Test extends WP_UnitTestCase {
 	 * Test track_link_click fires the tracked action.
 	 */
 	public function test_track_link_click_fires_action() {
-		$fired_popup_id  = null;
+		$fired_popup_id   = null;
 		$fired_event_data = null;
 
 		add_action(
 			'popup_maker/link_click_tracked',
 			function ( $popup_id, $event_data ) use ( &$fired_popup_id, &$fired_event_data ) {
-				$fired_popup_id  = $popup_id;
+				$fired_popup_id   = $popup_id;
 				$fired_event_data = $event_data;
 			},
 			10,


### PR DESCRIPTION
## Scope

Standalone performance and correctness change directly based on current `develop` for form-conversion and link-click counter writes.

## TL;DR

Reduces each steady-state two-counter event from **6 SQL calls to 4 (-33.3%)** while preserving atomic increments, non-autoloaded site counters, WordPress cache coherence, and bounded request behavior during first-write contention.

## What changed

- Site counters use the options table's unique `option_name` key for one atomic insert-or-increment statement instead of an existence read followed by an update.
- Direct first inserts clear the relevant WordPress negative option cache; steady-state increments preserve unrelated negative-cache entries.
- Existing autoloaded counter options are normalized to non-autoloaded storage, and `alloptions` is invalidated before readback so an increment cannot return stale cached data.
- A failed option upsert returns an explicit `WP_Error` instead of reading and returning a stale count.
- Per-popup counters use update-first and avoid an existence query after initialization.
- A shared `AnalyticsCounter` utility owns the database and cache behavior used by both tracking services.
- Missing post-meta counters initialize under a connection-scoped advisory lock because WordPress post meta has no unique `(post_id, meta_key)` constraint.
- Contended initializers make three one-second writer-routed lock attempts. After every timeout they retry the atomic update, consuming a row created by the lock owner as soon as it exists.
- If all three waits expire, the utility returns a retryable `WP_Error`; tracking emits `popup_maker/analytics_counter_failed` and does not increment the site total or fire a success action. The event is not reported as stored.
- If the popup counter succeeds but the following site-option upsert fails, the failure hook identifies the failed site counter and the success action is suppressed. The already-stored popup count is intentionally not rolled back; this database error is marked non-retryable as a whole event.
- When advisory locks are unavailable, the utility retains the prior WordPress metadata fallback instead of making lock support a hard runtime requirement.
- Lock names include the database, site-specific postmeta table, meta key, and post ID for multisite/cross-installation isolation.

## Why the lock is warranted

`wp_postmeta` has indexes on `post_id` and `meta_key`, but no unique composite key. Two simultaneous first events can therefore both pass WordPress's application-level `$unique` check and create duplicate counter rows. The lock exists only on the missing-row path; initialized counters remain a single atomic update.

## Performance measurement

MySQL 8 / PHP 8.3, temporary tables using the WordPress options/postmeta schemas, 30 alternating samples of 100 complete two-counter events:

| Metric | Before | After | Gain |
|---|---:|---:|---:|
| SQL calls per steady-state event | 6 | 4 | **-2 (-33.3%)** |
| Median time per 100 events | 22.91 ms | 16.25 ms | **-6.66 ms (-29.1%)** |

The contention logic adds no steady-state queries.

## Validation

- Exact head: `0174a5cc76c4584c1dbc18bace868ab7144a5455`; sole parent: current `develop` `52a17cb11f2e3ec31138d2b2ce25c6f4facfea81`; 0 behind / 1 ahead / no merge commits.
- Focused tracking suite: **24 tests, 67 assertions**, green.
- Full PHP suite: **1,122 tests, 2,688 assertions, 19 skips**, green.
- Real two-connection regression: a second connection holds the initialization lock for 2.2 seconds (past the old two-attempt window); the third attempt persists the event and produces exactly one meta row.
- Retry-window ablation: reducing the implementation back to two attempts reproduces the failure; restoring three passes.
- Partial-count ablation: site-first ordering leaves site=1/popup=0 on exhausted contention; popup-first ordering leaves both at zero and exposes the retryable failure.
- Option-error ablation: removing the false-result check reproduces the stale-success behavior; restoring it makes both services report failure and suppress their success actions.
- `alloptions` ablation: removing aggregate-cache invalidation returns stale count 3 after SQL stored 4; restoring it returns 4 and removes the counter from autoloaded options.
- Lock release, writer routing, database namespace, cache scope, error propagation, and four-query steady-state behavior have focused coverage.
- Changed production files: PHPCS and PHPStan clean apart from unchanged `error_log` warnings; PHP 7.4 compatibility, syntax, and `git diff --check` clean.
- Full local PHPCS/PHPStan reproduce only pre-existing `develop` failures, with no new failures.
- Substantive local CodeRabbit review on the complete tree: **0 findings**. Remote CodeRabbit is advisory while its quota is rate-limited.
- Topology-only replay onto current `develop` is patch-identical by `git range-diff`. Final exact-head GitHub CI and Codex review are running.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of form conversion and link-click analytics counting.
  * Added safer handling for counter update failures, including retryable error reporting.
  * Ensured popup counts are recorded before site-wide totals and prevent incomplete updates.
  * Improved cache consistency when initializing analytics counters.

* **Tests**
  * Expanded coverage for counter initialization, concurrency, failures, cache behavior, and efficient updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

