### PR TITLE
[codex] Fix batched analytics REST validation

### DIFF
--- a/classes/Analytics.php
+++ b/classes/Analytics.php
@@ -220,7 +220,7 @@ class PUM_Analytics {
 		$args = $request->get_params();
 
 		if ( $request->has_param( 'events' ) ) {
-			$events = self::parse_batch_events( $request, $args );
+			$events = self::parse_batch_events( $args );
 
 			if ( is_wp_error( $events ) ) {
 				return $events;
@@ -259,35 +259,46 @@ class PUM_Analytics {
 	 * Accepts an `events` parameter that is either a JSON-encoded array
 	 * (sendBeacon FormData can only carry strings) or an already-decoded array.
 	 *
-	 * @param WP_REST_Request $request Request.
-	 * @param array           $args    Parsed params.
+	 * @param array $args Parsed params.
 	 * @return array<int,array>|WP_Error Array of event payloads or an error.
 	 */
-	protected static function parse_batch_events( WP_REST_Request $request, $args ) {
-		$events = isset( $args['events'] ) ? $args['events'] : $request->get_param( 'events' );
+	protected static function parse_batch_events( $args ) {
+		$error  = new WP_Error( 'invalid_events', __( 'Invalid analytics events payload.', 'popup-maker' ), [ 'status' => 400 ] );
+		$events = isset( $args['events'] ) ? $args['events'] : null;
 
 		if ( is_string( $events ) ) {
 			$decoded = json_decode( $events, true );
 
 			if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) ) {
-				return new WP_Error( 'invalid_events', __( 'Invalid analytics events payload.', 'popup-maker' ), [ 'status' => 400 ] );
+				return $error;
 			}
 
 			$events = $decoded;
 		}
 
 		if ( ! is_array( $events ) || empty( $events ) ) {
-			return new WP_Error( 'invalid_events', __( 'Invalid analytics events payload.', 'popup-maker' ), [ 'status' => 400 ] );
+			return $error;
 		}
 
 		// Require a list of event objects, not an associative single event.
 		if ( array_values( $events ) !== $events ) {
-			return new WP_Error( 'invalid_events', __( 'Invalid analytics events payload.', 'popup-maker' ), [ 'status' => 400 ] );
+			return $error;
+		}
+
+		/**
+		 * Filters the maximum number of events accepted in one REST request.
+		 *
+		 * @param int $limit Maximum number of events.
+		 */
+		$batch_limit = max( 1, absint( apply_filters( 'pum_analytics_rest_batch_limit', 100 ) ) );
+
+		if ( count( $events ) > $batch_limit ) {
+			return $error;
 		}
 
 		foreach ( $events as $event ) {
 			if ( ! is_array( $event ) ) {
-				return new WP_Error( 'invalid_events', __( 'Invalid analytics events payload.', 'popup-maker' ), [ 'status' => 400 ] );
+				return $error;
 			}
 		}
 
@@ -305,7 +316,7 @@ class PUM_Analytics {
 			return new WP_Error( 'missing_params', __( 'Missing Parameters.', 'default' ), [ 'status' => 400 ] );
 		}
 
-		if ( ! is_string( $args['event'] ) || ! is_numeric( $args['pid'] ) ) {
+		if ( ! is_string( $args['event'] ) || ! self::endpoint_absint( $args['pid'] ) ) {
 			return new WP_Error( 'invalid_params', __( 'Invalid analytics event parameters.', 'popup-maker' ), [ 'status' => 400 ] );
 		}
 
@@ -335,7 +346,13 @@ class PUM_Analytics {
 	 * @return bool
 	 */
 	public static function endpoint_absint( $param ) {
-		return is_numeric( $param );
+		if ( ! is_numeric( $param ) ) {
+			return false;
+		}
+
+		$integer = absint( $param );
+
+		return 0 < $integer && (float) $integer === (float) $param;
 	}
 
 	/**
@@ -382,11 +399,11 @@ class PUM_Analytics {
 							'type'        => 'string',
 						],
 						'pid'       => [
-							'required'            => false,
-							'description'         => __( 'Popup ID', 'popup-maker' ),
-							'type'                => 'integer',
-							'validation_callback' => [ __CLASS__, 'endpoint_absint' ],
-							'sanitize_callback'   => 'absint',
+							'required'          => false,
+							'description'       => __( 'Popup ID', 'popup-maker' ),
+							'type'              => 'integer',
+							'validate_callback' => [ __CLASS__, 'endpoint_absint' ],
+							'sanitize_callback' => 'absint',
 						],
 						'events'    => [
 							'required'    => false,

--- a/classes/Analytics.php
+++ b/classes/Analytics.php
@@ -219,33 +219,38 @@ class PUM_Analytics {
 	public static function analytics_endpoint( WP_REST_Request $request ) {
 		$args = $request->get_params();
 
-		// Batch beacon: the client may send multiple events in one request as
-		// an `events` array (debounced/flush-on-exit batching). Each entry is a
-		// full event payload; process them through the same single-event path.
-		// Back-compatible — a single-event POST (top-level pid/event) still works.
-		$batch = self::parse_batch_events( $request, $args );
+		if ( $request->has_param( 'events' ) ) {
+			$events = self::parse_batch_events( $request, $args );
 
-		if ( null !== $batch ) {
-			foreach ( $batch as $event_args ) {
-				if ( is_array( $event_args ) && ! empty( $event_args['pid'] ) ) {
-					self::track( $event_args );
-				}
+			if ( is_wp_error( $events ) ) {
+				return $events;
+			}
+		} else {
+			$events = [ $args ];
+		}
+
+		$validated_events = [];
+
+		// Validate the complete payload before tracking to prevent partial batches.
+		foreach ( $events as $event_args ) {
+			$validated_event = self::validate_event( $event_args );
+
+			if ( is_wp_error( $validated_event ) ) {
+				return $validated_event;
 			}
 
+			$validated_events[] = $validated_event;
+		}
+
+		foreach ( $validated_events as $event_args ) {
+			self::track( $event_args );
+		}
+
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
 			self::serve_no_content();
-
-			return true;
 		}
 
-		if ( ! $args || empty( $args['pid'] ) ) {
-			return new WP_Error( 'missing_params', __( 'Missing Parameters.', 'default' ), [ 'status' => 404 ] );
-		}
-
-		self::track( $args );
-
-		self::serve_no_content();
-
-		return true;
+		return new WP_REST_Response( null, 204 );
 	}
 
 	/**
@@ -256,31 +261,72 @@ class PUM_Analytics {
 	 *
 	 * @param WP_REST_Request $request Request.
 	 * @param array           $args    Parsed params.
-	 * @return array<int,array>|null Array of event payloads, or null when not a batch.
+	 * @return array<int,array>|WP_Error Array of event payloads or an error.
 	 */
 	protected static function parse_batch_events( WP_REST_Request $request, $args ) {
 		$events = isset( $args['events'] ) ? $args['events'] : $request->get_param( 'events' );
 
-		if ( empty( $events ) ) {
-			return null;
-		}
-
 		if ( is_string( $events ) ) {
 			$decoded = json_decode( $events, true );
-			$events  = is_array( $decoded ) ? $decoded : null;
+
+			if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) ) {
+				return new WP_Error( 'invalid_events', __( 'Invalid analytics events payload.', 'popup-maker' ), [ 'status' => 400 ] );
+			}
+
+			$events = $decoded;
 		}
 
 		if ( ! is_array( $events ) || empty( $events ) ) {
-			return null;
+			return new WP_Error( 'invalid_events', __( 'Invalid analytics events payload.', 'popup-maker' ), [ 'status' => 400 ] );
 		}
 
-		// Must be a list of event objects, not an associative single event.
-		$first = reset( $events );
-		if ( ! is_array( $first ) ) {
-			return null;
+		// Require a list of event objects, not an associative single event.
+		if ( array_values( $events ) !== $events ) {
+			return new WP_Error( 'invalid_events', __( 'Invalid analytics events payload.', 'popup-maker' ), [ 'status' => 400 ] );
 		}
 
-		return array_values( $events );
+		foreach ( $events as $event ) {
+			if ( ! is_array( $event ) ) {
+				return new WP_Error( 'invalid_events', __( 'Invalid analytics events payload.', 'popup-maker' ), [ 'status' => 400 ] );
+			}
+		}
+
+		return $events;
+	}
+
+	/**
+	 * Validate and normalize one analytics event before tracking.
+	 *
+	 * @param mixed $args Event arguments.
+	 * @return array|WP_Error Normalized event arguments or an error.
+	 */
+	protected static function validate_event( $args ) {
+		if ( ! is_array( $args ) || empty( $args['event'] ) || empty( $args['pid'] ) ) {
+			return new WP_Error( 'missing_params', __( 'Missing Parameters.', 'default' ), [ 'status' => 400 ] );
+		}
+
+		if ( ! is_string( $args['event'] ) || ! is_numeric( $args['pid'] ) ) {
+			return new WP_Error( 'invalid_params', __( 'Invalid analytics event parameters.', 'popup-maker' ), [ 'status' => 400 ] );
+		}
+
+		$args['event'] = sanitize_text_field( $args['event'] );
+		$args['pid']   = absint( $args['pid'] );
+
+		if ( empty( $args['pid'] ) || ! in_array( $args['event'], self::valid_events(), true ) ) {
+			return new WP_Error( 'invalid_params', __( 'Invalid analytics event parameters.', 'popup-maker' ), [ 'status' => 400 ] );
+		}
+
+		$popup = pum_get_popup( $args['pid'] );
+
+		if ( ! pum_is_popup( $popup ) ) {
+			return new WP_Error( 'invalid_params', __( 'Invalid analytics event parameters.', 'popup-maker' ), [ 'status' => 400 ] );
+		}
+
+		if ( array_key_exists( 'eventData', $args ) ) {
+			$args['eventData'] = self::sanitize_event_data( $args['eventData'] );
+		}
+
+		return $args;
 	}
 
 	/**
@@ -331,16 +377,20 @@ class PUM_Analytics {
 					'permission_callback' => '__return_true',
 					'args'                => [
 						'event'     => [
-							'required'    => true,
+							'required'    => false,
 							'description' => __( 'Event Type', 'popup-maker' ),
 							'type'        => 'string',
 						],
 						'pid'       => [
-							'required'            => true,
+							'required'            => false,
 							'description'         => __( 'Popup ID', 'popup-maker' ),
 							'type'                => 'integer',
 							'validation_callback' => [ __CLASS__, 'endpoint_absint' ],
 							'sanitize_callback'   => 'absint',
+						],
+						'events'    => [
+							'required'    => false,
+							'description' => __( 'Analytics events (JSON or array)', 'popup-maker' ),
 						],
 						'eventData' => [
 							'required'          => false,

--- a/classes/Analytics.php
+++ b/classes/Analytics.php
@@ -267,13 +267,13 @@ class PUM_Analytics {
 		$events = isset( $args['events'] ) ? $args['events'] : null;
 
 		if ( is_string( $events ) ) {
-			$decoded = json_decode( $events, true );
+			$decoded = json_decode( $events );
 
 			if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) ) {
 				return $error;
 			}
 
-			$events = $decoded;
+			$events = json_decode( $events, true );
 		}
 
 		if ( ! is_array( $events ) || empty( $events ) ) {

--- a/tests/php/tests/PUM_Analytics_Expanded_Test.php
+++ b/tests/php/tests/PUM_Analytics_Expanded_Test.php
@@ -188,7 +188,10 @@ class PUM_Analytics_Expanded_Test extends WP_UnitTestCase {
 	 * Test sanitize_event_data with array input.
 	 */
 	public function test_sanitize_event_data_array_passthrough() {
-		$data   = [ 'type' => 'form_submission', 'formId' => '123' ];
+		$data   = [
+			'type'   => 'form_submission',
+			'formId' => '123',
+		];
 		$result = PUM_Analytics::sanitize_event_data( $data );
 
 		$this->assertEquals( $data, $result, 'Array input should pass through unchanged.' );
@@ -365,9 +368,24 @@ class PUM_Analytics_Expanded_Test extends WP_UnitTestCase {
 		}
 		$popup->reset_counts();
 
-		PUM_Analytics::track( [ 'pid' => $this->popup_id, 'event' => 'open' ] );
-		PUM_Analytics::track( [ 'pid' => $this->popup_id, 'event' => 'open' ] );
-		PUM_Analytics::track( [ 'pid' => $this->popup_id, 'event' => 'open' ] );
+		PUM_Analytics::track(
+			[
+				'pid'   => $this->popup_id,
+				'event' => 'open',
+			]
+		);
+		PUM_Analytics::track(
+			[
+				'pid'   => $this->popup_id,
+				'event' => 'open',
+			]
+		);
+		PUM_Analytics::track(
+			[
+				'pid'   => $this->popup_id,
+				'event' => 'open',
+			]
+		);
 
 		$count = (int) get_post_meta( $this->popup_id, 'popup_open_count', true );
 		$this->assertEquals( 3, $count, 'Open count should be 3 after three tracks.' );
@@ -450,15 +468,15 @@ class PUM_Analytics_Expanded_Test extends WP_UnitTestCase {
 	 * Test endpoint_absint with float values.
 	 */
 	public function test_endpoint_absint_with_float() {
-		$this->assertTrue( PUM_Analytics::endpoint_absint( '3.14' ), 'Float string should pass is_numeric check.' );
-		$this->assertTrue( PUM_Analytics::endpoint_absint( 3.14 ), 'Float should pass is_numeric check.' );
+		$this->assertFalse( PUM_Analytics::endpoint_absint( '3.14' ), 'Float string should fail.' );
+		$this->assertFalse( PUM_Analytics::endpoint_absint( 3.14 ), 'Float should fail.' );
 	}
 
 	/**
 	 * Test endpoint_absint with negative numbers.
 	 */
 	public function test_endpoint_absint_with_negative() {
-		$this->assertTrue( PUM_Analytics::endpoint_absint( '-5' ), 'Negative numeric string should pass is_numeric.' );
+		$this->assertFalse( PUM_Analytics::endpoint_absint( '-5' ), 'Negative numeric string should fail.' );
 	}
 
 	/**

--- a/tests/php/tests/PUM_Analytics_REST_Test.php
+++ b/tests/php/tests/PUM_Analytics_REST_Test.php
@@ -194,6 +194,7 @@ class PUM_Analytics_REST_Test extends WP_UnitTestCase {
 			'empty array'               => [ [] ],
 			'empty string'              => [ '' ],
 			'JSON object'               => [ '{"event":"open","pid":1}' ],
+			'numeric-keyed JSON object' => [ '{"0":{"event":"open","pid":1}}' ],
 			'JSON scalar'               => [ '42' ],
 			'decoded associative array' => [
 				[

--- a/tests/php/tests/PUM_Analytics_REST_Test.php
+++ b/tests/php/tests/PUM_Analytics_REST_Test.php
@@ -170,13 +170,13 @@ class PUM_Analytics_REST_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Empty batches are rejected without tracking.
+	 * Empty and non-list batches are rejected without tracking.
 	 *
-	 * @dataProvider empty_batch_provider
+	 * @dataProvider invalid_batch_payload_provider
 	 *
 	 * @param mixed $events Events value.
 	 */
-	public function test_empty_batch_returns_400_without_tracking( $events ) {
+	public function test_invalid_batch_payload_returns_400_without_tracking( $events ) {
 		$response = $this->dispatch_form_request( [ 'events' => $events ] );
 
 		$this->assert_error_response( $response, 'invalid_events' );
@@ -184,15 +184,23 @@ class PUM_Analytics_REST_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Supply empty batch encodings.
+	 * Supply empty and non-list batch encodings.
 	 *
 	 * @return array<string,array<int,mixed>>
 	 */
-	public function empty_batch_provider() {
+	public function invalid_batch_payload_provider() {
 		return [
-			'empty JSON array' => [ '[]' ],
-			'empty array'      => [ [] ],
-			'empty string'     => [ '' ],
+			'empty JSON array'          => [ '[]' ],
+			'empty array'               => [ [] ],
+			'empty string'              => [ '' ],
+			'JSON object'               => [ '{"event":"open","pid":1}' ],
+			'JSON scalar'               => [ '42' ],
+			'decoded associative array' => [
+				[
+					'event' => 'open',
+					'pid'   => 1,
+				],
+			],
 		];
 	}
 
@@ -242,6 +250,21 @@ class PUM_Analytics_REST_Test extends WP_UnitTestCase {
 
 		$this->assert_error_response( $invalid_event, 'invalid_params' );
 		$this->assert_error_response( $invalid_popup, 'invalid_params' );
+		$this->assert_event_counts( 0, 0 );
+	}
+
+	/**
+	 * Flat popup IDs are validated before the route sanitizes them.
+	 */
+	public function test_flat_negative_popup_id_fails_route_validation_without_tracking() {
+		$response = $this->dispatch_form_request(
+			[
+				'event' => 'open',
+				'pid'   => -$this->popup_id,
+			]
+		);
+
+		$this->assert_error_response( $response, 'rest_invalid_param' );
 		$this->assert_event_counts( 0, 0 );
 	}
 
@@ -299,6 +322,76 @@ class PUM_Analytics_REST_Test extends WP_UnitTestCase {
 			'invalid event' => [ 'event' ],
 			'invalid popup' => [ 'popup' ],
 		];
+	}
+
+	/**
+	 * Batch popup IDs must be positive integers before normalization.
+	 */
+	public function test_batch_rejects_popup_ids_that_would_normalize_to_valid_popup() {
+		$hook_count = 0;
+		$hook       = function () use ( &$hook_count ) {
+			++$hook_count;
+		};
+
+		add_action( 'pum_analytics_event', $hook );
+
+		foreach ( [ -$this->popup_id, $this->popup_id + 0.5 ] as $invalid_pid ) {
+			$response = $this->dispatch_json_request(
+				[
+					'events' => [
+						[
+							'event' => 'open',
+							'pid'   => $invalid_pid,
+						],
+					],
+				]
+			);
+
+			$this->assert_error_response( $response, 'invalid_params' );
+		}
+
+		remove_action( 'pum_analytics_event', $hook );
+
+		$this->assert_event_counts( 0, 0 );
+		$this->assertSame( 0, $hook_count );
+	}
+
+	/**
+	 * Oversized batches are rejected atomically before tracking.
+	 */
+	public function test_batch_limit_rejects_complete_payload_without_tracking() {
+		$hook_count   = 0;
+		$hook         = function () use ( &$hook_count ) {
+			++$hook_count;
+		};
+		$limit_filter = function () {
+			return 1;
+		};
+
+		add_action( 'pum_analytics_event', $hook );
+		add_filter( 'pum_analytics_rest_batch_limit', $limit_filter );
+
+		$response = $this->dispatch_json_request(
+			[
+				'events' => [
+					[
+						'event' => 'open',
+						'pid'   => $this->popup_id,
+					],
+					[
+						'event' => 'conversion',
+						'pid'   => $this->popup_id,
+					],
+				],
+			]
+		);
+
+		remove_filter( 'pum_analytics_rest_batch_limit', $limit_filter );
+		remove_action( 'pum_analytics_event', $hook );
+
+		$this->assert_error_response( $response, 'invalid_events' );
+		$this->assert_event_counts( 0, 0 );
+		$this->assertSame( 0, $hook_count );
 	}
 
 	/**

--- a/tests/php/tests/PUM_Analytics_REST_Test.php
+++ b/tests/php/tests/PUM_Analytics_REST_Test.php
@@ -1,0 +1,498 @@
+<?php
+/**
+ * Analytics REST endpoint tests.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Test analytics requests through WordPress REST validation and dispatch.
+ */
+class PUM_Analytics_REST_Test extends WP_UnitTestCase {
+
+	/**
+	 * Popup ID for test events.
+	 *
+	 * @var int
+	 */
+	private $popup_id;
+
+	/**
+	 * Original remote address.
+	 *
+	 * @var string|null
+	 */
+	private $remote_addr;
+
+	/**
+	 * Set up the REST server and popup fixture.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		$this->remote_addr      = isset( $_SERVER['REMOTE_ADDR'] ) ? sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) : null;
+		$_SERVER['REMOTE_ADDR'] = '192.0.2.10';
+		$this->popup_id         = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Analytics REST Test Popup',
+			]
+		);
+
+		$this->reset_rest_server();
+	}
+
+	/**
+	 * Reset globals changed by the test.
+	 */
+	public function tearDown(): void {
+		global $wp_rest_server;
+
+		$wp_rest_server = null;
+
+		if ( null === $this->remote_addr ) {
+			unset( $_SERVER['REMOTE_ADDR'] );
+		} else {
+			$_SERVER['REMOTE_ADDR'] = $this->remote_addr;
+		}
+
+		PUM_Utils_Options::delete( 'bypass_adblockers' );
+		PUM_Utils_Options::delete( 'adblock_bypass_url_method' );
+		PUM_Utils_Options::delete( 'adblock_bypass_custom_filename' );
+
+		parent::tearDown();
+	}
+
+	/**
+	 * A flat event passes route validation and tracks once.
+	 */
+	public function test_flat_single_event_returns_204_and_tracks_once() {
+		$event_args     = [];
+		$specific_hooks = 0;
+		$generic_hook   = function ( $args ) use ( &$event_args ) {
+			$event_args[] = $args;
+		};
+		$open_hook      = function () use ( &$specific_hooks ) {
+			++$specific_hooks;
+		};
+
+		add_action( 'pum_analytics_event', $generic_hook );
+		add_action( 'pum_analytics_open', $open_hook, 10, 2 );
+
+		$response = $this->dispatch_form_request(
+			[
+				'event'     => 'open',
+				'pid'       => $this->popup_id,
+				'eventData' => '{"source":"flat"}',
+			]
+		);
+
+		remove_action( 'pum_analytics_event', $generic_hook );
+		remove_action( 'pum_analytics_open', $open_hook, 10 );
+
+		$this->assert_no_content( $response );
+		$this->assert_event_counts( 1, 0 );
+		$this->assertSame( 1, $specific_hooks );
+		$this->assertCount( 1, $event_args );
+		$this->assertSame( [ 'source' => 'flat' ], $event_args[0]['eventData'] );
+	}
+
+	/**
+	 * A FormData-compatible JSON string batch tracks every event once.
+	 */
+	public function test_json_string_batch_returns_204_and_tracks_each_event_once() {
+		$tracked_events = [];
+		$generic_hook   = function ( $args ) use ( &$tracked_events ) {
+			$tracked_events[] = $args;
+		};
+
+		add_action( 'pum_analytics_event', $generic_hook );
+
+		$response = $this->dispatch_form_request(
+			[
+				'events' => wp_json_encode(
+					[
+						[
+							'event' => 'open',
+							'pid'   => $this->popup_id,
+						],
+						[
+							'event'     => 'conversion',
+							'pid'       => $this->popup_id,
+							'eventData' => '{"type":"form_submission"}',
+						],
+					]
+				),
+			]
+		);
+
+		remove_action( 'pum_analytics_event', $generic_hook );
+
+		$this->assert_no_content( $response );
+		$this->assert_event_counts( 1, 1 );
+		$this->assertSame( [ 'open', 'conversion' ], wp_list_pluck( $tracked_events, 'event' ) );
+		$this->assertSame( [ 'type' => 'form_submission' ], $tracked_events[1]['eventData'] );
+	}
+
+	/**
+	 * A JSON REST client can send an already-decoded events array.
+	 */
+	public function test_decoded_array_batch_returns_204_and_tracks_each_event_once() {
+		$response = $this->dispatch_json_request(
+			[
+				'events' => [
+					[
+						'event' => 'open',
+						'pid'   => $this->popup_id,
+					],
+					[
+						'event'     => 'conversion',
+						'pid'       => $this->popup_id,
+						'eventData' => [ 'source' => 'json' ],
+					],
+				],
+			]
+		);
+
+		$this->assert_no_content( $response );
+		$this->assert_event_counts( 1, 1 );
+	}
+
+	/**
+	 * Malformed JSON is rejected without tracking.
+	 */
+	public function test_malformed_json_returns_400_without_tracking() {
+		$response = $this->dispatch_form_request( [ 'events' => '[{"event":"open"' ] );
+
+		$this->assert_error_response( $response, 'invalid_events' );
+		$this->assert_event_counts( 0, 0 );
+	}
+
+	/**
+	 * Empty batches are rejected without tracking.
+	 *
+	 * @dataProvider empty_batch_provider
+	 *
+	 * @param mixed $events Events value.
+	 */
+	public function test_empty_batch_returns_400_without_tracking( $events ) {
+		$response = $this->dispatch_form_request( [ 'events' => $events ] );
+
+		$this->assert_error_response( $response, 'invalid_events' );
+		$this->assert_event_counts( 0, 0 );
+	}
+
+	/**
+	 * Supply empty batch encodings.
+	 *
+	 * @return array<string,array<int,mixed>>
+	 */
+	public function empty_batch_provider() {
+		return [
+			'empty JSON array' => [ '[]' ],
+			'empty array'      => [ [] ],
+			'empty string'     => [ '' ],
+		];
+	}
+
+	/**
+	 * Missing flat parameters are rejected by endpoint validation.
+	 *
+	 * @dataProvider missing_params_provider
+	 *
+	 * @param array $params Request parameters.
+	 */
+	public function test_missing_event_or_pid_returns_400_without_tracking( $params ) {
+		$response = $this->dispatch_form_request( $params );
+
+		$this->assert_error_response( $response, 'missing_params' );
+		$this->assert_event_counts( 0, 0 );
+	}
+
+	/**
+	 * Supply incomplete flat payloads.
+	 *
+	 * @return array<string,array<int,array<string,mixed>>>
+	 */
+	public function missing_params_provider() {
+		return [
+			'empty request' => [ [] ],
+			'missing event' => [ [ 'pid' => 1 ] ],
+			'missing pid'   => [ [ 'event' => 'open' ] ],
+		];
+	}
+
+	/**
+	 * Invalid flat event and popup values are rejected without tracking.
+	 */
+	public function test_invalid_flat_event_and_popup_return_400_without_tracking() {
+		$invalid_event = $this->dispatch_form_request(
+			[
+				'event' => 'unknown',
+				'pid'   => $this->popup_id,
+			]
+		);
+		$invalid_popup = $this->dispatch_form_request(
+			[
+				'event' => 'open',
+				'pid'   => 999999,
+			]
+		);
+
+		$this->assert_error_response( $invalid_event, 'invalid_params' );
+		$this->assert_error_response( $invalid_popup, 'invalid_params' );
+		$this->assert_event_counts( 0, 0 );
+	}
+
+	/**
+	 * One invalid batch entry rejects the whole batch before hooks or counters.
+	 *
+	 * @dataProvider invalid_batch_event_provider
+	 *
+	 * @param string $invalid_part Invalid event part.
+	 */
+	public function test_invalid_batch_does_not_partially_track( $invalid_part ) {
+		$hook_count    = 0;
+		$hook          = function () use ( &$hook_count ) {
+			++$hook_count;
+		};
+		$invalid_event = [
+			'event' => 'conversion',
+			'pid'   => $this->popup_id,
+		];
+
+		if ( 'event' === $invalid_part ) {
+			$invalid_event['event'] = 'unknown';
+		} else {
+			$invalid_event['pid'] = 999999;
+		}
+
+		add_action( 'pum_analytics_event', $hook );
+
+		$response = $this->dispatch_json_request(
+			[
+				'events' => [
+					[
+						'event' => 'open',
+						'pid'   => $this->popup_id,
+					],
+					$invalid_event,
+				],
+			]
+		);
+
+		remove_action( 'pum_analytics_event', $hook );
+
+		$this->assert_error_response( $response, 'invalid_params' );
+		$this->assert_event_counts( 0, 0 );
+		$this->assertSame( 0, $hook_count );
+	}
+
+	/**
+	 * Supply invalid entries after a valid event.
+	 *
+	 * @return array<string,array<int,string>>
+	 */
+	public function invalid_batch_event_provider() {
+		return [
+			'invalid event' => [ 'event' ],
+			'invalid popup' => [ 'popup' ],
+		];
+	}
+
+	/**
+	 * Custom events continue to use the public event filter and hooks.
+	 */
+	public function test_batch_preserves_custom_event_filter_and_hooks() {
+		$hook_count   = 0;
+		$event_filter = function ( $events ) {
+			$events[] = 'dismiss';
+			return $events;
+		};
+		$event_hook   = function () use ( &$hook_count ) {
+			++$hook_count;
+		};
+
+		add_filter( 'pum_analytics_valid_events', $event_filter );
+		add_action( 'pum_analytics_dismiss', $event_hook, 10, 2 );
+
+		$response = $this->dispatch_form_request(
+			[
+				'events' => wp_json_encode(
+					[
+						[
+							'event' => 'dismiss',
+							'pid'   => $this->popup_id,
+						],
+					]
+				),
+			]
+		);
+
+		remove_filter( 'pum_analytics_valid_events', $event_filter );
+		remove_action( 'pum_analytics_dismiss', $event_hook, 10 );
+
+		$this->assert_no_content( $response );
+		$this->assertSame( 1, (int) get_post_meta( $this->popup_id, 'popup_dismiss_count', true ) );
+		$this->assertSame( 1, $hook_count );
+	}
+
+	/**
+	 * Every batch entry still passes through the existing rate limiter.
+	 */
+	public function test_batch_preserves_per_event_rate_limiting() {
+		$limits_filter = function () {
+			return [
+				'window' => MINUTE_IN_SECONDS,
+				'max'    => 1,
+			];
+		};
+
+		add_filter( 'popup_maker/analytics/rate_limit', $limits_filter );
+
+		$response = $this->dispatch_json_request(
+			[
+				'events' => [
+					[
+						'event' => 'open',
+						'pid'   => $this->popup_id,
+					],
+					[
+						'event' => 'open',
+						'pid'   => $this->popup_id,
+					],
+				],
+			]
+		);
+
+		remove_filter( 'popup_maker/analytics/rate_limit', $limits_filter );
+
+		$this->assert_no_content( $response );
+		$this->assert_event_counts( 1, 0 );
+	}
+
+	/**
+	 * Filtered route arguments and ad-block-bypass route names remain supported.
+	 */
+	public function test_filtered_custom_route_dispatches_batch() {
+		$route_filter = function ( $route_args ) {
+			$route_args['args']['source'] = [
+				'required' => false,
+				'type'     => 'string',
+			];
+
+			return $route_args;
+		};
+
+		PUM_Utils_Options::update( 'bypass_adblockers', true );
+		PUM_Utils_Options::update( 'adblock_bypass_url_method', 'custom' );
+		PUM_Utils_Options::update( 'adblock_bypass_custom_filename', 'custom-metrics' );
+		add_filter( 'pum_analytics_rest_route_args', $route_filter );
+		$this->reset_rest_server();
+		remove_filter( 'pum_analytics_rest_route_args', $route_filter );
+
+		$routes = rest_get_server()->get_routes();
+		$route  = $this->route();
+
+		$this->assertArrayHasKey( $route, $routes );
+		$this->assertArrayHasKey( 'source', $routes[ $route ][0]['args'] );
+
+		$response = $this->dispatch_form_request(
+			[
+				'events' => wp_json_encode(
+					[
+						[
+							'event' => 'open',
+							'pid'   => $this->popup_id,
+						],
+					]
+				),
+				'source' => 'beacon',
+			]
+		);
+
+		$this->assert_no_content( $response );
+		$this->assert_event_counts( 1, 0 );
+	}
+
+	/**
+	 * Reset and initialize the WordPress REST server.
+	 */
+	private function reset_rest_server() {
+		global $wp_rest_server;
+
+		$wp_rest_server = new WP_REST_Server();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Dispatch URL-encoded form parameters through the REST server.
+	 *
+	 * @param array $params Request parameters.
+	 * @return WP_REST_Response
+	 */
+	private function dispatch_form_request( $params ) {
+		$request = new WP_REST_Request( 'POST', $this->route() );
+		$request->set_body_params( $params );
+
+		return rest_do_request( $request );
+	}
+
+	/**
+	 * Dispatch a JSON body through the REST server.
+	 *
+	 * @param array $params Request parameters.
+	 * @return WP_REST_Response
+	 */
+	private function dispatch_json_request( $params ) {
+		$request = new WP_REST_Request( 'POST', $this->route() );
+		$request->set_header( 'content-type', 'application/json' );
+		$request->set_body( wp_json_encode( $params ) );
+
+		return rest_do_request( $request );
+	}
+
+	/**
+	 * Get the current analytics route path.
+	 *
+	 * @return string
+	 */
+	private function route() {
+		return '/' . PUM_Analytics::get_analytics_namespace() . '/' . PUM_Analytics::get_analytics_route();
+	}
+
+	/**
+	 * Assert a successful no-content REST response.
+	 *
+	 * @param WP_REST_Response $response REST response.
+	 */
+	private function assert_no_content( $response ) {
+		$this->assertSame( 204, $response->get_status() );
+		$this->assertNull( $response->get_data() );
+	}
+
+	/**
+	 * Assert an error REST response.
+	 *
+	 * @param WP_REST_Response $response REST response.
+	 * @param string           $code     Expected error code.
+	 */
+	private function assert_error_response( $response, $code ) {
+		$data = $response->get_data();
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( $code, $data['code'] );
+	}
+
+	/**
+	 * Assert the popup's core analytics counters.
+	 *
+	 * @param int $opens       Expected open count.
+	 * @param int $conversions Expected conversion count.
+	 */
+	private function assert_event_counts( $opens, $conversions ) {
+		$this->assertSame( $opens, (int) get_post_meta( $this->popup_id, 'popup_open_count', true ) );
+		$this->assertSame( $conversions, (int) get_post_meta( $this->popup_id, 'popup_conversion_count', true ) );
+	}
+}


### PR DESCRIPTION
## Summary

Fix batched frontend analytics beacons being rejected by WordPress REST validation before the analytics callback can unpack them.

- Allow the route to accept either the existing flat `event`/`pid` shape or an `events` batch.
- Accept `events` as the JSON string emitted by `sendBeacon`/`FormData` or as an already-decoded JSON array.
- Validate and normalize the complete payload before tracking so malformed or invalid batches return HTTP 400 without partial counter or hook side effects.
- Keep every accepted event on the existing `PUM_Analytics::track()` path, including custom event filters, event-specific/generic hooks, rate limiting, and `eventData` handling.
- Preserve the endpoint's immediate empty HTTP 204 path for real REST requests while returning a testable 204 response for internal `rest_do_request()` dispatches.

## Root cause

`assets/js/src/site/plugins/pum-analytics.js` batches two or more queued events into `FormData` with only an `events` field. The registered REST route still marked top-level `event` and `pid` as required. WordPress therefore returned `rest_missing_callback_param` before `PUM_Analytics::analytics_endpoint()` could call `parse_batch_events()`.

The callback already understood batches, but the route schema made that code unreachable for the frontend payload.

## Before / after reproduction

Tested against a clean `origin/develop` worktree with a published popup (`pid=13`) in `wp-env`.

Before:

```text
flat  event=open&pid=13
HTTP 204, empty body, open count +1

batch events=[{"event":"open","pid":13},{"event":"conversion","pid":13}]
HTTP 400, 130-byte JSON body
{"code":"rest_missing_callback_param","message":"Missing parameter(s): event, pid",...}
open/conversion counts unchanged by the batch
```

After:

```text
flat  event=open&pid=13
HTTP 204, empty body, open count exactly 1 after reset

batch events=[{"event":"open","pid":13},{"event":"conversion","pid":13}]
HTTP 204, empty body, open count exactly 1 and conversion count exactly 1 after reset
```

The end-to-end batch check used the same URL-encoded shape as the browser beacon:

```bash
curl -i -X POST \
  http://127.0.0.1:8880/wp-json/pum/v1/analytics/ \
  --data-urlencode 'events=[{"event":"open","pid":13},{"event":"conversion","pid":13}]'
```

## Validation and compatibility

- Flat single-event REST payloads remain supported.
- JSON-string FormData and decoded-array batches both return 204 when valid.
- Malformed JSON, empty/non-list batches, missing `event`/`pid`, invalid popup IDs, and invalid event names return HTTP 400 and do not increment counters.
- Popup IDs are rejected unless they are positive integers before normalization, preventing negative or fractional values from aliasing another popup.
- REST batches are capped at 100 events by default (filterable with `pum_analytics_rest_batch_limit`) and oversized batches are rejected atomically.
- The route uses WordPress’s recognized `validate_callback` key so popup ID validation runs during REST dispatch.
- The full batch is validated before any call to `track()`, preventing partial tracking; successful tests also assert exact hook invocation order/counts to catch duplicate tracking.
- Nested `eventData` continues through the existing sanitizer before reaching public hooks.
- `pum_analytics_valid_events`, event-specific hooks, `pum_analytics_event`, and `popup_maker/analytics/rate_limit` are covered by the route-dispatch suite.
- Custom/ad-block-bypass route names and additions made through `pum_analytics_rest_route_args` are covered.
- Legacy AJAX, image beacon, and REST GET fallback live checks remain unchanged:
  - AJAX: HTTP 204, empty body.
  - Image: HTTP 200, `image/gif`, 35-byte body.
  - REST GET: HTTP 204, empty body.
  - All three incremented the open counter exactly once.
- PHP remains compatible with 7.4; no PHP 8-only syntax or new strict callback types were added.

## Performance

The historical immediate HTTP 204 exit is retained for real REST requests after an intermediate response-only implementation showed avoidable overhead. Database general-log captures found no added single-event SQL work (43 baseline statements versus 39 in the warmed post-fix capture; the difference was one-time environment queries, not a new analytics query).

Local Docker TTFB was noisy under disk pressure, but the final fast-path samples overlapped the baseline: baseline median 73 ms (57-86 ms, n=9) versus final median 86 ms (61-128 ms, n=9). Given the unchanged immediate exit and no added queries, no meaningful deterministic single-event regression was identified.

## Tests

- New route-dispatch regression suite: **23 tests, 107 assertions**.
- Focused analytics suite: **65 tests, 173 assertions, 1 existing skip**.
- Full PHPUnit suite: **924 tests, 1,993 assertions, 29 existing skips**.
- PHPCS on all changed files: pass.
- PHP syntax checks on all changed files: pass.
- PHPStan on all changed files: pass.
- Full-project PHPStan was also run and continues to report 28 unrelated pre-existing errors outside this change.

The regression tests use `rest_do_request()` through a fresh `WP_REST_Server`, so WordPress route argument validation and dispatch are exercised rather than calling `analytics_endpoint()` directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for submitting multiple analytics events in a single request.
  * Analytics event submissions can use JSON or array-formatted batch data.
  * Individual event and popup identifiers are validated before tracking.
* **Bug Fixes**
  * Malformed, empty, or invalid submissions are rejected before events are recorded.
  * Batch requests prevent partial tracking when one event is invalid.
  * Invalid popup IDs and numeric values are now rejected consistently.
  * Successful analytics requests now return an HTTP 204 response.
  * Existing rate limiting and custom event handling continue to apply to batched events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->