### PR TITLE
Performance: prime popup bulk admin actions

### DIFF
--- a/classes/Admin/Popups.php
+++ b/classes/Admin/Popups.php
@@ -126,6 +126,8 @@ class PUM_Admin_Popups {
 		$count   = 0;
 		$skipped = 0;
 
+		self::prime_bulk_action_caches( $post_ids );
+
 		foreach ( $post_ids as $post_id ) {
 			// Check user can edit this popup.
 			if ( ! current_user_can( 'edit_post', $post_id ) ) {
@@ -158,6 +160,44 @@ class PUM_Admin_Popups {
 		);
 
 		return $redirect_url;
+	}
+
+	/**
+	 * Prime popup objects used by a bulk state change.
+	 *
+	 * @param int[] $post_ids Selected post IDs.
+	 * @return void
+	 */
+	private static function prime_bulk_action_caches( $post_ids ) {
+		$popup_ids = wp_parse_id_list( $post_ids );
+
+		if ( empty( $popup_ids ) ) {
+			return;
+		}
+
+		$cached_posts       = wp_cache_get_multiple( $popup_ids, 'posts' );
+		$uncached_popup_ids = [];
+
+		foreach ( $popup_ids as $popup_id ) {
+			if ( ! array_key_exists( $popup_id, $cached_posts ) || false === $cached_posts[ $popup_id ] ) {
+				$uncached_popup_ids[] = $popup_id;
+			}
+		}
+
+		if ( empty( $uncached_popup_ids ) ) {
+			return;
+		}
+
+		\PopupMaker\plugin( 'popups' )->query_posts(
+			[
+				'post_status'            => array_keys( get_post_stati() ),
+				'post__in'               => $uncached_popup_ids,
+				'posts_per_page'         => count( $uncached_popup_ids ),
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			]
+		);
 	}
 
 	/**
@@ -1651,7 +1691,7 @@ class PUM_Admin_Popups {
 	/**
 	 * Prepends Popup ID to the action row on All Popups
 	 *
-	 * @param array         $actions The row actions.
+	 * @param array $actions The row actions.
 	 * @param $post The post
 	 *
 	 * @return array The new actions.

--- a/tests/php/tests/PUM_Admin_Popups_Test.php
+++ b/tests/php/tests/PUM_Admin_Popups_Test.php
@@ -484,6 +484,105 @@ class PUM_Admin_Popups_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Bulk actions prime selected popup objects before per-popup processing.
+	 */
+	public function test_handle_bulk_actions_primes_selected_popup_objects() {
+		global $wpdb;
+
+		$popup_ids = [];
+
+		for ( $i = 0; $i < 20; ++$i ) {
+			$popup_id = $this->factory->post->create(
+				[
+					'post_type'   => 'popup',
+					'post_status' => 'publish',
+				]
+			);
+
+			update_post_meta( $popup_id, 'enabled', 0 );
+			update_post_meta( $popup_id, 'data_version', 3 );
+			$popup_ids[] = $popup_id;
+			clean_post_cache( $popup_id );
+		}
+
+		$start_queries = $wpdb->num_queries;
+		$result        = PUM_Admin_Popups::handle_bulk_actions(
+			'https://example.com/wp-admin/edit.php?post_type=popup',
+			'pum_enable',
+			$popup_ids
+		);
+
+		$this->assertLessThanOrEqual( 62, $wpdb->num_queries - $start_queries );
+		$this->assertStringContainsString( 'pum_bulk_count=20', $result );
+
+		foreach ( $popup_ids as $popup_id ) {
+			$this->assertSame( '1', get_post_meta( $popup_id, 'enabled', true ) );
+		}
+	}
+
+	/**
+	 * Bulk cache priming avoids a database query when every popup is cached.
+	 */
+	public function test_bulk_cache_priming_skips_cached_posts() {
+		global $wpdb;
+
+		$popup_ids = $this->factory->post->create_many(
+			3,
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		foreach ( $popup_ids as $popup_id ) {
+			$this->assertInstanceOf( WP_Post::class, get_post( $popup_id ) );
+		}
+
+		$prime_method = new ReflectionMethod( PUM_Admin_Popups::class, 'prime_bulk_action_caches' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prime_method->setAccessible( true );
+		}
+
+		$start_queries = $wpdb->num_queries;
+		$prime_method->invoke( null, $popup_ids );
+
+		$this->assertSame( 0, $wpdb->num_queries - $start_queries );
+	}
+
+	/**
+	 * Bulk cache priming queries cold popup objects through the repository.
+	 */
+	public function test_bulk_cache_priming_uses_repository_query() {
+		global $wpdb;
+
+		$popup_ids = $this->factory->post->create_many(
+			3,
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		foreach ( $popup_ids as $popup_id ) {
+			clean_post_cache( $popup_id );
+		}
+
+		$prime_method = new ReflectionMethod( PUM_Admin_Popups::class, 'prime_bulk_action_caches' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$prime_method->setAccessible( true );
+		}
+
+		$start_queries = $wpdb->num_queries;
+		$prime_method->invoke( null, $popup_ids );
+
+		$this->assertLessThanOrEqual( 2, $wpdb->num_queries - $start_queries );
+
+		foreach ( $popup_ids as $popup_id ) {
+			$this->assertInstanceOf( WP_Post::class, get_post( $popup_id ) );
+		}
+	}
+
+	/**
 	 * Empty post IDs results in zero counts.
 	 */
 	public function test_handle_bulk_actions_empty_post_ids() {


### PR DESCRIPTION
## Scope

Standalone performance change against `develop` for popup-list bulk actions.

## Summary

- Prime selected popup post objects before per-popup bulk processing.
- Query only for post objects missing from the WordPress object cache; a fully warm selection adds no priming SQL.
- Deliberately leave metadata unprimed: the write-heavy path is faster with indexed per-popup metadata reads.
- Preserve per-popup capability checks, popup model validation, published-status checks, metadata APIs/hooks, result counts, and redirects.
- Enforce a 62-query upper budget instead of an exact WordPress-version-dependent count.

## Measured impact

Benchmark: ten fresh batches of 20 published popups, each with `enabled=0`, current data version, and a cleared post object cache. Timings cover only `handle_bulk_actions()` and use the median batch.

| Metric | Baseline | Optimized | Change |
|---|---:|---:|---:|
| Median SQL queries | 80 | 62 | -22.5% |
| Median execution time | 4.980 ms | 3.604 ms | -27.6% |
| Popups enabled per batch | 20/20 | 20/20 | unchanged |

Warm-cache review fixture:

| Metric | Before follow-up | After follow-up |
|---|---:|---:|
| Priming SQL with every selected post cached | 1 | 0 |

Ablations:

- Priming posts plus all metadata reduced SQL to 43 but regressed median time to 7.975 ms, so it was removed.
- WordPress's lower-level cache primer reached 42 queries but was slower than the retained public query path and would couple this code to an internal API, so it was removed.
- Removing the cache-miss filter reproduced the unnecessary warm-cache query; restoring it returned the fixture to zero SQL.

## Validation

- Full GitHub `Tests` matrix and `CI - Code Quality`: green on the final SHA.
- Popup admin focus: 46 tests, 120 assertions.
- Changed production-file PHPCS at CI error severity: passed.
- PHP syntax and `git diff --check`: passed.
- Both prior Codex findings remain fixed; no unresolved review threads.
- Original three-commit scoped range replayed unchanged onto current `develop` (`git range-diff` exact match).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved bulk enabling and disabling of popups by reducing unnecessary database queries.
  * Bulk actions now process selected published popups more efficiently, especially when managing multiple items.

* **Bug Fixes**
  * Improved reliability when applying bulk popup status changes to selected items.

* **Tests**
  * Added coverage to verify efficient processing and correct popup enablement during bulk actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->