### PR TITLE
Harden CSS viewer fallbacks and endpoint tests

### DIFF
--- a/assets/js/src/admin/settings-page/index.js
+++ b/assets/js/src/admin/settings-page/index.js
@@ -33,6 +33,7 @@ import './license-key-enhancements';
 		const args = settingsEditor.form_args || {};
 		const values = settingsEditor.current_values || {};
 		const cssViewerConfig = window.pum_css_viewer || {};
+		const cssViewerI18n = cssViewerConfig.i18n || {};
 		let cssViewerStyles = null;
 
 		function cssViewerErrorMessage( response ) {
@@ -40,7 +41,7 @@ import './license-key-enhancements';
 				response.responseJSON &&
 				response.responseJSON.data
 				? response.responseJSON.data.message
-				: cssViewerConfig.i18n.load_error;
+				: cssViewerI18n.load_error;
 		}
 
 		function showCssViewer( $viewer, styles ) {
@@ -55,7 +56,7 @@ import './license-key-enhancements';
 			if ( ! styles.readable_available ) {
 				$readableButton
 					.prop( 'disabled', true )
-					.attr( 'title', cssViewerConfig.i18n.readable_unavailable );
+					.attr( 'title', cssViewerI18n.readable_unavailable );
 			}
 
 			$viewer
@@ -74,9 +75,7 @@ import './license-key-enhancements';
 			const $button = $viewer.find( '#show_pum_styles' );
 			const $status = $viewer.find( '.pum-css-viewer__status' );
 
-			$button
-				.prop( 'disabled', true )
-				.text( cssViewerConfig.i18n.loading );
+			$button.prop( 'disabled', true ).text( cssViewerI18n.loading );
 			$status.attr( 'hidden', true ).removeClass( 'notice notice-error' );
 
 			$.ajax( {
@@ -90,12 +89,12 @@ import './license-key-enhancements';
 				.done( ( response ) => {
 					if ( ! response.success || ! response.data ) {
 						$status
-							.text( cssViewerConfig.i18n.load_error )
+							.text( cssViewerI18n.load_error )
 							.addClass( 'notice notice-error' )
 							.removeAttr( 'hidden' );
 						$button
 							.prop( 'disabled', false )
-							.text( cssViewerConfig.i18n.show );
+							.text( cssViewerI18n.show );
 						return;
 					}
 
@@ -109,7 +108,7 @@ import './license-key-enhancements';
 						.removeAttr( 'hidden' );
 					$button
 						.prop( 'disabled', false )
-						.text( cssViewerConfig.i18n.show );
+						.text( cssViewerI18n.show );
 				} );
 		}
 

--- a/assets/js/src/admin/settings-page/index.js
+++ b/assets/js/src/admin/settings-page/index.js
@@ -33,7 +33,18 @@ import './license-key-enhancements';
 		const args = settingsEditor.form_args || {};
 		const values = settingsEditor.current_values || {};
 		const cssViewerConfig = window.pum_css_viewer || {};
-		const cssViewerI18n = cssViewerConfig.i18n || {};
+		const configuredCssViewerI18n = cssViewerConfig.i18n || {};
+		const cssViewerI18n = {
+			loading:
+				configuredCssViewerI18n.loading || 'Loading Popup Maker CSS…',
+			load_error:
+				configuredCssViewerI18n.load_error ||
+				'Popup Maker CSS could not be loaded. Please try again.',
+			readable_unavailable:
+				configuredCssViewerI18n.readable_unavailable ||
+				'Readable CSS is unavailable. Rebuild the plugin assets and try again.',
+			show: configuredCssViewerI18n.show || 'Show Popup Maker CSS',
+		};
 		let cssViewerStyles = null;
 
 		function cssViewerErrorMessage( response ) {

--- a/tests/php/tests/PUM_Admin_Settings_Ajax_Test.php
+++ b/tests/php/tests/PUM_Admin_Settings_Ajax_Test.php
@@ -1,0 +1,92 @@
+<?php
+/**
+ * AJAX tests for the Popup Maker CSS viewer.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Verify the CSS viewer endpoint security boundary.
+ *
+ * @group ajax
+ */
+class PUM_Admin_Settings_Ajax_Test extends WP_Ajax_UnitTestCase {
+
+	/**
+	 * Register the plugin endpoint in the AJAX test environment.
+	 *
+	 * The normal test bootstrap does not enter wp-admin, so the admin loader does
+	 * not register this production hook automatically.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		add_action( 'wp_ajax_pum_get_css_styles', [ 'PUM_Admin_Settings', 'ajax_get_css_styles' ] );
+	}
+
+	/**
+	 * Remove the test-registered endpoint.
+	 *
+	 * @return void
+	 */
+	public function tear_down() {
+		remove_action( 'wp_ajax_pum_get_css_styles', [ 'PUM_Admin_Settings', 'ajax_get_css_styles' ] );
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Invalid nonces are rejected before CSS generation.
+	 *
+	 * @return void
+	 */
+	public function test_css_viewer_ajax_rejects_invalid_nonce() {
+		$this->_setRole( 'administrator' );
+		$_POST['nonce'] = 'invalid-css-viewer-nonce';
+
+		$response = $this->dispatch_css_viewer_request();
+
+		$this->assertFalse( $response['success'] );
+		$this->assertSame(
+			'The CSS viewer request expired. Refresh the page and try again.',
+			$response['data']['message']
+		);
+	}
+
+	/**
+	 * Users without settings access cannot load CSS after nonce validation.
+	 *
+	 * @return void
+	 */
+	public function test_css_viewer_ajax_rejects_missing_capability() {
+		$this->_setRole( 'subscriber' );
+		$_POST['nonce'] = wp_create_nonce( 'pum_get_css_styles' );
+
+		$response = $this->dispatch_css_viewer_request();
+
+		$this->assertFalse( $response['success'] );
+		$this->assertSame( 'You do not have permission to view these styles.', $response['data']['message'] );
+	}
+
+	/**
+	 * Dispatch the registered CSS viewer endpoint and decode its response.
+	 *
+	 * @return array{success:bool,data:array{message:string}}
+	 */
+	private function dispatch_css_viewer_request() {
+		$response = [];
+
+		try {
+			$this->_handleAjax( 'pum_get_css_styles' );
+			$this->fail( 'The AJAX endpoint did not terminate the request.' );
+		} catch ( WPAjaxDieContinueException $exception ) {
+			$response = json_decode( $this->_last_response, true );
+		}
+
+		$this->assertIsArray( $response );
+
+		return $response;
+	}
+}

--- a/tests/php/tests/PUM_Admin_Settings_Test.php
+++ b/tests/php/tests/PUM_Admin_Settings_Test.php
@@ -79,23 +79,57 @@ class PUM_Admin_Settings_Test extends WP_UnitTestCase {
 	 * CSS data is loaded from build artifacts only when requested.
 	 */
 	public function test_get_css_styles_returns_built_variants() {
-		$minified_path = Popup_Maker::$DIR . 'dist/assets/site.css';
+		$asset_directory = Popup_Maker::$DIR . 'dist/assets/';
+		$minified_path   = $asset_directory . 'site.css';
+		$readable_path   = $asset_directory . 'site-readable.css';
 
-		if ( ! file_exists( $minified_path ) ) {
+		if ( ! file_exists( $minified_path ) || ! file_exists( $readable_path ) ) {
 			$this->markTestSkipped( 'Dist assets not built in test environment.' );
 		}
 
-		$readable_path = Popup_Maker::$DIR . 'dist/assets/site-readable.css';
-		$styles        = PUM_Admin_Settings::get_css_styles();
+		$styles = PUM_Admin_Settings::get_css_styles();
 
 		$this->assertIsArray( $styles );
 		$this->assertSame( file_get_contents( $minified_path ), $styles['core']['minified'] );
-		$this->assertSame( file_exists( $readable_path ), $styles['readable_available'] );
-		$this->assertSame(
-			file_exists( $readable_path ) ? file_get_contents( $readable_path ) : $styles['core']['minified'],
-			$styles['core']['readable']
-		);
+		$this->assertTrue( $styles['readable_available'] );
+		$this->assertSame( file_get_contents( $readable_path ), $styles['core']['readable'] );
 		$this->assertIsString( $styles['generated'] );
+	}
+
+	/**
+	 * A missing readable artifact falls back to the minified core stylesheet.
+	 */
+	public function test_get_css_styles_uses_minified_readable_fallback() {
+		$original_directory = Popup_Maker::$DIR;
+		$fixture_directory  = get_temp_dir() . 'pum-css-viewer-' . wp_generate_uuid4() . '/';
+		$asset_directory    = $fixture_directory . 'dist/assets/';
+		$minified_path      = $asset_directory . 'site.css';
+		$minified_styles    = '.pum{display:block}';
+
+		$this->assertTrue( wp_mkdir_p( $asset_directory ) );
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Isolated test fixture.
+		$this->assertNotFalse( file_put_contents( $minified_path, $minified_styles ) );
+
+		Popup_Maker::$DIR = $fixture_directory;
+
+		try {
+			$styles = PUM_Admin_Settings::get_css_styles();
+		} finally {
+			Popup_Maker::$DIR = $original_directory;
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Remove only the test-created fixture.
+			unlink( $minified_path );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Remove only test-created empty directories.
+			rmdir( $asset_directory );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Remove only test-created empty directories.
+			rmdir( $fixture_directory . 'dist/' );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Remove only the test-created empty directory.
+			rmdir( $fixture_directory );
+		}
+
+		$this->assertIsArray( $styles );
+		$this->assertFalse( $styles['readable_available'] );
+		$this->assertSame( $styles['core']['minified'], $styles['core']['readable'] );
+		$this->assertSame( $minified_styles, $styles['core']['readable'] );
 	}
 
 	/**

--- a/tests/php/tests/PUM_Admin_Settings_Test.php
+++ b/tests/php/tests/PUM_Admin_Settings_Test.php
@@ -80,10 +80,11 @@ class PUM_Admin_Settings_Test extends WP_UnitTestCase {
 	 */
 	public function test_get_css_styles_returns_built_variants() {
 		$asset_directory = Popup_Maker::$DIR . 'dist/assets/';
-		$minified_path   = $asset_directory . 'site.css';
-		$readable_path   = $asset_directory . 'site-readable.css';
+		$asset_name      = 'site' . ( is_rtl() ? '-rtl' : '' );
+		$minified_path   = $asset_directory . $asset_name . '.css';
+		$readable_path   = $asset_directory . $asset_name . '-readable.css';
 
-		if ( ! file_exists( $minified_path ) || ! file_exists( $readable_path ) ) {
+		if ( ! is_readable( $minified_path ) || ! is_readable( $readable_path ) ) {
 			$this->markTestSkipped( 'Dist assets not built in test environment.' );
 		}
 
@@ -103,27 +104,31 @@ class PUM_Admin_Settings_Test extends WP_UnitTestCase {
 		$original_directory = Popup_Maker::$DIR;
 		$fixture_directory  = get_temp_dir() . 'pum-css-viewer-' . wp_generate_uuid4() . '/';
 		$asset_directory    = $fixture_directory . 'dist/assets/';
-		$minified_path      = $asset_directory . 'site.css';
+		$asset_name         = 'site' . ( is_rtl() ? '-rtl' : '' );
+		$minified_path      = $asset_directory . $asset_name . '.css';
 		$minified_styles    = '.pum{display:block}';
 
-		$this->assertTrue( wp_mkdir_p( $asset_directory ) );
-		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Isolated test fixture.
-		$this->assertNotFalse( file_put_contents( $minified_path, $minified_styles ) );
-
-		Popup_Maker::$DIR = $fixture_directory;
-
 		try {
-			$styles = PUM_Admin_Settings::get_css_styles();
+			$this->assertTrue( wp_mkdir_p( $asset_directory ) );
+			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_file_put_contents -- Isolated test fixture.
+			$this->assertNotFalse( file_put_contents( $minified_path, $minified_styles ) );
+
+			Popup_Maker::$DIR = $fixture_directory;
+			$styles           = PUM_Admin_Settings::get_css_styles();
 		} finally {
 			Popup_Maker::$DIR = $original_directory;
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Remove only the test-created fixture.
-			unlink( $minified_path );
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Remove only test-created empty directories.
-			rmdir( $asset_directory );
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Remove only test-created empty directories.
-			rmdir( $fixture_directory . 'dist/' );
-			// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Remove only the test-created empty directory.
-			rmdir( $fixture_directory );
+
+			if ( is_file( $minified_path ) ) {
+				// phpcs:ignore WordPress.WP.AlternativeFunctions.unlink_unlink -- Remove only the test-created fixture.
+				unlink( $minified_path );
+			}
+
+			foreach ( [ $asset_directory, $fixture_directory . 'dist/', $fixture_directory ] as $directory ) {
+				if ( is_dir( $directory ) ) {
+					// phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_operations_rmdir -- Remove only test-created empty directories.
+					rmdir( $directory );
+				}
+			}
 		}
 
 		$this->assertIsArray( $styles );
@@ -136,9 +141,10 @@ class PUM_Admin_Settings_Test extends WP_UnitTestCase {
 	 * Generated CSS cannot break out of the viewer textarea.
 	 */
 	public function test_get_css_styles_neutralizes_textarea_breakout_sequences() {
-		$minified_path = Popup_Maker::$DIR . 'dist/assets/site.css';
+		$asset_name    = 'site' . ( is_rtl() ? '-rtl' : '' );
+		$minified_path = Popup_Maker::$DIR . 'dist/assets/' . $asset_name . '.css';
 
-		if ( ! file_exists( $minified_path ) ) {
+		if ( ! is_readable( $minified_path ) ) {
 			$this->markTestSkipped( 'Dist assets not built in test environment.' );
 		}
 


### PR DESCRIPTION
## Summary

Follow-up to #1351 that addresses the remaining CSS viewer review findings:

- Guards the nested localized `i18n` configuration before reading viewer labels.
- Adds an explicit minified-only fixture proving the readable view falls back safely when `site-readable.css` is absent.
- Exercises the production AJAX endpoint for invalid nonce and missing-capability rejection.

## Validation

- Rebuilt as the two original commits directly on current `develop`; no merge commits, with an exact range-diff.
- Focused settings PHPUnit: 32 tests, 76 assertions, 3 existing environment skips.
- Focused AJAX PHPUnit: 2 tests, 6 assertions.
- Changed JavaScript syntax, PHP syntax, PHPCS (no errors), and `git diff --check`: pass.
- Exact-head GitHub CI and Codex review are being refreshed for commit `e2b895346b`.

## Scope

This PR contains only the review hardening and regression tests for #1351.
