### PR TITLE
Performance: optimize CTA UUID lookups

### DIFF
--- a/classes/Services/Repository/CallToActions.php
+++ b/classes/Services/Repository/CallToActions.php
@@ -96,9 +96,11 @@ class CallToActions extends Repository {
 		}
 
 		$items = $this->query( [
-			'meta_key'       => 'cta_uuid', // phpcs:ignore WordPress.DB.SlowDBQuery
-			'meta_value'     => $uuid, // phpcs:ignore WordPress.DB.SlowDBQuery
-			'posts_per_page' => 1,
+			'meta_key'              => 'cta_uuid', // phpcs:ignore WordPress.DB.SlowDBQuery
+			'meta_value'            => $uuid, // phpcs:ignore WordPress.DB.SlowDBQuery
+			'posts_per_page'        => 1,
+			'no_found_rows'         => true,
+			'update_post_term_cache' => false,
 		] );
 
 		$item = ! empty( $items ) ? $items[0] : null;

--- a/tests/php/tests/CallToActions_Repository_Test.php
+++ b/tests/php/tests/CallToActions_Repository_Test.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * Call to action repository tests.
+ *
+ * @package Popup_Maker
+ */
+
+use function PopupMaker\plugin;
+
+/**
+ * Test query behavior in the call to action repository.
+ */
+class CallToActions_Repository_Test extends WP_UnitTestCase {
+
+	/**
+	 * CTA fixture ID.
+	 *
+	 * @var int
+	 */
+	private $cta_id;
+
+	/**
+	 * CTA fixture UUID.
+	 *
+	 * @var string
+	 */
+	private $uuid;
+
+	/**
+	 * Set up the CTA fixture.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->uuid   = 'repository-query-' . wp_generate_uuid4();
+		$this->cta_id = wp_insert_post(
+			[
+				'post_type'   => 'pum_cta',
+				'post_status' => 'publish',
+				'post_title'  => 'Repository Query Test',
+			]
+		);
+
+		update_post_meta( $this->cta_id, 'cta_uuid', $this->uuid );
+		update_post_meta( $this->cta_id, 'cta_settings', [] );
+		update_post_meta( $this->cta_id, 'data_version', 1 );
+	}
+
+	/**
+	 * Remove the CTA fixture and lookup cache.
+	 */
+	public function tearDown(): void {
+		wp_cache_delete( 'popup_maker_cta_id_by_uuid_' . $this->uuid, 'popup_maker_ctas' );
+		wp_delete_post( $this->cta_id, true );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * Test a cold UUID lookup skips the unused found-rows query.
+	 */
+	public function test_get_by_uuid_uses_three_queries() {
+		global $wpdb;
+
+		clean_post_cache( $this->cta_id );
+		wp_cache_delete( 'popup_maker_cta_id_by_uuid_' . $this->uuid, 'popup_maker_ctas' );
+		$query_count = $wpdb->num_queries;
+
+		$cta = plugin( 'ctas' )->get_by_uuid( $this->uuid );
+
+		$this->assertNotNull( $cta );
+		$this->assertSame( $this->cta_id, $cta->ID );
+		$this->assertSame( 3, $wpdb->num_queries - $query_count );
+	}
+}


### PR DESCRIPTION
## Scope

Standalone performance change against `develop` for CTA UUID repository lookups.

## Summary

- Mark single-result UUID queries with `no_found_rows` because callers never consume a total.
- Disable the unused post-term cache priming for the CTA lookup.
- Add a regression test for the cold-cache query budget and returned CTA.

## Measured impact

Benchmark: 15 published CTAs with unique UUIDs, each lookup run cold after clearing the post and repository caches. Baseline and optimized modes ran in separate WP-CLI processes against the same local database.

| Metric | Baseline | Optimized | Change |
|---|---:|---:|---:|
| SQL queries per cold lookup | 4 | 3 | -25.0% |
| Median lookup latency | 3.228 ms | 2.494 ms | -22.7% |
| Mean lookup latency | 3.597 ms | 2.755 ms | -23.4% |
| Successful results | 15/15 | 15/15 | unchanged |

Forcing WordPress out of its split-query path reduced the visible query count to two but made the lookup slower in the ablation, so this PR deliberately preserves WordPress's normal query strategy.

## Validation

- Full GitHub `Tests` matrix and `CI - Code Quality`: green on the final SHA.
- Focused repository test: 1 test, 3 assertions.
- Changed production-file PHPStan and PHPCS at CI error severity: passed.
- PHP syntax and `git diff --check`: passed.
- No unresolved review threads.
- Original scoped commit replayed unchanged onto current `develop` (`git range-diff` exact match).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CTA lookup by UUID for faster, more efficient results.
  * Limited UUID searches to a single matching CTA while preserving metadata filtering.

* **Tests**
  * Added coverage verifying UUID lookups return the expected CTA and use the intended number of database queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->