### PR TITLE
fix(admin): lazy-load readable CSS viewer

### DIFF
--- a/assets/js/src/admin/settings-page/editor.scss
+++ b/assets/js/src/admin/settings-page/editor.scss
@@ -128,6 +128,30 @@
 	}
 }
 
+.pum-css-viewer {
+	&__status.notice {
+		display: block;
+		margin: 12px 0;
+		padding: 8px 12px;
+	}
+
+	&__formats {
+		display: flex;
+		gap: 6px;
+		margin: 16px 0 12px;
+		padding: 0;
+		border: 0;
+	}
+
+	textarea {
+		display: block;
+		width: 100%;
+		min-height: 200px;
+		margin: 4px 0 16px;
+		white-space: pre;
+	}
+}
+
 // License tab content spacing
 #pum-settings_licenses.tab-content {
 	padding-top: 8px;

--- a/assets/js/src/admin/settings-page/index.js
+++ b/assets/js/src/admin/settings-page/index.js
@@ -28,9 +28,90 @@ import './license-key-enhancements';
 			}
 		}
 
-		var $container = $( '#pum-settings-container' ),
-			args = pum_settings_editor.form_args || {},
-			values = pum_settings_editor.current_values || {};
+		const $container = $( '#pum-settings-container' );
+		const settingsEditor = window.pum_settings_editor || {};
+		const args = settingsEditor.form_args || {};
+		const values = settingsEditor.current_values || {};
+		const cssViewerConfig = window.pum_css_viewer || {};
+		let cssViewerStyles = null;
+
+		function cssViewerErrorMessage( response ) {
+			return response &&
+				response.responseJSON &&
+				response.responseJSON.data
+				? response.responseJSON.data.message
+				: cssViewerConfig.i18n.load_error;
+		}
+
+		function showCssViewer( $viewer, styles ) {
+			const $output = $viewer.find( '#pum_style_output' );
+			const $readableButton = $viewer.find(
+				'[data-pum-css-format="readable"]'
+			);
+
+			$viewer.find( '#pum_core_styles' ).val( styles.core.minified );
+			$viewer.find( '#pum_generated_styles' ).val( styles.generated );
+
+			if ( ! styles.readable_available ) {
+				$readableButton
+					.prop( 'disabled', true )
+					.attr( 'title', cssViewerConfig.i18n.readable_unavailable );
+			}
+
+			$viewer
+				.find( '#show_pum_styles' )
+				.attr( 'aria-expanded', 'true' )
+				.hide();
+			$output.removeAttr( 'hidden' ).hide().slideDown();
+		}
+
+		function loadCssViewer( $viewer ) {
+			if ( cssViewerStyles ) {
+				showCssViewer( $viewer, cssViewerStyles );
+				return;
+			}
+
+			const $button = $viewer.find( '#show_pum_styles' );
+			const $status = $viewer.find( '.pum-css-viewer__status' );
+
+			$button
+				.prop( 'disabled', true )
+				.text( cssViewerConfig.i18n.loading );
+			$status.attr( 'hidden', true ).removeClass( 'notice notice-error' );
+
+			$.ajax( {
+				url: cssViewerConfig.ajax_url,
+				method: 'POST',
+				data: {
+					action: 'pum_get_css_styles',
+					nonce: cssViewerConfig.nonce,
+				},
+			} )
+				.done( ( response ) => {
+					if ( ! response.success || ! response.data ) {
+						$status
+							.text( cssViewerConfig.i18n.load_error )
+							.addClass( 'notice notice-error' )
+							.removeAttr( 'hidden' );
+						$button
+							.prop( 'disabled', false )
+							.text( cssViewerConfig.i18n.show );
+						return;
+					}
+
+					cssViewerStyles = response.data;
+					showCssViewer( $viewer, cssViewerStyles );
+				} )
+				.fail( ( response ) => {
+					$status
+						.text( cssViewerErrorMessage( response ) )
+						.addClass( 'notice notice-error' )
+						.removeAttr( 'hidden' );
+					$button
+						.prop( 'disabled', false )
+						.text( cssViewerConfig.i18n.show );
+				} );
+		}
 
 		function updateSaveButtonVisibility() {
 			const $activeMainPanel = $container
@@ -49,8 +130,33 @@ import './license-key-enhancements';
 
 		if ( $container.length ) {
 			$container.find( '.pum-no-js' ).hide();
-			PUM_Admin.forms.render( args, values, $container );
+			window.PUM_Admin.forms.render( args, values, $container );
 			updateSaveButtonVisibility();
+
+			$container.on( 'click', '#show_pum_styles', function () {
+				loadCssViewer( $( this ).closest( '.pum-css-viewer' ) );
+			} );
+
+			$container.on( 'click', '[data-pum-css-format]', function () {
+				if ( ! cssViewerStyles ) {
+					return;
+				}
+
+				const $button = $( this );
+				const format = $button.data( 'pum-css-format' );
+				const $viewer = $button.closest( '.pum-css-viewer' );
+
+				$viewer
+					.find( '#pum_core_styles' )
+					.val( cssViewerStyles.core[ format ] );
+				$viewer
+					.find( '[data-pum-css-format]' )
+					.removeClass( 'button-primary' )
+					.attr( 'aria-pressed', 'false' );
+				$button
+					.addClass( 'button-primary' )
+					.attr( 'aria-pressed', 'true' );
+			} );
 
 			// Check hash on page load
 			switchToHashTab();
@@ -65,7 +171,7 @@ import './license-key-enhancements';
 				function () {
 					setTimeout( () => {
 						if ( window.location.hash ) {
-							history.replaceState(
+							window.history.replaceState(
 								null,
 								null,
 								window.location.pathname +
@@ -79,4 +185,4 @@ import './license-key-enhancements';
 			);
 		}
 	} );
-} )( jQuery );
+} )( window.jQuery );

--- a/bin/verify-release-artifact.js
+++ b/bin/verify-release-artifact.js
@@ -9,6 +9,10 @@ const pluginRoot = 'popup-maker';
 const requiredPaths = [
 	'popup-maker.php',
 	'readme.txt',
+	'dist/assets/site.css',
+	'dist/assets/site-readable.css',
+	'dist/assets/site-rtl.css',
+	'dist/assets/site-rtl-readable.css',
 	'vendor-prefixed/autoload.php',
 ];
 

--- a/classes/Admin/Assets.php
+++ b/classes/Admin/Assets.php
@@ -123,6 +123,20 @@ class PUM_Admin_Assets {
 
 		if ( pum_is_settings_page() ) {
 			wp_enqueue_script( 'pum-admin-settings-page' );
+			wp_localize_script(
+				'pum-admin-settings-page',
+				'pum_css_viewer',
+				[
+					'ajax_url' => admin_url( 'admin-ajax.php' ),
+					'nonce'    => wp_create_nonce( 'pum_get_css_styles' ),
+					'i18n'     => [
+						'loading'              => __( 'Loading Popup Maker CSS…', 'popup-maker' ),
+						'load_error'           => __( 'Popup Maker CSS could not be loaded. Please try again.', 'popup-maker' ),
+						'readable_unavailable' => __( 'Readable CSS is unavailable. Rebuild the plugin assets and try again.', 'popup-maker' ),
+						'show'                 => __( 'Show Popup Maker CSS', 'popup-maker' ),
+					],
+				]
+			);
 		}
 	}
 

--- a/classes/Admin/Settings.php
+++ b/classes/Admin/Settings.php
@@ -751,13 +751,23 @@ class PUM_Admin_Settings {
 
 		$readable_available = false !== $readable_styles;
 		$user_styles        = PUM_AssetCache::generate_font_imports() . PUM_AssetCache::generate_popup_theme_styles() . PUM_AssetCache::generate_popup_styles();
+		$safe_user_styles   = preg_replace(
+			'/(<\/?\s*|&lt;\/?\s*)t\s*e\s*x\s*t\s*a\s*r\s*e\s*a\b/i',
+			'',
+			$user_styles
+		);
+
+		// Fail closed if the historical textarea-breakout hardening cannot run.
+		if ( ! is_string( $safe_user_styles ) ) {
+			$safe_user_styles = '';
+		}
 
 		return [
 			'core'               => [
 				'minified' => $minified_styles,
 				'readable' => $readable_available ? $readable_styles : $minified_styles,
 			],
-			'generated'          => $user_styles,
+			'generated'          => $safe_user_styles,
 			'readable_available' => $readable_available,
 		];
 	}

--- a/classes/Admin/Settings.php
+++ b/classes/Admin/Settings.php
@@ -26,6 +26,7 @@ class PUM_Admin_Settings {
 	public static function init() {
 		add_action( 'admin_notices', [ __CLASS__, 'notices' ] );
 		add_action( 'admin_init', [ __CLASS__, 'save' ] );
+		add_action( 'wp_ajax_pum_get_css_styles', [ __CLASS__, 'ajax_get_css_styles' ] );
 		add_action( 'plugins_loaded', [ __CLASS__, 'maybe_register_legacy_license_operation' ], 100 );
 	}
 
@@ -703,51 +704,85 @@ class PUM_Admin_Settings {
 	 * @return string
 	 */
 	public static function field_pum_styles() {
-		$core_styles = file_get_contents( Popup_Maker::$DIR . 'dist/assets/site' . ( is_rtl() ? '-rtl' : '' ) . '.css' );
-
-		$user_styles = PUM_AssetCache::generate_font_imports() . PUM_AssetCache::generate_popup_theme_styles() . PUM_AssetCache::generate_popup_styles();
-
-		// Prevent both raw and HTML-encoded variations of textarea tag
-		// This regex prevents both HTML and HTML-encoded textarea tags:
-		// (<\/?\s*|&lt;\/?\s*) - Matches either < or &lt; optionally followed by /, with optional whitespace
-		// t\s*e\s*x\s*t\s*a\s*r\s*e\s*a\b - Matches "textarea" with optional whitespace between letters
-		// /i flag makes it case-insensitive
-		$safe_user_styles = preg_replace(
-			'/(<\/?\s*|&lt;\/?\s*)t\s*e\s*x\s*t\s*a\s*r\s*e\s*a\b/i',
-			'',
-			$user_styles
-		);
-
 		ob_start();
 
 		?>
-		<button type="button" id="show_pum_styles" onclick="jQuery('#pum_style_output').slideDown();jQuery(this).hide();"><?php esc_html_e( 'Show Popup Maker CSS', 'popup-maker' ); ?></button>
-		<p class="pum-desc desc"><?php __( "Use this to quickly copy Popup Maker's CSS to your own stylesheet.", 'popup-maker' ); ?></p>
+		<div class="pum-css-viewer">
+			<button type="button" class="button" id="show_pum_styles" aria-controls="pum_style_output" aria-expanded="false"><?php esc_html_e( 'Show Popup Maker CSS', 'popup-maker' ); ?></button>
+			<p class="pum-desc desc"><?php esc_html_e( "Use this to quickly copy Popup Maker's CSS to your own stylesheet.", 'popup-maker' ); ?></p>
+			<p class="pum-css-viewer__status" role="status" aria-live="polite" hidden></p>
 
-		<div id="pum_style_output" style="display:none;">
-			<label for="pum_core_styles"><?php esc_html_e( 'Core Styles', 'popup-maker' ); ?></label> <br />
+			<div id="pum_style_output" hidden>
+				<fieldset class="pum-css-viewer__formats">
+					<legend class="screen-reader-text"><?php esc_html_e( 'Core CSS format', 'popup-maker' ); ?></legend>
+					<button type="button" class="button button-primary" data-pum-css-format="minified" aria-pressed="true"><?php esc_html_e( 'Minified (recommended)', 'popup-maker' ); ?></button>
+					<button type="button" class="button" data-pum-css-format="readable" aria-pressed="false"><?php esc_html_e( 'Readable', 'popup-maker' ); ?></button>
+				</fieldset>
 
-			<textarea id="pum_core_styles" wrap="off" style="white-space: pre; width: 100%; min-height: 200px;" readonly="readonly">
-				<?php
-				// Ignored because this is generated CSS.
-				echo esc_html( $core_styles );
-				?>
-			</textarea>
+				<label for="pum_core_styles"><?php esc_html_e( 'Core Styles', 'popup-maker' ); ?></label>
+				<textarea id="pum_core_styles" wrap="off" readonly="readonly"></textarea>
 
-			<br /> <br />
-
-			<label for="pum_generated_styles"><?php esc_html_e( 'Generated Popup & Popup Theme Styles', 'popup-maker' ); ?></label> <br />
-
-			<textarea id="pum_generated_styles" wrap="off" style="white-space: pre; width: 100%; min-height: 200px;" readonly="readonly">
-				<?php
-				echo esc_html( $safe_user_styles );
-				?>
-			</textarea>
+				<label for="pum_generated_styles"><?php esc_html_e( 'Generated Popup & Popup Theme Styles', 'popup-maker' ); ?></label>
+				<textarea id="pum_generated_styles" wrap="off" readonly="readonly"></textarea>
+			</div>
 		</div>
 
 		<?php
 
 		return ob_get_clean();
+	}
+
+	/**
+	 * Return the CSS displayed by the settings viewer.
+	 *
+	 * @return array{core:array{minified:string,readable:string},generated:string,readable_available:bool}|WP_Error
+	 */
+	public static function get_css_styles() {
+		$asset_name      = 'site' . ( is_rtl() ? '-rtl' : '' );
+		$asset_directory = Popup_Maker::$DIR . 'dist/assets/';
+		$minified_path   = $asset_directory . $asset_name . '.css';
+		$readable_path   = $asset_directory . $asset_name . '-readable.css';
+		$minified_styles = is_readable( $minified_path ) ? file_get_contents( $minified_path ) : false;
+		$readable_styles = is_readable( $readable_path ) ? file_get_contents( $readable_path ) : false;
+
+		if ( false === $minified_styles ) {
+			return new WP_Error( 'pum_missing_core_styles', __( 'Popup Maker core styles could not be loaded.', 'popup-maker' ) );
+		}
+
+		$readable_available = false !== $readable_styles;
+		$user_styles        = PUM_AssetCache::generate_font_imports() . PUM_AssetCache::generate_popup_theme_styles() . PUM_AssetCache::generate_popup_styles();
+
+		return [
+			'core'               => [
+				'minified' => $minified_styles,
+				'readable' => $readable_available ? $readable_styles : $minified_styles,
+			],
+			'generated'          => $user_styles,
+			'readable_available' => $readable_available,
+		];
+	}
+
+	/**
+	 * Load the CSS viewer data only when requested from the settings page.
+	 *
+	 * @return void
+	 */
+	public static function ajax_get_css_styles() {
+		if ( ! check_ajax_referer( 'pum_get_css_styles', 'nonce', false ) ) {
+			wp_send_json_error( [ 'message' => __( 'The CSS viewer request expired. Refresh the page and try again.', 'popup-maker' ) ], 403 );
+		}
+
+		if ( ! current_user_can( \PopupMaker\plugin()->get_permission( 'manage_settings' ) ) ) {
+			wp_send_json_error( [ 'message' => __( 'You do not have permission to view these styles.', 'popup-maker' ) ], 403 );
+		}
+
+		$styles = self::get_css_styles();
+
+		if ( is_wp_error( $styles ) ) {
+			wp_send_json_error( [ 'message' => $styles->get_error_message() ], 500 );
+		}
+
+		wp_send_json_success( $styles );
 	}
 
 	/**

--- a/custom-tools/readable-css-assets-webpack-plugin.js
+++ b/custom-tools/readable-css-assets-webpack-plugin.js
@@ -1,0 +1,66 @@
+const prettier = require( 'prettier' );
+
+const readableAssets = {
+	'site.css': 'site-readable.css',
+	'site-rtl.css': 'site-rtl-readable.css',
+};
+
+/**
+ * Emit readable copies of the production core stylesheets.
+ *
+ * Formatting at build time keeps CSS parsing out of WordPress requests while
+ * ensuring the readable and minified files come from the same compiled asset.
+ */
+class ReadableCssAssetsWebpackPlugin {
+	apply( compiler ) {
+		compiler.hooks.thisCompilation.tap(
+			'ReadableCssAssetsWebpackPlugin',
+			( compilation ) => {
+				compilation.hooks.processAssets.tapPromise(
+					{
+						name: 'ReadableCssAssetsWebpackPlugin',
+						stage: compiler.webpack.Compilation
+							.PROCESS_ASSETS_STAGE_SUMMARIZE,
+					},
+					async () => {
+						for ( const [
+							sourceName,
+							readableName,
+						] of Object.entries( readableAssets ) ) {
+							const asset = compilation.getAsset( sourceName );
+
+							if ( ! asset ) {
+								continue;
+							}
+
+							const css = asset.source
+								.source()
+								.toString()
+								.replace(
+									/\n?\/\*# sourceMappingURL=.*?\*\/\s*$/,
+									''
+								);
+							const readableCss = await prettier.format( css, {
+								parser: 'css',
+								tabWidth: 4,
+								useTabs: true,
+							} );
+							const source =
+								new compiler.webpack.sources.RawSource(
+									readableCss
+								);
+
+							if ( compilation.getAsset( readableName ) ) {
+								compilation.updateAsset( readableName, source );
+							} else {
+								compilation.emitAsset( readableName, source );
+							}
+						}
+					}
+				);
+			}
+		);
+	}
+}
+
+module.exports = ReadableCssAssetsWebpackPlugin;

--- a/tests/php/tests/PUM_Admin_Settings_Test.php
+++ b/tests/php/tests/PUM_Admin_Settings_Test.php
@@ -99,6 +99,38 @@ class PUM_Admin_Settings_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Generated CSS cannot break out of the viewer textarea.
+	 */
+	public function test_get_css_styles_neutralizes_textarea_breakout_sequences() {
+		$minified_path = Popup_Maker::$DIR . 'dist/assets/site.css';
+
+		if ( ! file_exists( $minified_path ) ) {
+			$this->markTestSkipped( 'Dist assets not built in test environment.' );
+		}
+
+		$payload = '/* </TeXtArEa><script>window.pumXss = true;</script><textarea> */'
+			. '/* &lt;/t e x t a r e a&gt;<img src=x onerror=alert(1)>&lt;t e x t a r e a&gt; */';
+		$filter  = static function ( $styles ) use ( $payload ) {
+			return $styles . $payload;
+		};
+
+		add_filter( 'pum_generate_popup_theme_styles', $filter );
+
+		try {
+			$styles = PUM_Admin_Settings::get_css_styles();
+		} finally {
+			remove_filter( 'pum_generate_popup_theme_styles', $filter );
+		}
+
+		$this->assertIsArray( $styles );
+		$this->assertDoesNotMatchRegularExpression(
+			'/(<\/?\s*|&lt;\/?\s*)t\s*e\s*x\s*t\s*a\s*r\s*e\s*a\b/i',
+			$styles['generated']
+		);
+		$this->assertStringContainsString( 'window.pumXss = true;', $styles['generated'] );
+	}
+
+	/**
 	 * Core alone keeps the Go Pro tab without rendering a redundant CTA field.
 	 */
 	public function test_core_alone_uses_hidden_go_pro_placeholder() {

--- a/tests/php/tests/PUM_Admin_Settings_Test.php
+++ b/tests/php/tests/PUM_Admin_Settings_Test.php
@@ -33,13 +33,6 @@ class PUM_Admin_Settings_Test extends WP_UnitTestCase {
 	public function setUp(): void {
 		parent::setUp();
 
-		// Most Admin Settings methods call fields() which reads dist/assets/site.css.
-		// Skip the entire class when dist is not built.
-		$dist_file = dirname( dirname( dirname( __DIR__ ) ) ) . '/dist/assets/site.css';
-		if ( ! file_exists( $dist_file ) ) {
-			$this->markTestSkipped( 'Dist assets not built in test environment.' );
-		}
-
 		// Run as admin so unfiltered_html is available.
 		wp_set_current_user( self::$admin_id );
 	}
@@ -66,6 +59,43 @@ class PUM_Admin_Settings_Test extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'general', $fields, 'Missing general tab.' );
 		$this->assertArrayHasKey( 'privacy', $fields, 'Missing privacy tab.' );
 		$this->assertArrayHasKey( 'misc', $fields, 'Missing misc tab.' );
+	}
+
+	/**
+	 * The settings payload contains only the lazy viewer shell.
+	 */
+	public function test_css_viewer_does_not_embed_styles_eagerly() {
+		$html = PUM_Admin_Settings::field_pum_styles();
+
+		$this->assertStringContainsString( 'id="show_pum_styles"', $html );
+		$this->assertStringContainsString( 'data-pum-css-format="minified"', $html );
+		$this->assertStringContainsString( 'data-pum-css-format="readable"', $html );
+		$this->assertStringContainsString( 'id="pum_core_styles"', $html );
+		$this->assertStringContainsString( 'readonly="readonly"></textarea>', $html );
+		$this->assertLessThan( 3000, strlen( $html ) );
+	}
+
+	/**
+	 * CSS data is loaded from build artifacts only when requested.
+	 */
+	public function test_get_css_styles_returns_built_variants() {
+		$minified_path = Popup_Maker::$DIR . 'dist/assets/site.css';
+
+		if ( ! file_exists( $minified_path ) ) {
+			$this->markTestSkipped( 'Dist assets not built in test environment.' );
+		}
+
+		$readable_path = Popup_Maker::$DIR . 'dist/assets/site-readable.css';
+		$styles        = PUM_Admin_Settings::get_css_styles();
+
+		$this->assertIsArray( $styles );
+		$this->assertSame( file_get_contents( $minified_path ), $styles['core']['minified'] );
+		$this->assertSame( file_exists( $readable_path ), $styles['readable_available'] );
+		$this->assertSame(
+			file_exists( $readable_path ) ? file_get_contents( $readable_path ) : $styles['core']['minified'],
+			$styles['core']['readable']
+		);
+		$this->assertIsString( $styles['generated'] );
 	}
 
 	/**

--- a/tests/unit/bin/verify-release-artifact.test.js
+++ b/tests/unit/bin/verify-release-artifact.test.js
@@ -23,6 +23,10 @@ describe( 'release artifact verifier', () => {
 			for ( const relativePath of [
 				'popup-maker.php',
 				'readme.txt',
+				'dist/assets/site.css',
+				'dist/assets/site-readable.css',
+				'dist/assets/site-rtl.css',
+				'dist/assets/site-rtl-readable.css',
 				'vendor-prefixed/autoload.php',
 			] ) {
 				const filePath = path.join( pluginRoot, relativePath );

--- a/webpack.old.config.js
+++ b/webpack.old.config.js
@@ -2,6 +2,7 @@ const path = require( 'path' );
 const CustomTemplatedPathPlugin = require( '@popup-maker/custom-templated-path-webpack-plugin' );
 const DependencyExtractionWebpackPlugin = require( '@popup-maker/dependency-extraction-webpack-plugin' );
 const CopyWebpackPlugin = require( 'copy-webpack-plugin' );
+const ReadableCssAssetsWebpackPlugin = require( './custom-tools/readable-css-assets-webpack-plugin' );
 // const UnminifiedWebpackPlugin = require( 'unminified-webpack-plugin' );
 
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
@@ -146,6 +147,7 @@ const config = {
 			// combineAssets: true,
 			// combinedOutputFile: '../plugin-assets.php',
 		} ),
+		new ReadableCssAssetsWebpackPlugin(),
 	],
 };
 


### PR DESCRIPTION
## Summary

- lazy-load the Settings > Misc > Assets CSS viewer only when opened
- keep the exact minified core CSS as the recommended default
- add a Readable toggle backed by build-time Prettier-generated LTR/RTL assets
- cache the loaded response client-side and require readable artifacts in release verification

Supersedes #1332.

## Why

The runtime formatter in #1332 added a fragile CSS parser to every settings-page render. The viewer was also eagerly generating theme and popup CSS while hidden. This moves all CSS generation behind the button and produces readable core CSS during the build.

## Performance

Local test site:

- Settings render: ~30.7 ms / 104.7 KB → ~17.3 ms / 75.6 KB
- Initial viewer shell: ~0.05 ms / 1.1 KB
- Lazy CSS generation: ~11.1 ms, only when opened

## Ablation

Removed the separate in-flight request state after proving the disabled button already owns duplicate-click prevention. Kept the response cache because it owns format toggling and prevents a repeat request after a viewer re-render. Removing the readable build artifact or release checks reproduces the missing-readable-output failure.

## Validation

- production build
- 1,005 PHP tests / 2,305 assertions
- 407 JavaScript tests
- changed-file PHPStan
- PHP 7.4 syntax
- JavaScript and SCSS lint
- live minified/readable toggle test
- release artifact verification (995 entries)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a CSS viewer to the settings page with minified and readable display options.
  - CSS styles now load on demand, with loading, error, and unavailable status messages.
  - Added support for readable and RTL-readable stylesheet versions.

- **Bug Fixes**
  - Improved handling of missing stylesheets and protected displayed CSS from breaking the page layout.

- **Tests**
  - Added coverage for CSS loading, fallback behavior, viewer rendering, and required release assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->