### PR TITLE
Harden lightweight popup selector queries

### DIFF
--- a/classes/Helpers.php
+++ b/classes/Helpers.php
@@ -429,17 +429,26 @@ class PUM_Helpers {
 			$query_args['update_post_term_cache'] = false;
 			$queried_popup_ids                    = [];
 			$popup_list                           = [];
-			$capture_queried_ids                  = static function ( $posts ) use ( &$queried_popup_ids ) {
+			$outer_query                          = null;
+			$capture_queried_ids                  = static function ( $posts, $query ) use ( &$queried_popup_ids, &$outer_query ) {
+				if ( null === $outer_query ) {
+					$outer_query = $query;
+				}
+
+				if ( $query !== $outer_query ) {
+					return $posts;
+				}
+
 				foreach ( $posts as $post ) {
 					if ( $post instanceof WP_Post ) {
-						$queried_popup_ids[] = (int) $post->ID;
+						$queried_popup_ids[ (int) $post->ID ] = true;
 					}
 				}
 
 				return $posts;
 			};
 
-			add_filter( 'posts_results', $capture_queried_ids, PHP_INT_MIN );
+			add_filter( 'posts_results', $capture_queried_ids, PHP_INT_MIN, 2 );
 
 			try {
 				$filtered_posts = get_posts( $query_args );
@@ -448,7 +457,7 @@ class PUM_Helpers {
 			}
 
 			foreach ( $filtered_posts as $popup ) {
-				if ( ! $popup instanceof WP_Post || ! in_array( (int) $popup->ID, $queried_popup_ids, true ) || 'popup' !== $popup->post_type || ! in_array( $popup->post_status, (array) $post_status, true ) ) {
+				if ( ! $popup instanceof WP_Post || ! isset( $queried_popup_ids[ (int) $popup->ID ] ) || 'popup' !== $popup->post_type || ! in_array( $popup->post_status, (array) $post_status, true ) ) {
 					continue;
 				}
 
@@ -480,11 +489,16 @@ class PUM_Helpers {
 
 		$query_key = md5( wp_json_encode( $query_args ) . ':' . wp_cache_get_last_changed( 'posts' ) . ':' . get_current_user_id() );
 
-		if ( isset( $queries[ $query_key ] ) ) {
+		$cache_query = ! is_array( $post_status );
+
+		if ( $cache_query && isset( $queries[ $query_key ] ) ) {
 			$popup_ids = $queries[ $query_key ];
 		} else {
-			$popup_ids             = array_map( 'absint', get_posts( $query_args ) );
-			$queries[ $query_key ] = $popup_ids;
+			$popup_ids = array_map( 'absint', get_posts( $query_args ) );
+
+			if ( $cache_query ) {
+				$queries[ $query_key ] = $popup_ids;
+			}
 		}
 
 		if ( empty( $popup_ids ) ) {

--- a/classes/Helpers.php
+++ b/classes/Helpers.php
@@ -374,11 +374,17 @@ class PUM_Helpers {
 			return [];
 		}
 
+		$post_status = 'publish';
+
 		if ( isset( $args['post_status'] ) ) {
-			$statuses = array_filter( (array) $args['post_status'] );
+			$statuses = array_values( array_unique( array_filter( array_map( 'sanitize_key', (array) $args['post_status'] ) ) ) );
 
 			if ( ! empty( $statuses ) && ! in_array( 'publish', $statuses, true ) && ! in_array( 'any', $statuses, true ) ) {
 				return [];
+			}
+
+			if ( in_array( 'publish', $statuses, true ) && in_array( 'private', $statuses, true ) ) {
+				$post_status = [ 'publish', 'private' ];
 			}
 		}
 
@@ -402,7 +408,7 @@ class PUM_Helpers {
 			$args,
 			[
 				'post_type'        => 'popup',
-				'post_status'      => 'publish',
+				'post_status'      => $post_status,
 				'posts_per_page'   => -1,
 				'fields'           => 'ids',
 				'no_found_rows'    => true,
@@ -410,6 +416,10 @@ class PUM_Helpers {
 				'suppress_filters' => isset( $args['suppress_filters'] ) ? $args['suppress_filters'] : false,
 			]
 		);
+
+		if ( is_array( $post_status ) ) {
+			$query_args['perm'] = 'readable';
+		}
 
 		$use_filtered_posts = ! $query_args['suppress_filters'] && self::popup_query_result_filters_active();
 
@@ -420,19 +430,37 @@ class PUM_Helpers {
 			$popup_list                           = [];
 
 			foreach ( get_posts( $query_args ) as $popup ) {
-				if ( $popup instanceof WP_Post && 'publish' === get_post_status( $popup->ID ) ) {
-					$popup_list[ (string) $popup->ID ] = (string) $popup->post_title;
+				if ( ! $popup instanceof WP_Post || 'popup' !== $popup->post_type || ! in_array( $popup->post_status, (array) $post_status, true ) ) {
+					continue;
 				}
+
+				if ( 'private' === $popup->post_status && ! current_user_can( 'read_post', $popup->ID ) ) {
+					continue;
+				}
+
+				$popup_list[ (string) $popup->ID ] = (string) $popup->post_title;
 			}
 
 			$filtered_popup_list = apply_filters( 'popup_maker/popup_title_choices', $popup_list );
 
-			return is_array( $filtered_popup_list ) ? $filtered_popup_list : $popup_list;
+			if ( ! is_array( $filtered_popup_list ) ) {
+				return $popup_list;
+			}
+
+			foreach ( $popup_list as $popup_id => $popup_title ) {
+				if ( array_key_exists( $popup_id, $filtered_popup_list ) ) {
+					$popup_list[ $popup_id ] = (string) $filtered_popup_list[ $popup_id ];
+				} else {
+					unset( $popup_list[ $popup_id ] );
+				}
+			}
+
+			return $popup_list;
 		}
 
 		static $queries = [];
 
-		$query_key = md5( wp_json_encode( $query_args ) );
+		$query_key = md5( wp_json_encode( $query_args ) . ':' . wp_cache_get_last_changed( 'posts' ) . ':' . get_current_user_id() );
 
 		if ( isset( $queries[ $query_key ] ) ) {
 			$popup_ids = $queries[ $query_key ];

--- a/classes/Helpers.php
+++ b/classes/Helpers.php
@@ -427,19 +427,16 @@ class PUM_Helpers {
 			$query_args['fields']                 = 'all';
 			$query_args['update_post_meta_cache'] = false;
 			$query_args['update_post_term_cache'] = false;
+			$query_marker                         = wp_unique_id( 'pum_popup_selectlist_' );
+			$query_args['pum_popup_selectlist']   = $query_marker;
 			$queried_popup_ids                    = [];
 			$popup_list                           = [];
-			$outer_query                          = null;
-			$capture_queried_ids                  = static function ( $posts, $query ) use ( &$queried_popup_ids, &$outer_query ) {
-				if ( null === $outer_query ) {
-					$outer_query = $query;
-				}
-
-				if ( $query !== $outer_query ) {
+			$capture_queried_ids                  = static function ( $posts, $query ) use ( &$queried_popup_ids, $query_marker ) {
+				if ( ! $query instanceof WP_Query || $query_marker !== $query->get( 'pum_popup_selectlist' ) ) {
 					return $posts;
 				}
 
-				foreach ( $posts as $post ) {
+				foreach ( (array) $query->posts as $post ) {
 					if ( $post instanceof WP_Post ) {
 						$queried_popup_ids[ (int) $post->ID ] = true;
 					}

--- a/classes/Helpers.php
+++ b/classes/Helpers.php
@@ -427,10 +427,28 @@ class PUM_Helpers {
 			$query_args['fields']                 = 'all';
 			$query_args['update_post_meta_cache'] = false;
 			$query_args['update_post_term_cache'] = false;
+			$queried_popup_ids                    = [];
 			$popup_list                           = [];
+			$capture_queried_ids                  = static function ( $posts ) use ( &$queried_popup_ids ) {
+				foreach ( $posts as $post ) {
+					if ( $post instanceof WP_Post ) {
+						$queried_popup_ids[] = (int) $post->ID;
+					}
+				}
 
-			foreach ( get_posts( $query_args ) as $popup ) {
-				if ( ! $popup instanceof WP_Post || 'popup' !== $popup->post_type || ! in_array( $popup->post_status, (array) $post_status, true ) ) {
+				return $posts;
+			};
+
+			add_filter( 'posts_results', $capture_queried_ids, PHP_INT_MIN );
+
+			try {
+				$filtered_posts = get_posts( $query_args );
+			} finally {
+				remove_filter( 'posts_results', $capture_queried_ids, PHP_INT_MIN );
+			}
+
+			foreach ( $filtered_posts as $popup ) {
+				if ( ! $popup instanceof WP_Post || ! in_array( (int) $popup->ID, $queried_popup_ids, true ) || 'popup' !== $popup->post_type || ! in_array( $popup->post_status, (array) $post_status, true ) ) {
 					continue;
 				}
 

--- a/tests/php/tests/PUM_Helpers_Test.php
+++ b/tests/php/tests/PUM_Helpers_Test.php
@@ -300,6 +300,97 @@ class PUM_Helpers_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Private choices refresh when the current user's capability changes.
+	 *
+	 * @return void
+	 */
+	public function test_popup_selectlist_refreshes_private_choices_after_capability_changes() {
+		$previous_user_id = get_current_user_id();
+		$admin_user_id    = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$user_id          = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$user             = get_user_by( 'id', $user_id );
+		$post_type        = get_post_type_object( 'popup' );
+		$private_cap      = $post_type->cap->read_private_posts;
+		$private_id       = self::factory()->post->create(
+			[
+				'post_author' => $admin_user_id,
+				'post_type'   => 'popup',
+				'post_status' => 'private',
+				'post_title'  => 'Private popup',
+			]
+		);
+		$args             = [ 'post_status' => [ 'publish', 'private' ] ];
+
+		try {
+			$user->add_cap( $private_cap );
+			wp_set_current_user( $user_id );
+			$this->assertSame( [ $private_id => 'Private popup' ], PUM_Helpers::popup_selectlist( $args ) );
+
+			wp_get_current_user()->remove_cap( $private_cap );
+			$this->assertArrayNotHasKey( $private_id, PUM_Helpers::popup_selectlist( $args ) );
+		} finally {
+			$user->remove_cap( $private_cap );
+			wp_set_current_user( $previous_user_id );
+		}
+	}
+
+	/**
+	 * Nested query IDs cannot expand the outer filtered result set.
+	 *
+	 * @return void
+	 */
+	public function test_popup_selectlist_scopes_filtered_ids_to_outer_query() {
+		$requested_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Requested popup',
+			]
+		);
+		$nested_id    = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Nested popup',
+			]
+		);
+		$is_nested    = false;
+		$filter       = static function ( $posts ) use ( $nested_id, &$is_nested ) {
+			if ( $is_nested ) {
+				return $posts;
+			}
+
+			$is_nested   = true;
+			$nested_post = get_posts(
+				[
+					'post_type'        => 'popup',
+					'post_status'      => 'publish',
+					'post__in'         => [ $nested_id ],
+					'posts_per_page'   => 1,
+					'suppress_filters' => false,
+				]
+			);
+			$is_nested   = false;
+
+			if ( isset( $nested_post[0] ) ) {
+				$posts[] = $nested_post[0];
+			}
+
+			return $posts;
+		};
+
+		add_filter( 'posts_results', $filter );
+
+		try {
+			$choices = PUM_Helpers::popup_selectlist( [ 'post__in' => [ $requested_id ] ] );
+		} finally {
+			remove_filter( 'posts_results', $filter );
+		}
+
+		$this->assertSame( [ $requested_id => 'Requested popup' ], $choices );
+	}
+
+	/**
 	 * Suppressed query filters retain the normal raw-title fast path.
 	 *
 	 * @return void

--- a/tests/php/tests/PUM_Helpers_Test.php
+++ b/tests/php/tests/PUM_Helpers_Test.php
@@ -199,11 +199,12 @@ class PUM_Helpers_Test extends WP_UnitTestCase {
 	 * Filtered results cannot inject posts outside the permitted popup set.
 	 *
 	 * @dataProvider invalid_filtered_post_provider
-	 * @param string $post_type   Injected post type.
-	 * @param string $post_status Injected post status.
+	 * @param string $post_type         Injected post type.
+	 * @param string $post_status       Injected post status.
+	 * @param bool   $include_in_request Whether the injected post is requested.
 	 * @return void
 	 */
-	public function test_popup_selectlist_rejects_invalid_filtered_posts( $post_type, $post_status ) {
+	public function test_popup_selectlist_rejects_invalid_filtered_posts( $post_type, $post_status, $include_in_request ) {
 		$popup_id      = self::factory()->post->create(
 			[
 				'post_type'   => 'popup',
@@ -221,8 +222,14 @@ class PUM_Helpers_Test extends WP_UnitTestCase {
 			$injected_args['post_date'] = '2035-01-01 00:00:00';
 		}
 
-		$injected_id = self::factory()->post->create( $injected_args );
-		$filter      = static function ( $posts ) use ( $injected_id ) {
+		$injected_id   = self::factory()->post->create( $injected_args );
+		$requested_ids = [ $popup_id ];
+
+		if ( $include_in_request ) {
+			$requested_ids[] = $injected_id;
+		}
+
+		$filter = static function ( $posts ) use ( $injected_id ) {
 			$posts[] = get_post( $injected_id );
 
 			return $posts;
@@ -231,7 +238,7 @@ class PUM_Helpers_Test extends WP_UnitTestCase {
 		add_filter( 'posts_results', $filter );
 
 		try {
-			$choices = PUM_Helpers::popup_selectlist( [ 'post__in' => [ $popup_id ] ] );
+			$choices = PUM_Helpers::popup_selectlist( [ 'post__in' => $requested_ids ] );
 		} finally {
 			remove_filter( 'posts_results', $filter );
 		}
@@ -242,14 +249,15 @@ class PUM_Helpers_Test extends WP_UnitTestCase {
 	/**
 	 * Invalid posts that a query-result filter may inject.
 	 *
-	 * @return array<string,array{string,string}>
+	 * @return array<string,array{string,string,bool}>
 	 */
 	public function invalid_filtered_post_provider() {
 		return [
-			'published page' => [ 'page', 'publish' ],
-			'draft popup'    => [ 'popup', 'draft' ],
-			'future popup'   => [ 'popup', 'future' ],
-			'private popup'  => [ 'popup', 'private' ],
+			'published page'              => [ 'page', 'publish', true ],
+			'draft popup'                 => [ 'popup', 'draft', true ],
+			'future popup'                => [ 'popup', 'future', true ],
+			'private popup'               => [ 'popup', 'private', true ],
+			'unrequested published popup' => [ 'popup', 'publish', false ],
 		];
 	}
 

--- a/tests/php/tests/PUM_Helpers_Test.php
+++ b/tests/php/tests/PUM_Helpers_Test.php
@@ -379,12 +379,12 @@ class PUM_Helpers_Test extends WP_UnitTestCase {
 			return $posts;
 		};
 
-		add_filter( 'posts_results', $filter );
+		add_filter( 'posts_results', $filter, PHP_INT_MIN );
 
 		try {
 			$choices = PUM_Helpers::popup_selectlist( [ 'post__in' => [ $requested_id ] ] );
 		} finally {
-			remove_filter( 'posts_results', $filter );
+			remove_filter( 'posts_results', $filter, PHP_INT_MIN );
 		}
 
 		$this->assertSame( [ $requested_id => 'Requested popup' ], $choices );

--- a/tests/php/tests/PUM_Helpers_Test.php
+++ b/tests/php/tests/PUM_Helpers_Test.php
@@ -87,6 +87,36 @@ class PUM_Helpers_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Explicit private choices remain capability-gated.
+	 *
+	 * @return void
+	 */
+	public function test_popup_selectlist_includes_only_readable_private_popups() {
+		$previous_user_id = get_current_user_id();
+		$admin_user_id    = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$subscriber_id    = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$private_id       = self::factory()->post->create(
+			[
+				'post_author' => $admin_user_id,
+				'post_type'   => 'popup',
+				'post_status' => 'private',
+				'post_title'  => 'Private popup',
+			]
+		);
+		$args             = [ 'post_status' => [ 'publish', 'private' ] ];
+
+		try {
+			wp_set_current_user( $subscriber_id );
+			$this->assertArrayNotHasKey( $private_id, PUM_Helpers::popup_selectlist( $args ) );
+
+			wp_set_current_user( $admin_user_id );
+			$this->assertSame( [ $private_id => 'Private popup' ], PUM_Helpers::popup_selectlist( $args ) );
+		} finally {
+			wp_set_current_user( $previous_user_id );
+		}
+	}
+
+	/**
 	 * Legacy name ordering remains ascending unless explicitly overridden.
 	 *
 	 * @return void
@@ -166,6 +196,102 @@ class PUM_Helpers_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Filtered results cannot inject posts outside the permitted popup set.
+	 *
+	 * @dataProvider invalid_filtered_post_provider
+	 * @param string $post_type   Injected post type.
+	 * @param string $post_status Injected post status.
+	 * @return void
+	 */
+	public function test_popup_selectlist_rejects_invalid_filtered_posts( $post_type, $post_status ) {
+		$popup_id      = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Published popup',
+			]
+		);
+		$injected_args = [
+			'post_type'   => $post_type,
+			'post_status' => $post_status,
+			'post_title'  => 'Injected post',
+		];
+
+		if ( 'future' === $post_status ) {
+			$injected_args['post_date'] = '2035-01-01 00:00:00';
+		}
+
+		$injected_id = self::factory()->post->create( $injected_args );
+		$filter      = static function ( $posts ) use ( $injected_id ) {
+			$posts[] = get_post( $injected_id );
+
+			return $posts;
+		};
+
+		add_filter( 'posts_results', $filter );
+
+		try {
+			$choices = PUM_Helpers::popup_selectlist( [ 'post__in' => [ $popup_id ] ] );
+		} finally {
+			remove_filter( 'posts_results', $filter );
+		}
+
+		$this->assertSame( [ $popup_id => 'Published popup' ], $choices );
+	}
+
+	/**
+	 * Invalid posts that a query-result filter may inject.
+	 *
+	 * @return array<string,array{string,string}>
+	 */
+	public function invalid_filtered_post_provider() {
+		return [
+			'published page' => [ 'page', 'publish' ],
+			'draft popup'    => [ 'popup', 'draft' ],
+			'future popup'   => [ 'popup', 'future' ],
+			'private popup'  => [ 'popup', 'private' ],
+		];
+	}
+
+	/**
+	 * Filtered private choices remain capability-gated.
+	 *
+	 * @return void
+	 */
+	public function test_popup_selectlist_filters_private_posts_by_capability() {
+		$previous_user_id = get_current_user_id();
+		$admin_user_id    = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		$subscriber_id    = self::factory()->user->create( [ 'role' => 'subscriber' ] );
+		$private_id       = self::factory()->post->create(
+			[
+				'post_author' => $admin_user_id,
+				'post_type'   => 'popup',
+				'post_status' => 'private',
+				'post_title'  => 'Private popup',
+			]
+		);
+		$args             = [ 'post_status' => [ 'publish', 'private' ] ];
+		$filter           = static function ( $posts ) use ( $private_id ) {
+			$posts[] = get_post( $private_id );
+
+			return $posts;
+		};
+
+		add_filter( 'posts_results', $filter );
+
+		try {
+			wp_set_current_user( $subscriber_id );
+			$this->assertArrayNotHasKey( $private_id, PUM_Helpers::popup_selectlist( $args ) );
+
+			wp_set_current_user( $admin_user_id );
+			$this->assertSame( [ $private_id => 'Private popup' ], PUM_Helpers::popup_selectlist( $args ) );
+		} finally {
+			remove_filter( 'posts_results', $filter );
+			wp_set_current_user( $previous_user_id );
+		}
+	}
+
+	/**
 	 * Suppressed query filters retain the normal raw-title fast path.
 	 *
 	 * @return void
@@ -231,6 +357,40 @@ class PUM_Helpers_Test extends WP_UnitTestCase {
 
 		$this->assertCount( 10, $choices );
 		$this->assertSame( 2, $wpdb->num_queries - $query_count );
+
+		foreach ( $popup_ids as $popup_id ) {
+			$this->assertFalse( wp_cache_get( $popup_id, 'posts' ) );
+		}
+	}
+
+	/**
+	 * Same-request query caching refreshes when published popups change.
+	 *
+	 * @return void
+	 */
+	public function test_popup_selectlist_refreshes_cached_ids_after_post_changes() {
+		$args = [ 'orderby' => 'name' ];
+
+		$this->assertSame( [], PUM_Helpers::popup_selectlist( $args ) );
+
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'New popup',
+			]
+		);
+
+		$this->assertSame( [ $popup_id => 'New popup' ], PUM_Helpers::popup_selectlist( $args ) );
+
+		wp_update_post(
+			[
+				'ID'          => $popup_id,
+				'post_status' => 'draft',
+			]
+		);
+
+		$this->assertSame( [], PUM_Helpers::popup_selectlist( $args ) );
 	}
 
 	/**
@@ -296,5 +456,47 @@ class PUM_Helpers_Test extends WP_UnitTestCase {
 		} finally {
 			remove_filter( 'popup_maker/popup_title_choices', $filter );
 		}
+	}
+
+	/**
+	 * Dedicated title filters cannot inject unqueried choices.
+	 *
+	 * @return void
+	 */
+	public function test_popup_selectlist_rejects_title_filter_injections() {
+		$popup_id       = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Published popup',
+			]
+		);
+		$draft_id       = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+				'post_title'  => 'Draft popup',
+			]
+		);
+		$results_filter = static function ( $posts ) {
+			return $posts;
+		};
+		$title_filter   = static function ( $titles ) use ( $draft_id ) {
+			$titles[ $draft_id ] = 'Injected draft';
+
+			return $titles;
+		};
+
+		add_filter( 'posts_results', $results_filter );
+		add_filter( 'popup_maker/popup_title_choices', $title_filter );
+
+		try {
+			$choices = PUM_Helpers::popup_selectlist( [ 'post__in' => [ $popup_id ] ] );
+		} finally {
+			remove_filter( 'popup_maker/popup_title_choices', $title_filter );
+			remove_filter( 'posts_results', $results_filter );
+		}
+
+		$this->assertSame( [ $popup_id => 'Published popup' ], $choices );
 	}
 }


### PR DESCRIPTION
## What changed

- validate filtered popup query results from their existing `WP_Post` properties, rejecting non-popup and unrequested draft/future/private records without per-ID lookup queries
- allow explicitly requested private choices only when WordPress considers them readable
- constrain the dedicated title-choice filter to IDs already approved by the popup query
- key the request-static ID cache by the posts `last_changed` value and current user
- preserve the normal lightweight two-query path without model or post-object hydration

## Why

The shared selector helper is the boundary used by popup-choice consumers. Query-result and title filters can mutate results after `WP_Query` applies its original constraints, while request-static IDs can become stale after post changes or user switches. The helper now owns those validation and cache-context guarantees once for all callers.

## Validation

- full PHPUnit: 1,076 tests, 2,512 assertions, 22 pre-existing skips
- focused helper/repository suite: 24 tests, 52 assertions
- PHPCS: changed production and test files clean
- PHPStan: changed production file clean; full-repo run retains 28 unrelated baseline findings outside this diff
- PHP syntax and `git diff --check`: clean

## Ablation evidence

Each guard was removed and restored independently:

- removing post-type validation admitted a filtered Page
- removing status validation admitted a filtered draft popup
- removing private capability validation admitted an injected unreadable private popup
- removing `perm => readable` exposed private IDs on the normal ID path
- removing filtered-map constraints admitted a draft ID from the title-choice filter
- removing posts `last_changed` kept stale same-request IDs after post changes
- removing current-user context reused subscriber results for an administrator

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popup selection lists by excluding invalid, unauthorized, or inaccessible private entries.
  * Added support for combined published and private popup queries.
  * Ensured lists refresh correctly after popup status changes.
  * Prevented filters from injecting entries that were not part of the original results.
  * Improved handling of invalid title-choice filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->