### PR TITLE
Add 50 billion popup views telemetry campaign

### DIFF
--- a/classes/Telemetry.php
+++ b/classes/Telemetry.php
@@ -21,6 +21,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 class PUM_Telemetry {
 
 	/**
+	 * Alert code for the 50 billion popup views campaign.
+	 *
+	 * @var string
+	 */
+	const OPTIN_ALERT_CODE = 'pum_telemetry_50_billion_notice';
+
+	/**
+	 * Alert code used by the original telemetry prompt.
+	 *
+	 * @var string
+	 */
+	const LEGACY_OPTIN_ALERT_CODE = 'pum_telemetry_notice';
+
+	/**
 	 * Initialization method
 	 */
 	public static function init() {
@@ -248,7 +262,7 @@ class PUM_Telemetry {
 	}
 
 	/**
-	 * Adds admin notice if we haven't asked before.
+	 * Adds the telemetry opt-in campaign alert when tracking is disabled.
 	 *
 	 * @param array $alerts The alerts currently in the alert system.
 	 * @return array Alerts for the alert system.
@@ -260,26 +274,27 @@ class PUM_Telemetry {
 		}
 
 		$alerts[] = [
-			'code'        => 'pum_telemetry_notice',
-			'title'       => '📊 ' . __( 'Help us make Popup Maker better', 'popup-maker' ),
-			'type'        => 'info',
-			'category'    => 'recommendation',
-			'message'     => esc_html__( "Help us prioritize the features that matter most by sharing anonymous usage stats. No visitor data or popup content is ever collected.", 'popup-maker' ),
-			'priority'    => 10,
-			'dismissible' => true,
-			'global'      => false,
-			'actions'     => [
+			'code'           => self::OPTIN_ALERT_CODE,
+			'title'          => '🎉 ' . __( 'The countdown to 50 billion popup views is on', 'popup-maker' ),
+			'type'           => 'info',
+			'category'       => 'announcement',
+			'message'        => esc_html__( "We're closing in on an estimated 50 billion popup views! Enable usage tracking to include your site's views in a more accurate estimate, show us which features matter most, and help us build even better ones. The more sites that join in, the sooner we can reach—and celebrate—the milestone together. No visitor data or popup content is collected.", 'popup-maker' ),
+			'priority'       => 10,
+			'dismissible'    => true,
+			'global'         => false,
+			'display_inline' => true,
+			'actions'        => [
 				[
 					'primary' => true,
 					'type'    => 'action',
 					'action'  => 'pum_optin_check_allow',
-					'text'    => __( 'Allow', 'popup-maker' ),
+					'text'    => __( 'Count my popup views', 'popup-maker' ),
 				],
 				[
 					'primary' => false,
 					'type'    => 'action',
 					'action'  => 'dismiss',
-					'text'    => __( 'Do not allow', 'popup-maker' ),
+					'text'    => __( 'Not now', 'popup-maker' ),
 				],
 				[
 					'primary' => false,
@@ -302,21 +317,21 @@ class PUM_Telemetry {
 	 * @since 1.11.0
 	 */
 	public static function optin_alert_check( $code, $action ) {
-		if ( 'pum_telemetry_notice' === $code ) {
-			if ( 'pum_optin_check_allow' === $action ) {
-				// The alert dismiss handler only requires edit_posts; enabling
-				// telemetry is a settings-level decision.
-				if ( ! current_user_can( \PopupMaker\plugin()->get_permission( 'manage_settings' ) ) ) {
-					return;
-				}
-
-				pum_update_option( 'telemetry', true );
-			}
+		if ( ! in_array( $code, [ self::OPTIN_ALERT_CODE, self::LEGACY_OPTIN_ALERT_CODE ], true ) || 'pum_optin_check_allow' !== $action ) {
+			return;
 		}
+
+		// The alert dismiss handler only requires edit_posts; enabling
+		// telemetry is a settings-level decision.
+		if ( ! current_user_can( \PopupMaker\plugin()->get_permission( 'manage_settings' ) ) ) {
+			return;
+		}
+
+		pum_update_option( 'telemetry', true );
 	}
 
 	/**
-	 * Whether or not we should show optin alert
+	 * Whether or not we should show the opt-in alert.
 	 *
 	 * @since 1.11.0
 	 * @return bool True if alert should be shown

--- a/classes/Telemetry.php
+++ b/classes/Telemetry.php
@@ -274,16 +274,15 @@ class PUM_Telemetry {
 		}
 
 		$alerts[] = [
-			'code'           => self::OPTIN_ALERT_CODE,
-			'title'          => '🎉 ' . __( 'The countdown to 50 billion popup views is on', 'popup-maker' ),
-			'type'           => 'info',
-			'category'       => 'announcement',
-			'message'        => esc_html__( "We're closing in on an estimated 50 billion popup views! Enable usage tracking to include your site's views in a more accurate estimate, show us which features matter most, and help us build even better ones. The more sites that join in, the sooner we can reach—and celebrate—the milestone together. No visitor data or popup content is collected.", 'popup-maker' ),
-			'priority'       => 10,
-			'dismissible'    => true,
-			'global'         => false,
-			'display_inline' => true,
-			'actions'        => [
+			'code'        => self::OPTIN_ALERT_CODE,
+			'title'       => '🎉 ' . __( 'The countdown to 50 billion popup views is on', 'popup-maker' ),
+			'type'        => 'info',
+			'category'    => 'announcement',
+			'message'     => esc_html__( "We're closing in on an estimated 50 billion popup views! Enable usage tracking to include your site's views in a more accurate estimate, show us which features matter most, and help us build even better ones. The more sites that join in, the sooner we can reach—and celebrate—the milestone together. No visitor data or popup content is collected.", 'popup-maker' ),
+			'priority'    => 10,
+			'dismissible' => true,
+			'global'      => false,
+			'actions'     => [
 				[
 					'primary' => true,
 					'type'    => 'action',
@@ -321,8 +320,8 @@ class PUM_Telemetry {
 			return;
 		}
 
-		// The alert dismiss handler only requires edit_posts; enabling
-		// telemetry is a settings-level decision.
+		// The alert dismiss handler only requires edit_posts.
+		// Enabling telemetry is a settings-level decision.
 		if ( ! current_user_can( \PopupMaker\plugin()->get_permission( 'manage_settings' ) ) ) {
 			return;
 		}

--- a/tests/php/tests/PUM_Telemetry_Test.php
+++ b/tests/php/tests/PUM_Telemetry_Test.php
@@ -43,6 +43,7 @@ class PUM_Telemetry_Test extends WP_UnitTestCase {
 		wp_set_current_user( self::$admin_id );
 		update_option( 'pum_installed_on', '2020-01-01 00:00:00' );
 		pum_delete_option( 'telemetry' );
+		delete_user_meta( self::$admin_id, '_pum_dismissed_alerts' );
 	}
 
 	/**
@@ -50,11 +51,12 @@ class PUM_Telemetry_Test extends WP_UnitTestCase {
 	 */
 	public function tearDown(): void {
 		pum_delete_option( 'telemetry' );
+		delete_user_meta( self::$admin_id, '_pum_dismissed_alerts' );
 		parent::tearDown();
 	}
 
 	/**
-	 * The campaign explains the milestone and appears on both notice surfaces.
+	 * The campaign explains the milestone and appears only in the panel.
 	 */
 	public function test_campaign_explains_the_milestone_and_benefits() {
 		$alerts = PUM_Telemetry::optin_alert( [] );
@@ -66,9 +68,9 @@ class PUM_Telemetry_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'more accurate estimate', $alert['message'] );
 		$this->assertStringContainsString( 'build even better ones', $alert['message'] );
 		$this->assertSame( 'Count my popup views', $alert['actions'][0]['text'] );
-		$this->assertTrue( $alert['display_inline'] );
+		$this->assertArrayNotHasKey( 'display_inline', $alert );
 		$this->assertTrue( PUM_Utils_Alerts::is_panel_eligible( $alert ) );
-		$this->assertTrue( PUM_Utils_Alerts::is_inline_eligible( $alert ) );
+		$this->assertFalse( PUM_Utils_Alerts::is_inline_eligible( $alert ) );
 	}
 
 	/**
@@ -92,6 +94,26 @@ class PUM_Telemetry_Test extends WP_UnitTestCase {
 		PUM_Telemetry::optin_alert_check( PUM_Telemetry::OPTIN_ALERT_CODE, 'pum_optin_check_allow' );
 
 		$this->assertTrue( PUM_Telemetry::has_opted_in() );
+		$this->assertSame( [], PUM_Telemetry::optin_alert( [] ) );
+	}
+
+	/**
+	 * Dismissing the campaign prevents it from nagging the same user again.
+	 */
+	public function test_campaign_dismissal_is_permanent_for_current_user() {
+		$this->assertTrue( PUM_Utils_Alerts::action_handler( PUM_Telemetry::OPTIN_ALERT_CODE, 'dismiss', '' ) );
+		$this->assertTrue( PUM_Utils_Alerts::has_dismissed_alert( PUM_Telemetry::OPTIN_ALERT_CODE ) );
+	}
+
+	/**
+	 * Dismissing the original prompt does not hide the new campaign.
+	 */
+	public function test_legacy_prompt_dismissal_does_not_hide_campaign() {
+		$this->assertTrue( PUM_Utils_Alerts::action_handler( PUM_Telemetry::LEGACY_OPTIN_ALERT_CODE, 'dismiss', '' ) );
+
+		$this->assertTrue( PUM_Utils_Alerts::has_dismissed_alert( PUM_Telemetry::LEGACY_OPTIN_ALERT_CODE ) );
+		$this->assertFalse( PUM_Utils_Alerts::has_dismissed_alert( PUM_Telemetry::OPTIN_ALERT_CODE ) );
+		$this->assertCount( 1, PUM_Telemetry::optin_alert( [] ) );
 	}
 
 	/**

--- a/tests/php/tests/PUM_Telemetry_Test.php
+++ b/tests/php/tests/PUM_Telemetry_Test.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Tests for Popup Maker telemetry notices.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Verify telemetry campaign targeting and opt-in behavior.
+ */
+class PUM_Telemetry_Test extends WP_UnitTestCase {
+
+	/**
+	 * Administrator user ID.
+	 *
+	 * @var int
+	 */
+	private static $admin_id;
+
+	/**
+	 * Editor user ID.
+	 *
+	 * @var int
+	 */
+	private static $editor_id;
+
+	/**
+	 * Create shared user fixtures.
+	 *
+	 * @param WP_UnitTest_Factory $factory Factory instance.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		self::$admin_id  = $factory->user->create( [ 'role' => 'administrator' ] );
+		self::$editor_id = $factory->user->create( [ 'role' => 'editor' ] );
+	}
+
+	/**
+	 * Prepare an eligible telemetry prompt for each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		wp_set_current_user( self::$admin_id );
+		update_option( 'pum_installed_on', '2020-01-01 00:00:00' );
+		pum_delete_option( 'telemetry' );
+	}
+
+	/**
+	 * Remove telemetry state after each test.
+	 */
+	public function tearDown(): void {
+		pum_delete_option( 'telemetry' );
+		parent::tearDown();
+	}
+
+	/**
+	 * The campaign explains the milestone and appears on both notice surfaces.
+	 */
+	public function test_campaign_explains_the_milestone_and_benefits() {
+		$alerts = PUM_Telemetry::optin_alert( [] );
+		$alert  = $alerts[0];
+
+		$this->assertCount( 1, $alerts );
+		$this->assertSame( PUM_Telemetry::OPTIN_ALERT_CODE, $alert['code'] );
+		$this->assertStringContainsString( '50 billion popup views', $alert['title'] );
+		$this->assertStringContainsString( 'more accurate estimate', $alert['message'] );
+		$this->assertStringContainsString( 'build even better ones', $alert['message'] );
+		$this->assertSame( 'Count my popup views', $alert['actions'][0]['text'] );
+		$this->assertTrue( $alert['display_inline'] );
+		$this->assertTrue( PUM_Utils_Alerts::is_panel_eligible( $alert ) );
+		$this->assertTrue( PUM_Utils_Alerts::is_inline_eligible( $alert ) );
+	}
+
+	/**
+	 * The campaign is limited to administrators who have not enabled telemetry.
+	 */
+	public function test_campaign_targets_admins_with_telemetry_disabled() {
+		$this->assertCount( 1, PUM_Telemetry::optin_alert( [] ) );
+
+		pum_update_option( 'telemetry', true );
+		$this->assertSame( [], PUM_Telemetry::optin_alert( [] ) );
+
+		pum_delete_option( 'telemetry' );
+		wp_set_current_user( self::$editor_id );
+		$this->assertSame( [], PUM_Telemetry::optin_alert( [] ) );
+	}
+
+	/**
+	 * The campaign action enables telemetry for an authorized administrator.
+	 */
+	public function test_campaign_action_enables_telemetry() {
+		PUM_Telemetry::optin_alert_check( PUM_Telemetry::OPTIN_ALERT_CODE, 'pum_optin_check_allow' );
+
+		$this->assertTrue( PUM_Telemetry::has_opted_in() );
+	}
+
+	/**
+	 * Stale links from the original prompt continue to enable telemetry.
+	 */
+	public function test_legacy_prompt_action_remains_compatible() {
+		PUM_Telemetry::optin_alert_check( PUM_Telemetry::LEGACY_OPTIN_ALERT_CODE, 'pum_optin_check_allow' );
+
+		$this->assertTrue( PUM_Telemetry::has_opted_in() );
+	}
+
+	/**
+	 * Users without settings access cannot enable telemetry through the action.
+	 */
+	public function test_campaign_action_requires_settings_permission() {
+		wp_set_current_user( self::$editor_id );
+
+		PUM_Telemetry::optin_alert_check( PUM_Telemetry::OPTIN_ALERT_CODE, 'pum_optin_check_allow' );
+
+		$this->assertFalse( PUM_Telemetry::has_opted_in() );
+	}
+}


### PR DESCRIPTION
## Summary

- refresh the telemetry opt-in notice with a celebratory 50 billion popup views campaign
- explain that usage tracking improves the view estimate and helps prioritize better features while keeping the privacy boundary clear
- give the campaign a new dismissal code so eligible admins can see it once across both the inline notice and notifications panel
- preserve compatibility with the original opt-in action and retain the settings-level capability check
- add focused coverage for targeting, messaging, notice surfaces, authorization, and legacy compatibility

## Why

Popup Maker's estimated total relies on the popup view count shared by sites that explicitly enable usage tracking. Admins with tracking disabled currently receive a generic opt-in prompt that does not explain how their participation improves the estimate or product decisions. This campaign connects that choice to the upcoming 50 billion view milestone without collecting visitor data or popup content.

## User impact

Administrators with usage tracking disabled will see a dismissible campaign on Popup Maker screens after the existing install-age delay. It appears inline and in the notifications panel with shared dismissal state. Sites that already enabled tracking and non-administrator users are unaffected.

## Validation

- `composer run tests` — 906 tests passed, 1,965 assertions, 2 existing skips
- targeted PHPCS for both changed PHP files — passed
- `git diff --check` — passed
- `composer run phpstan` — reports the repository's existing 40 baseline findings; no finding is on a changed line

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced an updated telemetry campaign message highlighting the 50-billion popup views milestone and benefits.
  * Campaign notices now appear inline and target administrators who have not enabled telemetry.
  * Enabling telemetry from the campaign requires the appropriate settings permission.

* **Bug Fixes**
  * Preserved compatibility with existing telemetry prompt actions and dismissal behavior.
  * Campaign dismissals remain effective for the current administrator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->