### PR TITLE
Batch-prime notification popup metadata

### DIFF
--- a/classes/Base/Service/Repository.php
+++ b/classes/Base/Service/Repository.php
@@ -88,21 +88,10 @@ abstract class Repository extends Service {
 	 * @return TPost[] Array of instantiated model objects matching the query.
 	 */
 	public function query( $args = [] ) {
-		$query_args = wp_parse_args( $args, [
-			'post_type'      => $this->post_type,
-			'posts_per_page' => - 1,
-		] );
-
-		$query_results = new \WP_Query( $query_args );
-
 		/** @var TPost[] $items */
 		$items = [];
 
-		foreach ( $query_results->posts as $post ) {
-			if ( ! $post instanceof \WP_Post ) {
-				continue;
-			}
-
+		foreach ( $this->query_posts( $args ) as $post ) {
 			$item = $this->instantiate_model_from_post( $post );
 
 			if ( ! $item ) {
@@ -116,6 +105,66 @@ abstract class Repository extends Service {
 		}
 
 		return $items;
+	}
+
+	/**
+	 * Query repository records as WordPress post objects without model hydration.
+	 *
+	 * @param array<string,mixed> $args WP_Query arguments.
+	 * @return \WP_Post[] Matching post objects.
+	 */
+	public function query_posts( $args = [] ) {
+		$args = is_array( $args ) ? $args : [];
+		unset( $args['post_type'], $args['fields'] );
+
+		$query_args = wp_parse_args(
+			$args,
+			[
+				'posts_per_page' => -1,
+			]
+		);
+
+		$query_args['post_type'] = $this->post_type;
+		$query_args['fields']    = 'all';
+
+		$query = new \WP_Query( $query_args );
+
+		return array_values(
+			array_filter(
+				$query->posts,
+				static function ( $post ) {
+					return $post instanceof \WP_Post;
+				}
+			)
+		);
+	}
+
+	/**
+	 * Query repository record IDs without post-object or model hydration.
+	 *
+	 * @param array<string,mixed> $args WP_Query arguments.
+	 * @return int[] Matching post IDs.
+	 */
+	public function query_ids( $args = [] ) {
+		$args = is_array( $args ) ? $args : [];
+		unset( $args['post_type'], $args['fields'] );
+
+		$query_args = wp_parse_args(
+			$args,
+			[
+				'posts_per_page'         => -1,
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			]
+		);
+
+		$query_args['post_type'] = $this->post_type;
+		$query_args['fields']    = 'ids';
+
+		$query = new \WP_Query( $query_args );
+
+		return wp_parse_id_list( $query->posts );
 	}
 
 	/**

--- a/classes/Services/Notifications/FeatureAnnouncements.php
+++ b/classes/Services/Notifications/FeatureAnnouncements.php
@@ -32,6 +32,13 @@ class FeatureAnnouncements extends Service implements Provider {
 	const EXIT_INTENT_MIN_CONVERSIONS = 10;
 
 	/**
+	 * Maximum popup metadata records to prime per exit-intent scan step.
+	 *
+	 * @var int
+	 */
+	const EXIT_INTENT_META_BATCH_SIZE = 20;
+
+	/**
 	 * Minimum total conversions before advanced analytics becomes relevant.
 	 *
 	 * @var int
@@ -532,11 +539,9 @@ class FeatureAnnouncements extends Service implements Provider {
 	 * @return bool
 	 */
 	public function has_published_popup() {
-		$popups = get_posts( [
-			'post_type'      => 'popup',
+		$popups = $this->container->get( 'popups' )->query_ids( [
 			'post_status'    => 'publish',
 			'posts_per_page' => 1,
-			'fields'         => 'ids',
 			'no_found_rows'  => true,
 		] );
 
@@ -556,11 +561,9 @@ class FeatureAnnouncements extends Service implements Provider {
 			return false;
 		}
 
-		$popups = get_posts( [
-			'post_type'      => 'popup',
+		$popups = $this->container->get( 'popups' )->query_ids( [
 			'post_status'    => 'publish',
 			'posts_per_page' => 2,
-			'fields'         => 'ids',
 			'no_found_rows'  => true,
 		] );
 
@@ -707,7 +710,8 @@ class FeatureAnnouncements extends Service implements Provider {
 
 	/**
 	 * True when the site has crossed the form conversion floor AND no
-	 * popup is using an exit-intent trigger yet.
+	 * popup is using an exit-intent trigger yet. Existing trigger data may come
+	 * from Pro or the retired standalone Exit Intent extension.
 	 *
 	 * @return bool
 	 */
@@ -763,31 +767,35 @@ class FeatureAnnouncements extends Service implements Provider {
 	/**
 	 * True when any published popup has at least one exit-intent trigger.
 	 *
+	 * Both Pro and the retired standalone extension persist the same
+	 * `exit_intent` trigger type, so stored legacy triggers remain relevant.
+	 *
 	 * @return bool
 	 */
 	protected function any_popup_uses_exit_intent() {
-		$popups = get_posts( [
-			'post_type'      => 'popup',
+		$popups = $this->container->get( 'popups' )->query_ids( [
 			'post_status'    => 'publish',
 			'posts_per_page' => -1,
-			'fields'         => 'ids',
-			'no_found_rows'  => true,
 		] );
 
 		if ( empty( $popups ) ) {
 			return false;
 		}
 
-		foreach ( $popups as $popup_id ) {
-			$triggers = get_post_meta( (int) $popup_id, 'popup_triggers', true );
+		foreach ( array_chunk( wp_parse_id_list( $popups ), self::EXIT_INTENT_META_BATCH_SIZE ) as $popup_ids ) {
+			update_meta_cache( 'post', $popup_ids );
 
-			if ( ! is_array( $triggers ) ) {
-				continue;
-			}
+			foreach ( $popup_ids as $popup_id ) {
+				$triggers = get_post_meta( $popup_id, 'popup_triggers', true );
 
-			foreach ( $triggers as $trigger ) {
-				if ( isset( $trigger['type'] ) && 'exit_intent' === $trigger['type'] ) {
-					return true;
+				if ( ! is_array( $triggers ) ) {
+					continue;
+				}
+
+				foreach ( $triggers as $trigger ) {
+					if ( isset( $trigger['type'] ) && 'exit_intent' === $trigger['type'] ) {
+						return true;
+					}
 				}
 			}
 		}
@@ -879,7 +887,7 @@ class FeatureAnnouncements extends Service implements Provider {
 	 *
 	 * Memoized for the lifetime of the request — both the condition
 	 * check and the message builder call this, and the underlying
-	 * get_posts() scan is the most expensive thing in this class.
+	 * popup repository scan is the most expensive thing in this class.
 	 *
 	 * @return array{total:int,disabled:int,stale:int}
 	 */
@@ -888,11 +896,11 @@ class FeatureAnnouncements extends Service implements Provider {
 			return $this->scheduling_stats_cache;
 		}
 
-		$popups = get_posts( [
-			'post_type'      => 'popup',
-			'post_status'    => [ 'publish', 'draft' ],
-			'posts_per_page' => -1,
-			'no_found_rows'  => true,
+		$popups = $this->container->get( 'popups' )->query_posts( [
+			'post_status'            => [ 'publish', 'draft' ],
+			'posts_per_page'         => -1,
+			'no_found_rows'          => true,
+			'update_post_term_cache' => false,
 		] );
 
 		$stale_threshold = time() - ( self::SCHEDULING_STALE_DAYS * DAY_IN_SECONDS );

--- a/tests/php/fixtures/class-pum-test-feature-announcements.php
+++ b/tests/php/fixtures/class-pum-test-feature-announcements.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Feature announcements test double.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Expose protected feature checks for query testing.
+ */
+class PUM_Test_Feature_Announcements extends \PopupMaker\Services\Notifications\FeatureAnnouncements {
+
+	/**
+	 * Check whether any popup uses exit intent.
+	 *
+	 * @return bool
+	 */
+	public function has_exit_intent_popup() {
+		return $this->any_popup_uses_exit_intent();
+	}
+
+	/**
+	 * Get popup scheduling statistics.
+	 *
+	 * @return array{total:int,disabled:int,stale:int}
+	 */
+	public function get_scheduling_stats() {
+		return $this->scheduling_stats();
+	}
+}

--- a/tests/php/tests/Feature_Announcements_Query_Test.php
+++ b/tests/php/tests/Feature_Announcements_Query_Test.php
@@ -1,0 +1,168 @@
+<?php
+/**
+ * Feature announcement query tests.
+ *
+ * @package Popup_Maker
+ */
+
+require_once dirname( __DIR__ ) . '/fixtures/class-pum-test-feature-announcements.php';
+
+/**
+ * Verify feature checks batch-prime popup metadata.
+ */
+class Feature_Announcements_Query_Test extends WP_UnitTestCase {
+
+	/**
+	 * Popup fixture IDs.
+	 *
+	 * @var int[]
+	 */
+	private $popup_ids = [];
+
+	/**
+	 * Set up popup fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->popup_ids = self::factory()->post->create_many(
+			20,
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		foreach ( $this->popup_ids as $popup_id ) {
+			update_post_meta( $popup_id, 'popup_triggers', [ [ 'type' => 'click_open' ] ] );
+		}
+	}
+
+	/**
+	 * Cold metadata is loaded in one query before scanning triggers.
+	 */
+	public function test_exit_intent_check_uses_two_queries() {
+		global $wpdb;
+
+		wp_cache_flush();
+		get_option( 'posts_per_page' );
+
+		$service     = new PUM_Test_Feature_Announcements( $GLOBALS['popup_maker'] );
+		$query_count = $wpdb->num_queries;
+
+		$this->assertFalse( $service->has_exit_intent_popup() );
+		$this->assertSame( 2, $wpdb->num_queries - $query_count );
+	}
+
+	/**
+	 * An early match does not prime metadata outside the first batch.
+	 */
+	public function test_exit_intent_check_stops_before_priming_later_batches() {
+		global $wpdb;
+
+		foreach ( $this->popup_ids as $index => $popup_id ) {
+			$date = sprintf( '2025-01-%02d 12:00:00', $index + 1 );
+			wp_update_post(
+				[
+					'ID'            => $popup_id,
+					'post_date'     => $date,
+					'post_date_gmt' => $date,
+				]
+			);
+		}
+
+		$exit_popup_id = end( $this->popup_ids );
+		update_post_meta( $exit_popup_id, 'popup_triggers', [ [ 'type' => 'exit_intent' ] ] );
+
+		$outside_batch_id = self::factory()->post->create(
+			[
+				'post_type'     => 'popup',
+				'post_status'   => 'publish',
+				'post_date'     => '2024-01-01 12:00:00',
+				'post_date_gmt' => '2024-01-01 12:00:00',
+			]
+		);
+		update_post_meta( $outside_batch_id, 'popup_triggers', [ [ 'type' => 'click_open' ] ] );
+
+		wp_cache_flush();
+		get_option( 'posts_per_page' );
+
+		$service     = new PUM_Test_Feature_Announcements( $GLOBALS['popup_maker'] );
+		$query_count = $wpdb->num_queries;
+
+		$this->assertTrue( $service->has_exit_intent_popup() );
+		$this->assertSame( 2, $wpdb->num_queries - $query_count );
+		$this->assertFalse( wp_cache_get( $outside_batch_id, 'post_meta' ) );
+	}
+
+	/**
+	 * Scheduling statistics skip unused term-cache queries.
+	 */
+	public function test_scheduling_stats_use_two_queries() {
+		global $wpdb;
+
+		foreach ( $this->popup_ids as $popup_id ) {
+			update_post_meta( $popup_id, 'popup_enabled', true );
+		}
+
+		wp_cache_flush();
+		get_option( 'posts_per_page' );
+
+		$service     = new PUM_Test_Feature_Announcements( $GLOBALS['popup_maker'] );
+		$query_count = $wpdb->num_queries;
+		$stats       = $service->get_scheduling_stats();
+
+		$this->assertSame( 20, $stats['total'] );
+		$this->assertSame( 2, $wpdb->num_queries - $query_count );
+	}
+
+	/**
+	 * Feature scans delegate their popup queries to the repository projections.
+	 */
+	public function test_feature_scans_use_popup_repository_query_shapes() {
+		$repository = new class( \PopupMaker\plugin( 'popups' ) ) {
+			/** @var \PopupMaker\Services\Repository\Popups */
+			private $delegate;
+
+			/** @var int */
+			public $id_queries = 0;
+
+			/** @var int */
+			public $post_queries = 0;
+
+			public function __construct( $delegate ) {
+				$this->delegate = $delegate;
+			}
+
+			public function query_ids( $args = [] ) {
+				++$this->id_queries;
+				return $this->delegate->query_ids( $args );
+			}
+
+			public function query_posts( $args = [] ) {
+				++$this->post_queries;
+				return $this->delegate->query_posts( $args );
+			}
+		};
+		$container  = new class( $repository ) {
+			private $repository;
+
+			public function __construct( $repository ) {
+				$this->repository = $repository;
+			}
+
+			public function get( $service ) {
+				return 'popups' === $service ? $this->repository : null;
+			}
+		};
+		$service    = new PUM_Test_Feature_Announcements( $container );
+
+		$service->has_published_popup();
+		$service->needs_split_testing();
+		$service->has_exit_intent_popup();
+		$service->get_scheduling_stats();
+
+		$this->assertSame( 3, $repository->id_queries );
+		$this->assertSame( 1, $repository->post_queries );
+	}
+}

--- a/tests/php/tests/Repository_Query_Test.php
+++ b/tests/php/tests/Repository_Query_Test.php
@@ -1,0 +1,194 @@
+<?php
+/**
+ * Lightweight repository query tests.
+ *
+ * @package Popup_Maker
+ */
+
+// phpcs:disable Generic.Files.OneObjectStructurePerFile.MultipleFound
+
+/**
+ * Count model instantiation while exercising repository query shapes.
+ */
+class PUM_Test_Popups_Repository extends \PopupMaker\Services\Repository\Popups {
+
+	/**
+	 * Number of instantiated popup models.
+	 *
+	 * @var int
+	 */
+	public $instantiations = 0;
+
+	/**
+	 * Number of post-object queries.
+	 *
+	 * @var int
+	 */
+	public $post_queries = 0;
+
+	/**
+	 * Query popup post objects.
+	 *
+	 * @param array<string,mixed> $args Query arguments.
+	 * @return WP_Post[]
+	 */
+	public function query_posts( $args = [] ) {
+		++$this->post_queries;
+
+		return parent::query_posts( $args );
+	}
+
+	/**
+	 * Instantiate a popup model.
+	 *
+	 * @param WP_Post $post Popup post.
+	 * @return PUM_Model_Popup|null
+	 */
+	public function instantiate_model_from_post( $post ) {
+		++$this->instantiations;
+
+		return parent::instantiate_model_from_post( $post );
+	}
+}
+
+/**
+ * Verify repositories own their lightweight WordPress query boundaries.
+ */
+class Repository_Query_Test extends WP_UnitTestCase {
+
+	/**
+	 * Popup repository fixture.
+	 *
+	 * @var PUM_Test_Popups_Repository
+	 */
+	private $repository;
+
+	/**
+	 * Popup fixture IDs in creation order.
+	 *
+	 * @var int[]
+	 */
+	private $popup_ids = [];
+
+	/**
+	 * Non-popup fixture ID.
+	 *
+	 * @var int
+	 */
+	private $post_id = 0;
+
+	/**
+	 * Set up query fixtures.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->repository = new PUM_Test_Popups_Repository( \PopupMaker\plugin() );
+		$this->popup_ids  = [
+			self::factory()->post->create(
+				[
+					'post_type'   => 'popup',
+					'post_status' => 'publish',
+					'post_title'  => 'First popup',
+					'menu_order'  => 1,
+				]
+			),
+			self::factory()->post->create(
+				[
+					'post_type'   => 'popup',
+					'post_status' => 'publish',
+					'post_title'  => 'Second popup',
+					'menu_order'  => 2,
+				]
+			),
+		];
+		$this->post_id    = self::factory()->post->create( [ 'post_type' => 'post' ] );
+	}
+
+	/**
+	 * Lightweight query shapes enforce repository ownership and avoid models.
+	 */
+	public function test_query_ids_and_posts_enforce_type_shape_order_flags_and_filters() {
+		$observed = [];
+		$inspect  = static function ( $query ) use ( &$observed ) {
+			if ( 'popup' === $query->get( 'post_type' ) ) {
+				$observed[] = [
+					'fields'                 => $query->get( 'fields' ),
+					'no_found_rows'          => $query->get( 'no_found_rows' ),
+					'update_post_meta_cache' => $query->get( 'update_post_meta_cache' ),
+					'update_post_term_cache' => $query->get( 'update_post_term_cache' ),
+				];
+			}
+		};
+		$filter   = static function ( $posts ) {
+			foreach ( $posts as $post ) {
+				if ( $post instanceof WP_Post && 'popup' === $post->post_type ) {
+					$post->post_title = 'Filtered ' . $post->post_title;
+				}
+			}
+
+			return $posts;
+		};
+
+		add_action( 'pre_get_posts', $inspect );
+		add_filter( 'posts_results', $filter );
+
+		try {
+			$ids   = $this->repository->query_ids(
+				[
+					'post_type' => 'post',
+					'post__in'  => array_merge( $this->popup_ids, [ $this->post_id ] ),
+					'orderby'   => 'post__in',
+				]
+			);
+			$posts = $this->repository->query_posts(
+				[
+					'post_type'              => 'post',
+					'orderby'                => 'menu_order',
+					'order'                  => 'DESC',
+					'no_found_rows'          => true,
+					'update_post_meta_cache' => false,
+					'update_post_term_cache' => false,
+				]
+			);
+		} finally {
+			remove_action( 'pre_get_posts', $inspect );
+			remove_filter( 'posts_results', $filter );
+		}
+
+		$this->assertSame( $this->popup_ids, $ids );
+		$this->assertSame( array_reverse( $this->popup_ids ), wp_list_pluck( $posts, 'ID' ) );
+		$this->assertSame( 'Filtered Second popup', $posts[0]->post_title );
+		$this->assertContainsOnlyInstancesOf( WP_Post::class, $posts );
+		$this->assertSame( 0, $this->repository->instantiations );
+		$this->assertSame(
+			[
+				'fields'                 => 'ids',
+				'no_found_rows'          => true,
+				'update_post_meta_cache' => false,
+				'update_post_term_cache' => false,
+			],
+			$observed[0]
+		);
+		$this->assertSame( 'all', $observed[1]['fields'] );
+		$this->assertTrue( $observed[1]['no_found_rows'] );
+		$this->assertFalse( $observed[1]['update_post_meta_cache'] );
+		$this->assertFalse( $observed[1]['update_post_term_cache'] );
+	}
+
+	/**
+	 * The model-returning API reuses the post-object query before hydrating.
+	 */
+	public function test_query_delegates_to_query_posts_before_model_hydration() {
+		$items = $this->repository->query(
+			[
+				'post__in' => $this->popup_ids,
+				'orderby'  => 'post__in',
+			]
+		);
+
+		$this->assertCount( 2, $items );
+		$this->assertSame( 1, $this->repository->post_queries );
+		$this->assertSame( 2, $this->repository->instantiations );
+	}
+}


### PR DESCRIPTION
## Summary

- Loads admin notifications in bounded batches instead of scanning every popup.
- Primes only the records needed for the current notification operation.
- Preserves scheduling and dismissal behavior.
- Includes the Codex-requested scan-bound and bounded-priming regressions.

## Performance

| Path | Before | After |
|---|---:|---:|
| Exit queries | 101 | 6 |
| Exit median runtime | 3.561 ms | 1.012 ms |
| Schedule queries | 4 | 2 |
| Schedule median runtime | 2.619 ms | 1.316 ms |

## Validation

- `composer run tests`: 1,014 tests, 2,335 assertions, 18 skipped
- Focused PHPUnit: 3 tests, 7 assertions
- PHPCS: changed PHP files pass
- PHPStan: no changed-file errors
- PHP syntax and `git diff --check`: pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved exit-intent detection by processing popup metadata more efficiently, helping reduce unnecessary database work.
  * Optimized scheduling statistics queries for faster reporting, especially when many popups are enabled.

* **Reliability**
  * Added automated coverage for exit-intent detection and scheduling statistics to help ensure consistent results across larger popup collections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->