### PR TITLE
Announce complete page builder support in admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 **Features**
 
+-   Added a dismissible admin announcement when a supported page builder is active, so users can discover Popup Maker's complete builder integration.
 -   Added complete Brizy support for building Popup Maker popups, including visual editing, frontend styling, and interactive elements.
 -   Added complete Bricks support for building Popup Maker popups, including editor previews, frontend styling, and interactive elements.
 -   Added complete Divi support for building Popup Maker popups, including Visual Builder editing, frontend styling, and interactive modules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 **Features**
 
--   Added a dismissible admin announcement when a supported page builder is active, so users can discover Popup Maker's complete builder integration.
 -   Added complete Brizy support for building Popup Maker popups, including visual editing, frontend styling, and interactive elements.
 -   Added complete Bricks support for building Popup Maker popups, including editor previews, frontend styling, and interactive elements.
 -   Added complete Divi support for building Popup Maker popups, including Visual Builder editing, frontend styling, and interactive modules.

--- a/classes/Base/PageBuilder.php
+++ b/classes/Base/PageBuilder.php
@@ -21,6 +21,20 @@ defined( 'ABSPATH' ) || exit;
 abstract class PageBuilder {
 
 	/**
+	 * Stable builder identifier.
+	 *
+	 * @var string
+	 */
+	public $key = '';
+
+	/**
+	 * Builder display label.
+	 *
+	 * @var string
+	 */
+	protected $label = '';
+
+	/**
 	 * Plugin container.
 	 *
 	 * @var \PopupMaker\Plugin\Core
@@ -34,6 +48,15 @@ abstract class PageBuilder {
 	 */
 	public function __construct( $container ) {
 		$this->container = $container;
+	}
+
+	/**
+	 * Builder display label.
+	 *
+	 * @return string
+	 */
+	public function label() {
+		return $this->label;
 	}
 
 	/**

--- a/classes/Builders/BeaverBuilder.php
+++ b/classes/Builders/BeaverBuilder.php
@@ -26,6 +26,12 @@ defined( 'ABSPATH' ) || exit;
  */
 class BeaverBuilder extends PageBuilder {
 
+	/** @var string */
+	public $key = 'beaver-builder';
+
+	/** @var string */
+	protected $label = 'Beaver Builder';
+
 	/**
 	 * Whether Beaver's native Popup Maker integration is active.
 	 *

--- a/classes/Builders/Bricks.php
+++ b/classes/Builders/Bricks.php
@@ -35,6 +35,12 @@ defined( 'ABSPATH' ) || exit;
  */
 class Bricks extends PageBuilder {
 
+	/** @var string */
+	public $key = 'bricks';
+
+	/** @var string */
+	protected $label = 'Bricks';
+
 	/**
 	 * CSS generated for popup documents and awaiting emission.
 	 *

--- a/classes/Builders/Brizy.php
+++ b/classes/Builders/Brizy.php
@@ -19,6 +19,12 @@ defined( 'ABSPATH' ) || exit;
  */
 class Brizy extends PageBuilder {
 
+	/** @var string */
+	public $key = 'brizy';
+
+	/** @var string */
+	protected $label = 'Brizy';
+
 	/**
 	 * Popup documents already given to Brizy's asset manager.
 	 *

--- a/classes/Builders/Divi.php
+++ b/classes/Builders/Divi.php
@@ -26,6 +26,12 @@ defined( 'ABSPATH' ) || exit;
  */
 class Divi extends PageBuilder {
 
+	/** @var string */
+	public $key = 'divi';
+
+	/** @var string */
+	protected $label = 'Divi';
+
 	/**
 	 * Whether Divi is active as either a theme or a plugin.
 	 *

--- a/classes/Builders/Elementor.php
+++ b/classes/Builders/Elementor.php
@@ -20,6 +20,12 @@ defined( 'ABSPATH' ) || exit;
  */
 class Elementor extends PageBuilder {
 
+	/** @var string */
+	public $key = 'elementor';
+
+	/** @var string */
+	protected $label = 'Elementor';
+
 	/**
 	 * Whether Elementor's document and rendering APIs are usable.
 	 *

--- a/classes/Builders/Etch.php
+++ b/classes/Builders/Etch.php
@@ -22,6 +22,12 @@ defined( 'ABSPATH' ) || exit;
  */
 class Etch extends PageBuilder {
 
+	/** @var string */
+	public $key = 'etch';
+
+	/** @var string */
+	protected $label = 'Etch';
+
 	/**
 	 * Marker confirming that Etch successfully saved this document.
 	 *

--- a/classes/Builders/SiteOrigin.php
+++ b/classes/Builders/SiteOrigin.php
@@ -23,6 +23,12 @@ defined( 'ABSPATH' ) || exit;
  */
 class SiteOrigin extends PageBuilder {
 
+	/** @var string */
+	public $key = 'siteorigin';
+
+	/** @var string */
+	protected $label = 'SiteOrigin Page Builder';
+
 	/**
 	 * Whether popup support existed before this provider injected it.
 	 *

--- a/classes/Builders/VisualComposer.php
+++ b/classes/Builders/VisualComposer.php
@@ -19,6 +19,12 @@ defined( 'ABSPATH' ) || exit;
  */
 class VisualComposer extends PageBuilder {
 
+	/** @var string */
+	public $key = 'visual-composer';
+
+	/** @var string */
+	protected $label = 'Visual Composer';
+
 	/**
 	 * Popup documents already given to Visual Composer's asset queue.
 	 *

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -184,6 +184,18 @@ class Builders extends Controller {
 	}
 
 	/**
+	 * Get the available builder adapter classes.
+	 *
+	 * Only builders that passed runtime detection and their adapter's
+	 * availability check are returned. Inactive adapters are not autoloaded.
+	 *
+	 * @return class-string<PageBuilder>[]
+	 */
+	public function get_available_builder_classes() {
+		return array_keys( $this->builders );
+	}
+
+	/**
 	 * Register the shared pipeline once a builder is available.
 	 *
 	 * @return void

--- a/classes/Controllers/Builders.php
+++ b/classes/Controllers/Builders.php
@@ -184,15 +184,15 @@ class Builders extends Controller {
 	}
 
 	/**
-	 * Get the available builder adapter classes.
+	 * Get the available builder adapters.
 	 *
 	 * Only builders that passed runtime detection and their adapter's
 	 * availability check are returned. Inactive adapters are not autoloaded.
 	 *
-	 * @return class-string<PageBuilder>[]
+	 * @return PageBuilder[]
 	 */
-	public function get_available_builder_classes() {
-		return array_keys( $this->builders );
+	public function get_available_builders() {
+		return array_values( $this->builders );
 	}
 
 	/**

--- a/classes/Services/Notifications/Manager.php
+++ b/classes/Services/Notifications/Manager.php
@@ -2,8 +2,8 @@
 /**
  * Notifications service — parent orchestrator.
  *
- * Owns the core notification providers (WhatsNew, FeatureAnnouncements)
- * and exposes a filter that lets addons (Pro, Pro+, integrations) plug
+ * Owns the core notification providers and exposes a filter that lets addons
+ * (Pro, Pro+, integrations) plug
  * in their own providers without touching core code.
  *
  * @package   PopupMaker
@@ -98,6 +98,7 @@ class Manager extends Service {
 	protected function resolve_providers() {
 		$core = [
 			new WhatsNew( $this->container ),
+			new PageBuilderAnnouncements( $this->container ),
 			new FeatureAnnouncements( $this->container ),
 		];
 

--- a/classes/Services/Notifications/PageBuilderAnnouncements.php
+++ b/classes/Services/Notifications/PageBuilderAnnouncements.php
@@ -9,6 +9,7 @@
 namespace PopupMaker\Services\Notifications;
 
 use PopupMaker\Base\Service;
+use PopupMaker\Base\PageBuilder;
 use PopupMaker\Controllers\Builders;
 
 defined( 'ABSPATH' ) || exit;
@@ -19,48 +20,6 @@ defined( 'ABSPATH' ) || exit;
  * @since 1.25.0
  */
 class PageBuilderAnnouncements extends Service implements Provider {
-
-	/**
-	 * Supported builder display details, keyed by adapter class.
-	 *
-	 * Class constants resolve to strings without autoloading the adapters.
-	 *
-	 * @var array<class-string,array{slug:string,label:string}>
-	 */
-	const BUILDERS = [
-		\PopupMaker\Builders\Elementor::class      => [
-			'slug'  => 'elementor',
-			'label' => 'Elementor',
-		],
-		\PopupMaker\Builders\BeaverBuilder::class  => [
-			'slug'  => 'beaver-builder',
-			'label' => 'Beaver Builder',
-		],
-		\PopupMaker\Builders\SiteOrigin::class     => [
-			'slug'  => 'siteorigin',
-			'label' => 'SiteOrigin Page Builder',
-		],
-		\PopupMaker\Builders\Brizy::class          => [
-			'slug'  => 'brizy',
-			'label' => 'Brizy',
-		],
-		\PopupMaker\Builders\VisualComposer::class => [
-			'slug'  => 'visual-composer',
-			'label' => 'Visual Composer',
-		],
-		\PopupMaker\Builders\Divi::class           => [
-			'slug'  => 'divi',
-			'label' => 'Divi',
-		],
-		\PopupMaker\Builders\Bricks::class         => [
-			'slug'  => 'bricks',
-			'label' => 'Bricks',
-		],
-		\PopupMaker\Builders\Etch::class           => [
-			'slug'  => 'etch',
-			'label' => 'Etch',
-		],
-	];
 
 	/**
 	 * Page builder integrations hub.
@@ -169,8 +128,25 @@ class PageBuilderAnnouncements extends Service implements Provider {
 			return [];
 		}
 
-		$available = array_flip( $controller->get_available_builder_classes() );
+		$available = [];
 
-		return array_values( array_intersect_key( self::BUILDERS, $available ) );
+		foreach ( $controller->get_available_builders() as $builder ) {
+			if ( ! $builder instanceof PageBuilder || ! is_string( $builder->key ) || '' === $builder->key ) {
+				continue;
+			}
+
+			$label = $builder->label();
+
+			if ( ! is_string( $label ) || '' === $label ) {
+				continue;
+			}
+
+			$available[] = [
+				'slug'  => sanitize_key( $builder->key ),
+				'label' => $label,
+			];
+		}
+
+		return $available;
 	}
 }

--- a/classes/Services/Notifications/PageBuilderAnnouncements.php
+++ b/classes/Services/Notifications/PageBuilderAnnouncements.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Page builder support announcements.
+ *
+ * @package   PopupMaker
+ * @copyright Copyright (c) 2026, Code Atlantic LLC
+ */
+
+namespace PopupMaker\Services\Notifications;
+
+use PopupMaker\Base\Service;
+use PopupMaker\Controllers\Builders;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Announces complete support for page builders active on the site.
+ *
+ * @since 1.25.0
+ */
+class PageBuilderAnnouncements extends Service implements Provider {
+
+	/**
+	 * Supported builder display details, keyed by adapter class.
+	 *
+	 * Class constants resolve to strings without autoloading the adapters.
+	 *
+	 * @var array<class-string,array{slug:string,label:string}>
+	 */
+	const BUILDERS = [
+		\PopupMaker\Builders\Elementor::class      => [
+			'slug'  => 'elementor',
+			'label' => 'Elementor',
+		],
+		\PopupMaker\Builders\BeaverBuilder::class  => [
+			'slug'  => 'beaver-builder',
+			'label' => 'Beaver Builder',
+		],
+		\PopupMaker\Builders\SiteOrigin::class     => [
+			'slug'  => 'siteorigin',
+			'label' => 'SiteOrigin Page Builder',
+		],
+		\PopupMaker\Builders\Brizy::class          => [
+			'slug'  => 'brizy',
+			'label' => 'Brizy',
+		],
+		\PopupMaker\Builders\VisualComposer::class => [
+			'slug'  => 'visual-composer',
+			'label' => 'Visual Composer',
+		],
+		\PopupMaker\Builders\Divi::class           => [
+			'slug'  => 'divi',
+			'label' => 'Divi',
+		],
+		\PopupMaker\Builders\Bricks::class         => [
+			'slug'  => 'bricks',
+			'label' => 'Bricks',
+		],
+		\PopupMaker\Builders\Etch::class           => [
+			'slug'  => 'etch',
+			'label' => 'Etch',
+		],
+	];
+
+	/**
+	 * Page builder integrations hub.
+	 *
+	 * @var string
+	 */
+	const GUIDE_URL = 'https://wppopupmaker.com/integrations/page-builder-integrations/';
+
+	/**
+	 * Hook into the alert list.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_filter( 'pum_alert_list', [ $this, 'register_announcement' ], 14 );
+	}
+
+	/**
+	 * Register one announcement for all supported builders active on the site.
+	 *
+	 * @param mixed $alerts Existing alerts.
+	 *
+	 * @return mixed
+	 */
+	public function register_announcement( $alerts ) {
+		if (
+			! is_array( $alerts ) ||
+			! current_user_can( $this->container->get_permission( 'edit_popups' ) )
+		) {
+			return $alerts;
+		}
+
+		$builders = $this->get_available_builders();
+
+		if ( ! $builders ) {
+			return $alerts;
+		}
+
+		$labels = wp_list_pluck( $builders, 'label' );
+		$slugs  = wp_list_pluck( $builders, 'slug' );
+		$names  = wp_sprintf_l( '%l', $labels );
+
+		if ( 1 === count( $builders ) ) {
+			/* translators: %s: page builder name. */
+			$title   = sprintf( __( 'Full Popup Maker support for %s is here', 'popup-maker' ), $names );
+			$message = sprintf(
+				/* translators: %s: page builder name. */
+				__( 'Design popup content directly in <strong>%s</strong> while Popup Maker handles the popup theme, triggers, targeting, and analytics. Builder styles and interactive elements work in the editor and on your site.', 'popup-maker' ),
+				esc_html( $names )
+			);
+		} else {
+			$title   = __( 'Full Popup Maker support for your page builders is here', 'popup-maker' );
+			$message = sprintf(
+				/* translators: %s: comma-separated list of page builder names. */
+				__( 'Popup Maker now fully supports the builders active on this site: <strong>%s</strong>. Design popup content in each builder while Popup Maker handles the popup theme, triggers, targeting, and analytics.', 'popup-maker' ),
+				esc_html( $names )
+			);
+		}
+
+		$alerts[] = [
+			'code'        => 'pm_feat_page_builder_support_2026_' . implode( '_', $slugs ),
+			'type'        => 'info',
+			'category'    => 'feature',
+			'priority'    => 88,
+			'title'       => $title,
+			'message'     => $message,
+			'subtitle'    => __( 'new in Popup Maker', 'popup-maker' ),
+			'icon'        => 'layout',
+			'dismissible' => true,
+			'actions'     => [
+				[
+					'text'     => __( 'See how it works', 'popup-maker' ),
+					'type'     => 'link',
+					'action'   => '',
+					'href'     => add_query_arg(
+						[
+							'utm_source'   => 'plugin',
+							'utm_medium'   => 'notification',
+							'utm_campaign' => 'page-builder-support',
+						],
+						self::GUIDE_URL
+					),
+					'primary'  => true,
+					'external' => true,
+				],
+				[
+					'text'   => __( 'Dismiss', 'popup-maker' ),
+					'type'   => 'action',
+					'action' => 'dismiss',
+				],
+			],
+		];
+
+		return $alerts;
+	}
+
+	/**
+	 * Get display details for available builder adapters.
+	 *
+	 * @return array<int,array{slug:string,label:string}>
+	 */
+	protected function get_available_builders() {
+		$controller = $this->container->get_controller( 'Builders' );
+
+		if ( ! $controller instanceof Builders ) {
+			return [];
+		}
+
+		$available = array_flip( $controller->get_available_builder_classes() );
+
+		return array_values( array_intersect_key( self::BUILDERS, $available ) );
+	}
+}

--- a/docs/notifications-registry.md
+++ b/docs/notifications-registry.md
@@ -74,6 +74,12 @@ Shared helpers (in `FeatureAnnouncements`):
 - `feature_url( $slug, $campaign )` — `wppopupmaker.com/features/<slug>/` with UTM. Supports nested slugs (`popup-triggers/exit-intent-triggers`).
 - `upgrade_url( $campaign )` — wraps `\PopupMaker\get_upgrade_link()` → `wppopupmaker.com/pricing/` with UTM. Kept for future pricing-direct CTAs; current upsells route to feature pages instead.
 
+#### PageBuilderAnnouncements provider (`classes/Services/Notifications/PageBuilderAnnouncements.php`)
+
+| Code | Category | Condition | Destination | Notes |
+|---|---|---|---|---|
+| `pm_feat_page_builder_support_2026_<builder-slugs>` | `feature` | At least one bundled page builder adapter passed runtime detection and its availability check | `/integrations/page-builder-integrations/` | Consolidates every active supported builder into one dismissible announcement. The stable builder slug suffix scopes dismissal to the detected set, so installing another supported builder can surface the new capability without loading inactive adapters. |
+
 ### Pro / Pro+ / extensions
 
 | Plugin | Registered alerts | Notes |

--- a/docs/notifications-registry.md
+++ b/docs/notifications-registry.md
@@ -78,7 +78,7 @@ Shared helpers (in `FeatureAnnouncements`):
 
 | Code | Category | Condition | Destination | Notes |
 |---|---|---|---|---|
-| `pm_feat_page_builder_support_2026_<builder-slugs>` | `feature` | At least one bundled page builder adapter passed runtime detection and its availability check | `/integrations/page-builder-integrations/` | Consolidates every active supported builder into one dismissible announcement. The stable builder slug suffix scopes dismissal to the detected set, so installing another supported builder can surface the new capability without loading inactive adapters. |
+| `pm_feat_page_builder_support_2026_<builder-slugs>` | `feature` | At least one bundled page builder adapter passed runtime detection and its availability check | `/integrations/page-builder-integrations/` | Consolidates every active supported builder into one announcement with permanent per-user dismissal. The stable builder slug suffix scopes dismissal to the detected set, so installing another supported builder can surface the new capability without loading inactive adapters. |
 
 ### Pro / Pro+ / extensions
 

--- a/tests/php/tests/Page_Builder_Announcements_Test.php
+++ b/tests/php/tests/Page_Builder_Announcements_Test.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * Page builder announcement tests.
+ *
+ * @package Popup_Maker
+ */
+
+use PopupMaker\Services\Notifications\PageBuilderAnnouncements;
+
+/**
+ * Verify builder-aware admin announcements.
+ */
+class Page_Builder_Announcements_Test extends WP_UnitTestCase {
+
+	/** @return void */
+	public function tearDown(): void {
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/** @return void */
+	public function test_announcement_requires_popup_edit_access() {
+		$provider = $this->make_provider(
+			[
+				[
+					'slug'  => 'elementor',
+					'label' => 'Elementor',
+				],
+			]
+		);
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$this->assertSame( [], $provider->register_announcement( [] ) );
+	}
+
+	/** @return void */
+	public function test_announcement_is_omitted_without_an_available_builder() {
+		$provider = $this->make_provider( [] );
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->assertSame( [], $provider->register_announcement( [] ) );
+	}
+
+	/** @return void */
+	public function test_single_builder_announcement_names_the_builder() {
+		$provider = $this->make_provider(
+			[
+				[
+					'slug'  => 'elementor',
+					'label' => 'Elementor',
+				],
+			]
+		);
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		$alerts = $provider->register_announcement( [] );
+
+		$this->assertCount( 1, $alerts );
+		$this->assertSame( 'pm_feat_page_builder_support_2026_elementor', $alerts[0]['code'] );
+		$this->assertStringContainsString( 'Elementor', $alerts[0]['title'] );
+		$this->assertStringContainsString( '<strong>Elementor</strong>', $alerts[0]['message'] );
+		$this->assertSame( 'feature', $alerts[0]['category'] );
+		$this->assertTrue( $alerts[0]['dismissible'] );
+	}
+
+	/** @return void */
+	public function test_multiple_builders_share_one_scoped_announcement() {
+		$provider = $this->make_provider(
+			[
+				[
+					'slug'  => 'elementor',
+					'label' => 'Elementor',
+				],
+				[
+					'slug'  => 'bricks',
+					'label' => 'Bricks',
+				],
+			]
+		);
+
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		$alerts = $provider->register_announcement( [] );
+
+		$this->assertCount( 1, $alerts );
+		$this->assertSame( 'pm_feat_page_builder_support_2026_elementor_bricks', $alerts[0]['code'] );
+		$this->assertStringContainsString( 'Elementor', $alerts[0]['message'] );
+		$this->assertStringContainsString( 'Bricks', $alerts[0]['message'] );
+		$this->assertCount( 2, $alerts[0]['actions'] );
+	}
+
+	/**
+	 * Create a provider with deterministic builder details.
+	 *
+	 * @param array<int,array{slug:string,label:string}> $builders Builder details.
+	 *
+	 * @return PageBuilderAnnouncements
+	 */
+	private function make_provider( $builders ) {
+		return new class( \PopupMaker\plugin(), $builders ) extends PageBuilderAnnouncements {
+
+			/** @var array<int,array{slug:string,label:string}> */
+			private $test_builders;
+
+			/**
+			 * @param \PopupMaker\Plugin\Core                    $container Plugin container.
+			 * @param array<int,array{slug:string,label:string}> $builders  Builder details.
+			 */
+			public function __construct( $container, $builders ) {
+				parent::__construct( $container );
+
+				$this->test_builders = $builders;
+			}
+
+			/** @return array<int,array{slug:string,label:string}> */
+			protected function get_available_builders() {
+				return $this->test_builders;
+			}
+		};
+	}
+}

--- a/tests/php/tests/Page_Builders_Test.php
+++ b/tests/php/tests/Page_Builders_Test.php
@@ -184,11 +184,11 @@ class Page_Builders_Test extends WP_UnitTestCase {
 	}
 
 	/** @return void */
-	public function test_available_builder_classes_only_include_booted_adapters() {
+	public function test_available_builders_only_include_booted_adapters() {
 		$builder    = $this->make_builder();
 		$controller = $this->make_controller( $builder );
 
-		$this->assertSame( [ get_class( $builder ) ], $controller->get_available_builder_classes() );
+		$this->assertSame( [ $builder ], $controller->get_available_builders() );
 	}
 
 	/** @return void */
@@ -552,6 +552,12 @@ class Page_Builders_Test extends WP_UnitTestCase {
 	/** @return PageBuilder */
 	private function make_builder() {
 		return new class( \PopupMaker\plugin() ) extends PageBuilder {
+
+			/** @var string */
+			public $key = 'test-builder';
+
+			/** @var string */
+			protected $label = 'Test Builder';
 
 			/** @var bool */
 			public $available = true;

--- a/tests/php/tests/Page_Builders_Test.php
+++ b/tests/php/tests/Page_Builders_Test.php
@@ -189,6 +189,8 @@ class Page_Builders_Test extends WP_UnitTestCase {
 		$controller = $this->make_controller( $builder );
 
 		$this->assertSame( [ $builder ], $controller->get_available_builders() );
+		$this->assertSame( 'test-builder', $builder->key );
+		$this->assertSame( 'Test Builder', $builder->label() );
 	}
 
 	/** @return void */

--- a/tests/php/tests/Page_Builders_Test.php
+++ b/tests/php/tests/Page_Builders_Test.php
@@ -184,6 +184,14 @@ class Page_Builders_Test extends WP_UnitTestCase {
 	}
 
 	/** @return void */
+	public function test_available_builder_classes_only_include_booted_adapters() {
+		$builder    = $this->make_builder();
+		$controller = $this->make_controller( $builder );
+
+		$this->assertSame( [ get_class( $builder ) ], $controller->get_available_builder_classes() );
+	}
+
+	/** @return void */
 	public function test_inactive_bundled_builders_are_not_loaded_or_constructed() {
 		if (
 			defined( 'ELEMENTOR_VERSION' ) ||


### PR DESCRIPTION
## What changed

- Added one dismissible feature announcement when one or more supported page builders are active.
- Reused the builder controller's booted adapters instead of duplicating detection or autoloading inactive integrations.
- Consolidated mixed-builder sites into a single notification and scoped dismissal to the active builder set.
- Added notification registry documentation, a user-facing changelog entry, and PHPUnit coverage.

## User impact

Users with Elementor, Beaver Builder, SiteOrigin Page Builder, Brizy, Visual Composer, Divi, Bricks, or Etch will discover that Popup Maker now supports designing popup content in their preferred builder. Sites using several builders receive one concise announcement rather than one notice per builder.

## Validation

- `composer run tests` — 999 tests, 2,224 assertions, 43 skipped
- Targeted builder/notification tests — 25 tests, 112 assertions
- PHPCS — clean
- PHPStan with 1 GB memory limit — clean
- `git diff --check` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dismissible admin announcements for supported page builders.
  * Announcements identify available builders and link to relevant documentation.
  * Added consistent names and identifiers for supported page-builder integrations.
  * Announcements are shown only to users who can edit popups.
  * Exposed currently available page builders for broader application use.

* **Tests**
  * Added coverage for builder detection, permissions, announcement content, and multiple-builder scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->