### PR TITLE
Keep What's New dismissals per user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,6 @@
 
 **Fixes**
 
--   Fixed dismissing a "What's New" notification hiding that release announcement from other administrators.
 -   Restored WPBakery Page Builder editing for popups when the block editor is enabled in Popup Maker.
 -   Added a compatibility safeguard for Jetpack synced forms that pass object-valued field attributes into string escaping.
 -   Prevented Astra Custom Layouts rendered inside popups from corrupting the pending WordPress main loop.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
 
 **Fixes**
 
+-   Fixed dismissing a "What's New" notification hiding that release announcement from other administrators.
 -   Restored WPBakery Page Builder editing for popups when the block editor is enabled in Popup Maker.
 -   Added a compatibility safeguard for Jetpack synced forms that pass object-valued field attributes into string escaping.
 -   Prevented Astra Custom Layouts rendered inside popups from corrupting the pending WordPress main loop.

--- a/classes/Services/Notifications/WhatsNew.php
+++ b/classes/Services/Notifications/WhatsNew.php
@@ -35,11 +35,19 @@ class WhatsNew extends Service implements Provider {
 	const SLOT_OPTION = 'pum_whats_new_slot';
 
 	/**
-	 * Option storing the last major.minor release the user dismissed.
+	 * Legacy site option used as an upgrade-state fallback.
+	 *
+	 * @var string
+	 * @deprecated 1.25.0 Dismissal state is now stored per user.
+	 */
+	const LAST_SEEN_OPTION = 'pum_whats_new_last_seen';
+
+	/**
+	 * User-meta key storing the last major.minor release the user dismissed.
 	 *
 	 * @var string
 	 */
-	const LAST_SEEN_OPTION = 'pum_whats_new_last_seen';
+	const LAST_SEEN_USER_META = 'pum_whats_new_last_seen';
 
 	/**
 	 * Prefix for the alert code. Actual code is suffixed with the current
@@ -130,8 +138,9 @@ class WhatsNew extends Service implements Provider {
 			return $alerts;
 		}
 
-		$latest = (string) $slot['latest'];
-		$since  = isset( $slot['since'] ) ? (string) $slot['since'] : '';
+		$latest         = (string) $slot['latest'];
+		$user_last_seen = $this->major_minor( (string) get_user_meta( get_current_user_id(), self::LAST_SEEN_USER_META, true ) );
+		$since          = $user_last_seen ?: ( isset( $slot['since'] ) ? (string) $slot['since'] : '' );
 
 		if ( $since && $since !== $latest ) {
 			/* translators: %s: version number they last dismissed notes for. */
@@ -268,10 +277,8 @@ class WhatsNew extends Service implements Provider {
 		$slot = $this->get_slot();
 
 		if ( ! empty( $slot['latest'] ) ) {
-			update_option( self::LAST_SEEN_OPTION, (string) $slot['latest'], false );
+			update_user_meta( get_current_user_id(), self::LAST_SEEN_USER_META, (string) $slot['latest'] );
 		}
-
-		delete_option( self::SLOT_OPTION );
 	}
 
 	/**

--- a/docs/notifications-registry.md
+++ b/docs/notifications-registry.md
@@ -23,7 +23,9 @@ Two dismissal paths from the panel:
 1. **Corner X** (`action: ''`) — permanent. Requires `dismissible: true` on the alert.
 2. **Declared "Not now" button** (`action: 'dismiss'` + `expires: '30 days'`) — snooze per the action's `expires` field.
 
-After successful dismissal, the REST endpoint fires `pum_alert_dismissed` so providers can run post-dismissal logic (e.g. `WhatsNew::on_dismiss` clears its slot and records `last_seen`).
+After successful dismissal, the REST endpoint fires `pum_alert_dismissed` so providers can run post-dismissal logic (e.g. `WhatsNew::on_dismiss` records that user's `last_seen` release).
+
+Dismissal scope is deliberately not configurable per message: standard notification dismissals are always per user. A custom action may change site state when that is the action's actual purpose (for example, enabling telemetry), but clicking Dismiss or the corner X must not suppress a message for other users.
 
 ## Registry
 
@@ -50,7 +52,7 @@ After successful dismissal, the REST endpoint fires `pum_alert_dismissed` so pro
 
 | Code | Category | Dismissible | Notes |
 |---|---|---|---|
-| `pm_whats_new_release_<major>_<minor>` | `feature` | Yes (permanent) | Auto-generated release announcement. One slot at a time. Code is version-suffixed so each major.minor gets its own dismissal record. On dismiss, clears the slot option and writes `pum_whats_new_last_seen`. Parses highlights from readme.txt between `last_seen` and `latest`. |
+| `pm_whats_new_release_<major>_<minor>` | `feature` | Yes (permanent, per user) | Auto-generated release announcement. One shared release slot remains available until the next release so every eligible user can see it. The version-suffixed code and `pum_whats_new_last_seen` user meta keep dismissal and catch-up copy user-specific. Parses highlights from readme.txt between each user's `last_seen` and `latest`. |
 
 Actions:
 - **View changelog** — iframe to WP plugin-information screen (install_plugins cap) or public `/changelog/` link (fallback).
@@ -117,7 +119,8 @@ wp eval 'update_user_meta( get_current_user_id(), "_pum_dismissed_alerts", [] );
 
 # Reset WhatsNew state:
 wp option delete pum_whats_new_slot
-wp option delete pum_whats_new_last_seen
+wp user meta delete <user-id> pum_whats_new_last_seen
+wp option delete pum_whats_new_last_seen # Legacy pre-per-user fallback.
 
 # Flush FeatureAnnouncements transient cache (locale-scoped, 12h TTL).
 # `wp cache flush` won't touch these — they live in the options table.

--- a/tests/php/tests/Whats_New_Notifications_Test.php
+++ b/tests/php/tests/Whats_New_Notifications_Test.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * What's New notification tests.
+ *
+ * @package Popup_Maker
+ */
+
+use PopupMaker\Services\Notifications\WhatsNew;
+
+/**
+ * Verify release announcements retain per-user dismissal state.
+ */
+class Whats_New_Notifications_Test extends WP_UnitTestCase {
+
+	/** @var WhatsNew */
+	private $provider;
+
+	/** @return void */
+	public function setUp(): void {
+		parent::setUp();
+
+		delete_option( WhatsNew::SLOT_OPTION );
+		delete_option( WhatsNew::LAST_SEEN_OPTION );
+
+		$this->provider = new WhatsNew( \PopupMaker\plugin() );
+	}
+
+	/** @return void */
+	public function tearDown(): void {
+		delete_option( WhatsNew::SLOT_OPTION );
+		delete_option( WhatsNew::LAST_SEEN_OPTION );
+		wp_set_current_user( 0 );
+
+		parent::tearDown();
+	}
+
+	/** @return void */
+	public function test_dismissal_keeps_release_available_to_other_users() {
+		$first_user  = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$second_user = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$code        = 'pm_whats_new_release_1_25';
+
+		$this->provider->on_version_update( '1.24.0', '1.25.0' );
+
+		wp_set_current_user( $first_user );
+		$this->assertTrue( PUM_Utils_Alerts::action_handler( $code, 'dismiss', '' ) );
+		$this->provider->on_dismiss( $code );
+
+		$this->assertTrue( PUM_Utils_Alerts::has_dismissed_alert( $code ) );
+		$this->assertSame( '1.25', get_user_meta( $first_user, WhatsNew::LAST_SEEN_USER_META, true ) );
+		$this->assertNotEmpty( get_option( WhatsNew::SLOT_OPTION ) );
+
+		wp_set_current_user( $second_user );
+		$this->assertFalse( PUM_Utils_Alerts::has_dismissed_alert( $code ) );
+		$this->assertCount( 1, $this->provider->register_alert( [] ) );
+	}
+
+	/** @return void */
+	public function test_catch_up_copy_uses_each_users_last_seen_release() {
+		$first_user  = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$second_user = $this->factory->user->create( [ 'role' => 'administrator' ] );
+
+		$this->provider->on_version_update( '1.24.0', '1.25.0' );
+		wp_set_current_user( $first_user );
+		$this->provider->on_dismiss( 'pm_whats_new_release_1_25' );
+		$this->provider->on_version_update( '1.25.0', '1.26.0' );
+
+		$first_alert = $this->provider->register_alert( [] );
+		$this->assertSame( 'since v1.25', $first_alert[0]['subtitle'] );
+
+		wp_set_current_user( $second_user );
+		$second_alert = $this->provider->register_alert( [] );
+		$this->assertSame( 'since v1.24', $second_alert[0]['subtitle'] );
+	}
+}


### PR DESCRIPTION
## Summary

- keep the shared release slot available so every eligible administrator can receive the current What’s New notification
- store each administrator’s last-seen release in user meta and personalize catch-up copy from it
- document that standard notification dismissal is always per user
- retain the legacy site option as an upgrade fallback

## Validation

- focused PHPUnit: 2 tests, 8 assertions
- full PHPUnit: 996 tests, 2,218 assertions, 43 expected skips
- PHPCS: clean
- PHPStan: clean
- `git diff --check`: clean