### PR TITLE
Consolidate popup title projections into cached repository helper

### DIFF
--- a/classes/Helpers.php
+++ b/classes/Helpers.php
@@ -411,6 +411,25 @@ class PUM_Helpers {
 			]
 		);
 
+		$use_filtered_posts = ! $query_args['suppress_filters'] && self::popup_query_result_filters_active();
+
+		if ( $use_filtered_posts ) {
+			$query_args['fields']                 = 'all';
+			$query_args['update_post_meta_cache'] = false;
+			$query_args['update_post_term_cache'] = false;
+			$popup_list                           = [];
+
+			foreach ( get_posts( $query_args ) as $popup ) {
+				if ( $popup instanceof WP_Post && 'publish' === get_post_status( $popup->ID ) ) {
+					$popup_list[ (string) $popup->ID ] = (string) $popup->post_title;
+				}
+			}
+
+			$filtered_popup_list = apply_filters( 'popup_maker/popup_title_choices', $popup_list );
+
+			return is_array( $filtered_popup_list ) ? $filtered_popup_list : $popup_list;
+		}
+
 		static $queries = [];
 
 		$query_key = md5( wp_json_encode( $query_args ) );
@@ -435,5 +454,44 @@ class PUM_Helpers {
 		}
 
 		return $popup_list;
+	}
+
+	/**
+	 * Check whether query-result filters can alter popup titles.
+	 *
+	 * WordPress registers its comment-status callback on `the_posts` by default;
+	 * that callback does not alter popup titles and should not disable the fast
+	 * projection path.
+	 *
+	 * @return bool
+	 */
+	private static function popup_query_result_filters_active() {
+		global $wp_filter;
+
+		if ( false !== has_filter( 'posts_results' ) ) {
+			return true;
+		}
+
+		if ( false === has_filter( 'the_posts' ) ) {
+			return false;
+		}
+
+		$the_posts_hook = isset( $wp_filter['the_posts'] ) ? $wp_filter['the_posts'] : null;
+
+		if ( ! is_object( $the_posts_hook ) || ! isset( $the_posts_hook->callbacks ) || ! is_array( $the_posts_hook->callbacks ) ) {
+			return true;
+		}
+
+		foreach ( $the_posts_hook->callbacks as $callbacks ) {
+			foreach ( $callbacks as $callback ) {
+				$function = isset( $callback['function'] ) ? $callback['function'] : null;
+
+				if ( '_close_comments_for_old_posts' !== $function ) {
+					return true;
+				}
+			}
+		}
+
+		return false;
 	}
 }

--- a/classes/Helpers.php
+++ b/classes/Helpers.php
@@ -375,9 +375,9 @@ class PUM_Helpers {
 		}
 
 		if ( isset( $args['post_status'] ) ) {
-			$statuses = (array) $args['post_status'];
+			$statuses = array_filter( (array) $args['post_status'] );
 
-			if ( ! in_array( 'publish', $statuses, true ) && ! in_array( 'any', $statuses, true ) ) {
+			if ( ! empty( $statuses ) && ! in_array( 'publish', $statuses, true ) && ! in_array( 'any', $statuses, true ) ) {
 				return [];
 			}
 		}
@@ -401,13 +401,13 @@ class PUM_Helpers {
 		$query_args = array_merge(
 			$args,
 			[
-				'post_type'              => 'popup',
-				'post_status'            => 'publish',
-				'posts_per_page'         => -1,
-				'fields'                 => 'ids',
-				'no_found_rows'          => true,
-				'order'                  => isset( $args['order'] ) ? $args['order'] : 'DESC',
-				'suppress_filters'       => isset( $args['suppress_filters'] ) ? $args['suppress_filters'] : false,
+				'post_type'        => 'popup',
+				'post_status'      => 'publish',
+				'posts_per_page'   => -1,
+				'fields'           => 'ids',
+				'no_found_rows'    => true,
+				'order'            => isset( $args['order'] ) ? $args['order'] : 'DESC',
+				'suppress_filters' => isset( $args['suppress_filters'] ) ? $args['suppress_filters'] : false,
 			]
 		);
 
@@ -416,18 +416,15 @@ class PUM_Helpers {
 		$query_key = md5( wp_json_encode( $query_args ) );
 
 		if ( isset( $queries[ $query_key ] ) ) {
-			return $queries[ $query_key ];
+			$popup_ids = $queries[ $query_key ];
+		} else {
+			$popup_ids             = array_map( 'absint', get_posts( $query_args ) );
+			$queries[ $query_key ] = $popup_ids;
 		}
-
-		$popup_ids = get_posts( $query_args );
 
 		if ( empty( $popup_ids ) ) {
-			$queries[ $query_key ] = [];
-
 			return [];
 		}
-
-		$popup_ids    = array_map( 'absint', $popup_ids );
 		$titles_by_id = \PopupMaker\plugin( 'popups' )->get_title_choices( $popup_ids );
 		$popup_list   = [];
 
@@ -436,8 +433,6 @@ class PUM_Helpers {
 				$popup_list[ (string) $popup_id ] = $titles_by_id[ $popup_id ];
 			}
 		}
-
-		$queries[ $query_key ] = $popup_list;
 
 		return $popup_list;
 	}

--- a/classes/Helpers.php
+++ b/classes/Helpers.php
@@ -370,15 +370,74 @@ class PUM_Helpers {
 	 * @return array<string,string> Popup ID => title mapping
 	 */
 	public static function popup_selectlist( $args = [] ) {
-		$popup_list = [];
+		if ( ! is_array( $args ) ) {
+			return [];
+		}
 
-		$popups = pum_get_all_popups( $args );
+		if ( isset( $args['post_status'] ) ) {
+			$statuses = (array) $args['post_status'];
 
-		foreach ( $popups as $popup ) {
-			if ( $popup->is_published() ) {
-				$popup_list[ (string) $popup->ID ] = $popup->post_title;
+			if ( ! in_array( 'publish', $statuses, true ) && ! in_array( 'any', $statuses, true ) ) {
+				return [];
 			}
 		}
+
+		if ( isset( $args['popups'] ) ) {
+			$args['post__in'] = wp_parse_id_list( $args['popups'] );
+			unset( $args['popups'] );
+		}
+
+		if ( ! isset( $args['orderby'] ) ) {
+			$args['orderby'] = 'modified';
+		} elseif ( 'name' === $args['orderby'] ) {
+			$args['orderby'] = 'title';
+			$args['order']   = isset( $args['order'] ) ? $args['order'] : 'ASC';
+		} elseif ( 'activity' === $args['orderby'] ) {
+			$args['orderby'] = 'modified';
+		} elseif ( 'user_order' === $args['orderby'] && ! empty( $args['post__in'] ) ) {
+			$args['orderby'] = 'post__in';
+		}
+
+		$query_args = array_merge(
+			$args,
+			[
+				'post_type'              => 'popup',
+				'post_status'            => 'publish',
+				'posts_per_page'         => -1,
+				'fields'                 => 'ids',
+				'no_found_rows'          => true,
+				'order'                  => isset( $args['order'] ) ? $args['order'] : 'DESC',
+				'suppress_filters'       => isset( $args['suppress_filters'] ) ? $args['suppress_filters'] : false,
+			]
+		);
+
+		static $queries = [];
+
+		$query_key = md5( wp_json_encode( $query_args ) );
+
+		if ( isset( $queries[ $query_key ] ) ) {
+			return $queries[ $query_key ];
+		}
+
+		$popup_ids = get_posts( $query_args );
+
+		if ( empty( $popup_ids ) ) {
+			$queries[ $query_key ] = [];
+
+			return [];
+		}
+
+		$popup_ids    = array_map( 'absint', $popup_ids );
+		$titles_by_id = \PopupMaker\plugin( 'popups' )->get_title_choices( $popup_ids );
+		$popup_list   = [];
+
+		foreach ( $popup_ids as $popup_id ) {
+			if ( isset( $titles_by_id[ $popup_id ] ) ) {
+				$popup_list[ (string) $popup_id ] = $titles_by_id[ $popup_id ];
+			}
+		}
+
+		$queries[ $query_key ] = $popup_list;
 
 		return $popup_list;
 	}

--- a/classes/Services/Repository/Popups.php
+++ b/classes/Services/Repository/Popups.php
@@ -69,6 +69,76 @@ class Popups extends Repository {
 	}
 
 	/**
+	 * Get popup titles keyed by popup ID.
+	 *
+	 * @param array<int,int|string> $ids Popup IDs.
+	 *
+	 * @return array<int,string> Popup ID => title mapping.
+	 */
+	public function get_title_choices( $ids ) {
+		global $wpdb;
+
+		if ( ! is_array( $ids ) ) {
+			return [];
+		}
+
+		$ids = array_values( array_unique( array_filter( array_map( 'absint', $ids ) ) ) );
+
+		if ( empty( $ids ) ) {
+			return [];
+		}
+
+		$last_changed = wp_cache_get_last_changed( 'posts' );
+		$cache_key    = 'pum_popup_title_choices:' . md5( implode( ',', $ids ) ) . ':' . $last_changed;
+
+		$cached_titles = wp_cache_get( $cache_key, 'popup-maker' );
+
+		if ( is_array( $cached_titles ) ) {
+			return $this->filter_title_choices( $cached_titles );
+		}
+
+		$placeholders = implode( ', ', array_fill( 0, count( $ids ), '%d' ) );
+		$query        = "SELECT ID, post_title FROM %i WHERE post_type = %s AND ID IN ($placeholders)";
+		$query_args   = array_merge( [ $wpdb->posts, $this->post_type ], $ids );
+
+		// Fetch only the ID and title fields needed by popup title consumers.
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
+		$rows = $wpdb->get_results( $wpdb->prepare( $query, $query_args ), ARRAY_A );
+		$rows = is_array( $rows ) ? $rows : [];
+
+		$title_choices = [];
+
+		foreach ( $rows as $row ) {
+			$popup_id = isset( $row['ID'] ) ? absint( $row['ID'] ) : 0;
+
+			if ( $popup_id > 0 ) {
+				$title_choices[ $popup_id ] = isset( $row['post_title'] ) ? (string) $row['post_title'] : '';
+			}
+		}
+
+		wp_cache_set( $cache_key, $title_choices, 'popup-maker' );
+
+		return $this->filter_title_choices( $title_choices );
+	}
+
+	/**
+	 * Allow per-request filtering of a raw ID => title map.
+	 *
+	 * Titles stay raw because WordPress title formatting entity-encodes plain-text
+	 * select labels. Multilingual plugins and extensions can remap the uncached
+	 * result through this dedicated filter.
+	 *
+	 * @param array<int,string> $title_choices Raw titles keyed by popup ID.
+	 *
+	 * @return array<int,string>
+	 */
+	protected function filter_title_choices( $title_choices ) {
+		$filtered = apply_filters( 'popup_maker/popup_title_choices', $title_choices );
+
+		return is_array( $filtered ) ? $filtered : $title_choices;
+	}
+
+	/**
 	 * Generate select list query.
 	 *
 	 * @param array $args Query arguments.

--- a/tests/php/tests/PUM_Helpers_Test.php
+++ b/tests/php/tests/PUM_Helpers_Test.php
@@ -1,0 +1,152 @@
+<?php
+/**
+ * Tests for Popup Maker helpers.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Verify helper query behavior.
+ */
+class PUM_Helpers_Test extends WP_UnitTestCase {
+
+	/**
+	 * Popup select lists return published IDs and titles without draft content.
+	 *
+	 * @return void
+	 */
+	public function test_popup_selectlist_returns_published_choices() {
+		$published_id = self::factory()->post->create(
+			[
+				'post_type'    => 'popup',
+				'post_status'  => 'publish',
+				'post_title'   => 'Published choice',
+				'post_content' => 'Large content is not needed by a select list.',
+			]
+		);
+		$draft_id     = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+				'post_title'  => 'Draft choice',
+			]
+		);
+
+		$choices = PUM_Helpers::popup_selectlist( [ 'post__in' => [ $published_id, $draft_id ] ] );
+
+		$this->assertSame( 'Published choice', $choices[ $published_id ] );
+		$this->assertArrayNotHasKey( $draft_id, $choices );
+	}
+
+	/**
+	 * Existing exclusions and status filters retain their behavior.
+	 *
+	 * @return void
+	 */
+	public function test_popup_selectlist_honors_query_filters() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Excluded choice',
+			]
+		);
+
+		$this->assertArrayNotHasKey(
+			$popup_id,
+			PUM_Helpers::popup_selectlist( [ 'post__not_in' => [ $popup_id ] ] )
+		);
+		$this->assertSame( [], PUM_Helpers::popup_selectlist( [ 'post_status' => 'draft' ] ) );
+	}
+
+	/**
+	 * Legacy name ordering remains ascending unless explicitly overridden.
+	 *
+	 * @return void
+	 */
+	public function test_popup_selectlist_preserves_name_ordering() {
+		$last_id  = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Zulu choice',
+			]
+		);
+		$first_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Alpha choice',
+			]
+		);
+
+		$choices = PUM_Helpers::popup_selectlist(
+			[
+				'popups'  => [ $last_id, $first_id ],
+				'orderby' => 'name',
+			]
+		);
+
+		$this->assertSame( [ $first_id, $last_id ], array_keys( $choices ) );
+	}
+
+	/**
+	 * A cold select list uses one ID query and one title projection query.
+	 *
+	 * @return void
+	 */
+	public function test_popup_selectlist_uses_two_cold_queries() {
+		global $wpdb;
+
+		$popup_ids = self::factory()->post->create_many(
+			10,
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		foreach ( $popup_ids as $popup_id ) {
+			update_post_meta( $popup_id, 'popup_settings', [ 'overlay_disabled' => false ] );
+		}
+
+		wp_cache_flush();
+		get_option( 'posts_per_page' );
+		$query_count = $wpdb->num_queries;
+		$choices    = PUM_Helpers::popup_selectlist( [ 'post__in' => $popup_ids ] );
+
+		$this->assertCount( 10, $choices );
+		$this->assertSame( 2, $wpdb->num_queries - $query_count );
+	}
+
+	/**
+	 * Dedicated title filters reach the select-list consumer.
+	 *
+	 * @return void
+	 */
+	public function test_popup_selectlist_applies_title_choice_filter() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Original title',
+			]
+		);
+		$filter   = static function ( $titles ) use ( $popup_id ) {
+			$titles[ $popup_id ] = 'Translated title';
+
+			return $titles;
+		};
+
+		add_filter( 'popup_maker/popup_title_choices', $filter );
+
+		try {
+			$this->assertSame(
+				[ $popup_id => 'Translated title' ],
+				PUM_Helpers::popup_selectlist( [ 'post__in' => [ $popup_id ] ] )
+			);
+		} finally {
+			remove_filter( 'popup_maker/popup_title_choices', $filter );
+		}
+	}
+}

--- a/tests/php/tests/PUM_Helpers_Test.php
+++ b/tests/php/tests/PUM_Helpers_Test.php
@@ -118,6 +118,93 @@ class PUM_Helpers_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Query-result filters retain their title mutations.
+	 *
+	 * @dataProvider query_result_filter_provider
+	 * @param string $hook Query result hook.
+	 * @return void
+	 */
+	public function test_popup_selectlist_preserves_query_result_title_filters( $hook ) {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Stored popup title',
+			]
+		);
+		$filter   = static function ( $posts ) use ( $popup_id ) {
+			foreach ( $posts as $post ) {
+				if ( $post instanceof WP_Post && $popup_id === (int) $post->ID ) {
+					$post->post_title = 'Filtered popup title';
+				}
+			}
+
+			return $posts;
+		};
+
+		add_filter( $hook, $filter );
+
+		try {
+			$choices = PUM_Helpers::popup_selectlist( [ 'post__in' => [ $popup_id ] ] );
+		} finally {
+			remove_filter( $hook, $filter );
+		}
+
+		$this->assertSame( [ $popup_id => 'Filtered popup title' ], $choices );
+	}
+
+	/**
+	 * Query-result hooks that can alter popup titles.
+	 *
+	 * @return array<string,array{string}>
+	 */
+	public function query_result_filter_provider() {
+		return [
+			'posts_results' => [ 'posts_results' ],
+			'the_posts'     => [ 'the_posts' ],
+		];
+	}
+
+	/**
+	 * Suppressed query filters retain the normal raw-title fast path.
+	 *
+	 * @return void
+	 */
+	public function test_popup_selectlist_skips_query_result_filters_when_suppressed() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Stored popup title',
+			]
+		);
+		$filter   = static function ( $posts ) {
+			foreach ( $posts as $post ) {
+				if ( $post instanceof WP_Post ) {
+					$post->post_title = 'Filtered popup title';
+				}
+			}
+
+			return $posts;
+		};
+
+		add_filter( 'posts_results', $filter );
+
+		try {
+			$choices = PUM_Helpers::popup_selectlist(
+				[
+					'post__in'         => [ $popup_id ],
+					'suppress_filters' => true,
+				]
+			);
+		} finally {
+			remove_filter( 'posts_results', $filter );
+		}
+
+		$this->assertSame( [ $popup_id => 'Stored popup title' ], $choices );
+	}
+
+	/**
 	 * A cold select list uses one ID query and one title projection query.
 	 *
 	 * @return void

--- a/tests/php/tests/PUM_Helpers_Test.php
+++ b/tests/php/tests/PUM_Helpers_Test.php
@@ -60,6 +60,33 @@ class PUM_Helpers_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Empty status arguments retain WordPress's published-post default.
+	 *
+	 * @return void
+	 */
+	public function test_popup_selectlist_treats_empty_post_status_as_default() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Published choice',
+			]
+		);
+
+		foreach ( [ '', false, [] ] as $post_status ) {
+			$this->assertSame(
+				[ $popup_id => 'Published choice' ],
+				PUM_Helpers::popup_selectlist(
+					[
+						'post__in'    => [ $popup_id ],
+						'post_status' => $post_status,
+					]
+				)
+			);
+		}
+	}
+
+	/**
 	 * Legacy name ordering remains ascending unless explicitly overridden.
 	 *
 	 * @return void
@@ -113,7 +140,7 @@ class PUM_Helpers_Test extends WP_UnitTestCase {
 		wp_cache_flush();
 		get_option( 'posts_per_page' );
 		$query_count = $wpdb->num_queries;
-		$choices    = PUM_Helpers::popup_selectlist( [ 'post__in' => $popup_ids ] );
+		$choices     = PUM_Helpers::popup_selectlist( [ 'post__in' => $popup_ids ] );
 
 		$this->assertCount( 10, $choices );
 		$this->assertSame( 2, $wpdb->num_queries - $query_count );
@@ -145,6 +172,40 @@ class PUM_Helpers_Test extends WP_UnitTestCase {
 				[ $popup_id => 'Translated title' ],
 				PUM_Helpers::popup_selectlist( [ 'post__in' => [ $popup_id ] ] )
 			);
+		} finally {
+			remove_filter( 'popup_maker/popup_title_choices', $filter );
+		}
+	}
+
+	/**
+	 * Title filters run again when a cached select list is requested.
+	 *
+	 * @return void
+	 */
+	public function test_popup_selectlist_reapplies_title_filter_to_cached_ids() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Original title',
+			]
+		);
+		$language = 'English';
+		$filter   = static function ( $titles ) use ( $popup_id, &$language ) {
+			$titles[ $popup_id ] = $language . ' title';
+
+			return $titles;
+		};
+		$args     = [ 'post__in' => [ $popup_id ] ];
+
+		add_filter( 'popup_maker/popup_title_choices', $filter );
+
+		try {
+			$this->assertSame( [ $popup_id => 'English title' ], PUM_Helpers::popup_selectlist( $args ) );
+
+			$language = 'French';
+
+			$this->assertSame( [ $popup_id => 'French title' ], PUM_Helpers::popup_selectlist( $args ) );
 		} finally {
 			remove_filter( 'popup_maker/popup_title_choices', $filter );
 		}

--- a/tests/php/tests/Popups_Repository_Title_Choices_Test.php
+++ b/tests/php/tests/Popups_Repository_Title_Choices_Test.php
@@ -1,0 +1,182 @@
+<?php
+/**
+ * Popup title choices repository tests.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Verify cached popup title lookups.
+ */
+class Popups_Repository_Title_Choices_Test extends WP_UnitTestCase {
+
+	/**
+	 * Requested popup titles are returned without unrelated post types.
+	 *
+	 * @return void
+	 */
+	public function test_get_title_choices_returns_popup_title_map() {
+		$first_popup_id = self::factory()->post->create(
+			[
+				'post_type'  => 'popup',
+				'post_title' => 'First popup title',
+			]
+		);
+		$second_popup_id = self::factory()->post->create(
+			[
+				'post_type'  => 'popup',
+				'post_title' => 'Second popup title',
+			]
+		);
+		$non_popup_id    = self::factory()->post->create(
+			[
+				'post_type'  => 'post',
+				'post_title' => 'Non-popup title',
+			]
+		);
+
+		$titles = \PopupMaker\plugin( 'popups' )->get_title_choices( [ $first_popup_id, $second_popup_id, $non_popup_id ] );
+
+		$this->assertCount( 2, $titles );
+		$this->assertSame( 'First popup title', $titles[ $first_popup_id ] );
+		$this->assertSame( 'Second popup title', $titles[ $second_popup_id ] );
+		$this->assertArrayNotHasKey( $non_popup_id, $titles );
+	}
+
+	/**
+	 * Repeated popup title lookups are served from cache.
+	 *
+	 * @return void
+	 */
+	public function test_get_title_choices_uses_cached_result_on_repeated_call() {
+		global $wpdb;
+
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'  => 'popup',
+				'post_title' => 'Cached popup title',
+			]
+		);
+		$popups   = \PopupMaker\plugin( 'popups' );
+
+		$popups->get_title_choices( [ $popup_id ] );
+		$queries_after_first_call = $wpdb->num_queries;
+		$titles                   = $popups->get_title_choices( [ $popup_id ] );
+
+		$this->assertSame( $queries_after_first_call, $wpdb->num_queries );
+		$this->assertSame( [ $popup_id => 'Cached popup title' ], $titles );
+	}
+
+	/**
+	 * Post updates rotate the cache key and return the current title.
+	 *
+	 * @return void
+	 */
+	public function test_get_title_choices_refreshes_after_popup_title_update() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'  => 'popup',
+				'post_title' => 'Original popup title',
+			]
+		);
+		$popups   = \PopupMaker\plugin( 'popups' );
+
+		$this->assertSame( [ $popup_id => 'Original popup title' ], $popups->get_title_choices( [ $popup_id ] ) );
+
+		wp_update_post(
+			[
+				'ID'         => $popup_id,
+				'post_title' => 'Updated popup title',
+			]
+		);
+
+		$this->assertSame( [ $popup_id => 'Updated popup title' ], $popups->get_title_choices( [ $popup_id ] ) );
+	}
+
+	/**
+	 * Invalid, zero, and duplicate popup IDs are ignored before querying.
+	 *
+	 * @return void
+	 */
+	public function test_get_title_choices_sanitizes_ids() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'  => 'popup',
+				'post_title' => 'Sanitized popup title',
+			]
+		);
+
+		$titles = \PopupMaker\plugin( 'popups' )->get_title_choices(
+			[
+				0,
+				'not-a-popup-id',
+				$popup_id,
+				(string) $popup_id,
+				$popup_id,
+			]
+		);
+
+		$this->assertSame( [ $popup_id => 'Sanitized popup title' ], $titles );
+	}
+
+	/**
+	 * Plain-text consumers receive raw punctuation, not HTML entities.
+	 *
+	 * @return void
+	 */
+	public function test_get_title_choices_preserves_raw_punctuation() {
+		$title    = 'Sales & “Offers” — Today';
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'  => 'popup',
+				'post_title' => $title,
+			]
+		);
+		$raw_title = get_post_field( 'post_title', $popup_id, 'raw' );
+		$filter    = static function ( $filtered_title, $filtered_popup_id ) use ( $popup_id ) {
+			return $popup_id === $filtered_popup_id ? 'Formatted & encoded title' : $filtered_title;
+		};
+
+		add_filter( 'the_title', $filter, 10, 2 );
+
+		try {
+			$titles = \PopupMaker\plugin( 'popups' )->get_title_choices( [ $popup_id ] );
+		} finally {
+			remove_filter( 'the_title', $filter, 10 );
+		}
+
+		$this->assertSame( $raw_title, $titles[ $popup_id ] );
+		$this->assertStringContainsString( '“Offers” — Today', $titles[ $popup_id ] );
+		$this->assertStringNotContainsString( '&#038;', $titles[ $popup_id ] );
+	}
+
+	/**
+	 * Extensions can remap cached raw titles for multilingual display.
+	 *
+	 * @return void
+	 */
+	public function test_get_title_choices_applies_dedicated_filter_to_cached_titles() {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'  => 'popup',
+				'post_title' => 'Original language',
+			]
+		);
+		$popups   = \PopupMaker\plugin( 'popups' );
+		$filter   = static function ( $titles ) use ( $popup_id ) {
+			$titles[ $popup_id ] = 'Translated title';
+
+			return $titles;
+		};
+
+		$this->assertSame( [ $popup_id => 'Original language' ], $popups->get_title_choices( [ $popup_id ] ) );
+
+		add_filter( 'popup_maker/popup_title_choices', $filter );
+
+		try {
+			$this->assertSame( [ $popup_id => 'Translated title' ], $popups->get_title_choices( [ $popup_id ] ) );
+		} finally {
+			remove_filter( 'popup_maker/popup_title_choices', $filter );
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a standalone popup repository helper that projects only popup IDs and raw stored titles.
- Updates popup select lists to request IDs first, then resolve titles through the cached helper.
- Memoizes only ordered popup IDs so multilingual title filtering is reapplied on every select-list call.
- Preserves legacy `posts_results` and `the_posts` title mutations through a compatibility fallback only when non-core query-result filters are active and filtering is not suppressed.
- Preserves status/order aliases, empty-status defaults, raw punctuation, and multilingual customization through the dedicated `popup_maker/popup_title_choices` filter.
- Avoids `the_title` formatting so stored popup titles are not mutated in the normal fast path.

## Query behavior

- Cold select-list fast path is bounded to two SQL queries.
- Warm title-projection reads use the WordPress object cache and execute zero SQL queries.
- WordPress's default comment-status `the_posts` callback does not disable the fast path.
- Explicit `suppress_filters=true` keeps the raw projection path.
- Cache keys rotate with the posts `last_changed` value, so title updates cannot return stale choices.

## Validation

- Current-`develop` full PHPUnit: 1,041 tests, 2,391 assertions, 16 skipped
- Repository-focused PHPUnit: 6 tests, 14 assertions
- Helper-focused PHPUnit: 10 tests, 16 assertions
- PHPCS and changed-file PHPStan: pass
- PHP syntax and `git diff --check`: pass
- Pre-PR ablation confirmed the compatibility fallback is required: removing it fails both `posts_results` and `the_posts` mutation regressions
- The normal two-query regression and suppressed-filter fast-path regression remain green