### PR TITLE
Fix numeric subscriber search test fixture

### DIFF
--- a/tests/php/tests/PUM_DB_Subscribers_Test.php
+++ b/tests/php/tests/PUM_DB_Subscribers_Test.php
@@ -696,16 +696,18 @@ class PUM_DB_Subscribers_Test extends WP_UnitTestCase {
 	public function test_query_numeric_search() {
 		$this->db->create_table();
 
-		$id1 = $this->db->insert( [
+		$id1         = $this->db->insert( [
 			'email'    => 'num1@example.com',
-			'popup_id' => 42,
+			'popup_id' => 0,
 		] );
-		$this->db->insert( [
+		$id2         = $this->db->insert( [
 			'email'    => 'num2@example.com',
-			'popup_id' => 99,
+			'popup_id' => 0,
 		] );
+		$search_value = max( (int) $id1, (int) $id2 ) + 1000;
+		$this->db->update( $id1, [ 'popup_id' => $search_value ] );
 
-		$results = $this->db->query( [ 's' => '42' ] );
+		$results = $this->db->query( [ 's' => (string) $search_value ] );
 		// Numeric search should match popup_id, user_id, and ID columns.
 		$this->assertCount( 1, $results );
 		$this->assertSame( (string) $id1, (string) $results[0]->ID );


### PR DESCRIPTION
## What changed

- Generate a numeric popup ID search value above both subscriber fixture IDs.
- Update the target subscriber with that value before running the search.
- Retain exact result-count and target-ID assertions.

## Why

The previous literal `42` could equal another subscriber's auto-increment ID. Because numeric search covers both `popup_id` and `ID`, that unrelated fixture could produce a second legitimate match and make the strict assertion order-dependent.

Production code is unchanged.

## Ablation evidence

- A deterministic collision was constructed by setting the target subscriber's `popup_id` to the second subscriber's `ID`.
- The former `>= 1` assertion passed while returning two rows.
- Restoring the strict count assertion reproduced the failure: expected one row, received two.
- The final non-colliding fixture passes the exact count and identity assertions.

## Validation

- `PUM_DB_Subscribers_Test`: 60 tests, 130 assertions.
- Focused numeric-search test: 1 test, 2 assertions.
- PHP syntax check passed.
- PHPCS passed with warnings disabled; the file has no errors.
- `git diff --check` passed.
