### PR TITLE
[codex] Move legacy extension guidance into Core

### DIFF
--- a/classes/Plugin/Core.php
+++ b/classes/Plugin/Core.php
@@ -219,6 +219,13 @@ final class Core extends \PopupMaker\Plugin\Container {
 		);
 
 		$this->set(
+			'legacy_extension_catalog',
+			function () {
+				return new \PopupMaker\Services\LegacyExtensionCatalog();
+			}
+		);
+
+		$this->set(
 			'logging',
 			/**
 			 * Get plugin logging.

--- a/classes/Services/LegacyExtensionCatalog.php
+++ b/classes/Services/LegacyExtensionCatalog.php
@@ -1,0 +1,427 @@
+<?php
+/**
+ * Local legacy-extension catalog.
+ *
+ * @package PopupMaker\Services
+ */
+
+namespace PopupMaker\Services;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Detects retired standalone extensions whose features now live in Pro.
+ *
+ * The bundled records are the compatibility boundary for old extensions that
+ * can no longer receive updates. Newer extensions may add local metadata via
+ * the catalog filter, but detection never depends on that registration.
+ */
+class LegacyExtensionCatalog {
+
+	/**
+	 * Get the bundled, backwards-compatible catalog.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	public function get_bundled_items() {
+		return [
+			'popup-analytics'               => [
+				'feature_name'       => 'Advanced Analytics',
+				'plugin_basenames'   => [
+					'popup-maker-popup-analytics/popup-maker-popup-analytics.php',
+				],
+				'license_shortnames' => [ 'popmake_popup_analytics' ],
+				'classes'            => [ 'PUM_Popup_Analytics' ],
+				'constants'          => [ 'POPMAKE_POPUPANALYTICS_VER' ],
+				'priority'           => 100,
+			],
+			'exit-intent-popups'            => [
+				'feature_name'       => 'Exit Intent',
+				'plugin_basenames'   => [
+					'popup-maker-exit-intent-popups/popup-maker-exit-intent-popups.php',
+				],
+				'license_shortnames' => [ 'popmake_exit_intent_popups' ],
+				'classes'            => [ 'PUM_EIP' ],
+				'priority'           => 95,
+			],
+			'advanced-targeting-conditions' => [
+				'feature_name'       => 'Advanced Targeting',
+				'plugin_basenames'   => [
+					'popup-maker-advanced-targeting-conditions/popup-maker-advanced-targeting-conditions.php',
+				],
+				'license_shortnames' => [ 'popmake_advanced_targeting_conditions' ],
+				'classes'            => [ 'PUM_ATC' ],
+				'priority'           => 90,
+			],
+			'scheduling'                    => [
+				'feature_name'       => 'Scheduling',
+				'plugin_basenames'   => [
+					'popup-maker-scheduling/popup-maker-scheduling.php',
+					'pum-scheduling/pum-scheduling.php',
+				],
+				'license_shortnames' => [ 'popmake_scheduling' ],
+				'classes'            => [ 'PUM_Scheduling' ],
+				'priority'           => 85,
+			],
+			'scroll-triggered-popups'       => [
+				'feature_name'       => 'Scroll Triggers',
+				'plugin_basenames'   => [
+					'popup-maker-scroll-triggered-popups/popup-maker-scroll-triggered-popups.php',
+					'popup-maker-scroll-triggers/popup-maker-scroll-triggered-popups.php',
+				],
+				'license_shortnames' => [ 'popmake_scroll_triggered_popups' ],
+				'classes'            => [ 'PUM_STP' ],
+				'priority'           => 80,
+			],
+			'advanced-theme-builder'        => [
+				'feature_name'       => 'Theme Builder',
+				'plugin_basenames'   => [
+					'popup-maker-advanced-theme-builder/popup-maker-advanced-theme-builder.php',
+				],
+				'license_shortnames' => [ 'popmake_advanced_theme_builder' ],
+				'classes'            => [ 'PUM_ATB' ],
+				'priority'           => 75,
+			],
+			'forced-interaction'            => [
+				'feature_name'       => 'Forced Interaction',
+				'plugin_basenames'   => [
+					'popup-maker-forced-interaction/popup-maker-forced-interaction.php',
+				],
+				'license_shortnames' => [ 'popmake_forced_interaction' ],
+				'classes'            => [ 'PUM_Forced_Interaction' ],
+				'priority'           => 70,
+			],
+			'terms-conditions-popups'       => [
+				'feature_name'       => 'Terms & Conditions',
+				'plugin_basenames'   => [
+					'popup-maker-terms-conditions-popups/popup-maker-terms-conditions-popups.php',
+				],
+				'license_shortnames' => [
+					'popmake_terms__conditions_popups',
+					'popmake_terms_conditions_popups',
+				],
+				'classes'            => [ 'PUM_TC' ],
+				'priority'           => 65,
+			],
+		];
+	}
+
+	/**
+	 * Get the bundled catalog plus locally registered metadata.
+	 *
+	 * Bundled entries cannot be removed by a broken registration callback.
+	 * Extensions may enhance an existing record or append another known Pro
+	 * feature, and every value is normalized before it is used for detection.
+	 *
+	 * @return array<string,array<string,mixed>>
+	 */
+	public function get_items() {
+		$bundled  = $this->get_bundled_items();
+		$filtered = apply_filters( 'popup_maker/legacy_extension_catalog', $bundled );
+		$items    = $bundled;
+
+		if ( is_array( $filtered ) ) {
+			foreach ( $filtered as $slug => $item ) {
+				if ( ! is_string( $slug ) || sanitize_key( $slug ) !== $slug || ! is_array( $item ) ) {
+					continue;
+				}
+
+				$items[ $slug ] = isset( $items[ $slug ] )
+					? $this->merge_item( $items[ $slug ], $item )
+					: $item;
+			}
+		}
+
+		$normalized = [];
+		foreach ( $items as $slug => $item ) {
+			$item = $this->normalize_item( $item );
+			if ( null !== $item ) {
+				$normalized[ $slug ] = $item;
+			}
+		}
+
+		return $normalized;
+	}
+
+	/**
+	 * Get detected local extension context.
+	 *
+	 * Optional arguments make the local-only state machine deterministic in
+	 * tests. Runtime calls read the same WordPress options and installed plugin
+	 * registry already present on the site.
+	 *
+	 * @param array<string,array<string,mixed>>|null $plugins                Installed plugin headers.
+	 * @param string[]|null                          $active_plugins         Site-active plugin basenames.
+	 * @param array<string,mixed>|string[]|null      $network_active_plugins Network-active basenames.
+	 * @param array<string,mixed>|null               $settings               Popup Maker settings.
+	 * @param array<string,mixed>|null               $license_statuses       License status by shortname.
+	 *
+	 * @return array<int,array<string,mixed>>
+	 */
+	public function get_installed_items( $plugins = null, $active_plugins = null, $network_active_plugins = null, $settings = null, $license_statuses = null ) {
+		if ( null === $plugins ) {
+			$this->load_plugin_dependencies();
+			$plugins = get_plugins();
+		}
+
+		$plugins                = is_array( $plugins ) ? $plugins : [];
+		$active_plugins         = null === $active_plugins
+			? (array) get_option( 'active_plugins', [] )
+			: (array) $active_plugins;
+		$network_active_plugins = null === $network_active_plugins
+			? (array) get_site_option( 'active_sitewide_plugins', [] )
+			: (array) $network_active_plugins;
+		$network_active_plugins = array_values(
+			array_unique(
+				array_merge(
+					array_keys( $network_active_plugins ),
+					array_values( $network_active_plugins )
+				)
+			)
+		);
+		$settings               = null === $settings ? get_option( 'popmake_settings', [] ) : $settings;
+		$settings               = is_array( $settings ) ? $settings : [];
+
+		$installed = [];
+		foreach ( $this->get_items() as $slug => $item ) {
+			$basename = $this->find_installed_basename( $item, $plugins );
+			$loaded   = $this->is_loaded( $item );
+
+			if ( '' === $basename && ! $loaded ) {
+				continue;
+			}
+
+			$site_active    = '' !== $basename && in_array( $basename, $active_plugins, true );
+			$network_active = '' !== $basename && in_array( $basename, $network_active_plugins, true );
+
+			$installed[] = array_merge(
+				$item,
+				[
+					'slug'            => $slug,
+					'plugin_basename' => $basename,
+					'active'          => $site_active || $network_active || $loaded,
+					'network_active'  => $network_active,
+					'license_state'   => $this->get_license_state( $item, $settings, $license_statuses ),
+				]
+			);
+		}
+
+		usort(
+			$installed,
+			static function ( $left, $right ) {
+				if ( ! empty( $left['active'] ) !== ! empty( $right['active'] ) ) {
+					return ! empty( $left['active'] ) ? -1 : 1;
+				}
+
+				return (int) $right['priority'] <=> (int) $left['priority'];
+			}
+		);
+
+		return $installed;
+	}
+
+	/**
+	 * Resolve an exact installed basename for a catalog record.
+	 *
+	 * @param array<string,mixed>               $item    Catalog record.
+	 * @param array<string,array<string,mixed>> $plugins Installed plugins.
+	 *
+	 * @return string
+	 */
+	public function find_installed_basename( $item, $plugins ) {
+		if ( ! is_array( $item ) || ! is_array( $plugins ) ) {
+			return '';
+		}
+
+		foreach ( (array) ( $item['plugin_basenames'] ?? [] ) as $basename ) {
+			if ( is_string( $basename ) && isset( $plugins[ $basename ] ) ) {
+				return $basename;
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Resolve locally stored legacy license state for a catalog record.
+	 *
+	 * @param array<string,mixed>      $item             Catalog record.
+	 * @param array<string,mixed>      $settings         Popup Maker settings.
+	 * @param array<string,mixed>|null $license_statuses Optional statuses by shortname.
+	 *
+	 * @return 'valid'|'expired'|'inactive'|'missing'
+	 */
+	public function get_license_state( $item, $settings = [], $license_statuses = null ) {
+		$has_key     = false;
+		$has_expired = false;
+
+		foreach ( (array) ( $item['license_shortnames'] ?? [] ) as $shortname ) {
+			$key    = isset( $settings[ $shortname . '_license_key' ] )
+				? trim( (string) $settings[ $shortname . '_license_key' ] )
+				: '';
+			$status = is_array( $license_statuses ) && array_key_exists( $shortname, $license_statuses )
+				? $license_statuses[ $shortname ]
+				: get_option( $shortname . '_license_active' );
+			$status = is_object( $status ) ? get_object_vars( $status ) : $status;
+
+			if ( '' !== $key ) {
+				$has_key = true;
+			}
+
+			if ( is_string( $status ) ) {
+				if ( '' !== $key && 'valid' === $status ) {
+					return 'valid';
+				}
+				$has_expired = $has_expired || 'expired' === $status;
+				continue;
+			}
+
+			if ( ! is_array( $status ) ) {
+				continue;
+			}
+
+			if (
+				'' !== $key
+				&& ! empty( $status['success'] )
+				&& isset( $status['license'] )
+				&& 'valid' === $status['license']
+			) {
+				return 'valid';
+			}
+
+			$has_expired = $has_expired
+				|| ( isset( $status['error'] ) && 'expired' === $status['error'] )
+				|| ( isset( $status['license'] ) && 'expired' === $status['license'] );
+		}
+
+		if ( $has_expired ) {
+			return 'expired';
+		}
+
+		return $has_key ? 'inactive' : 'missing';
+	}
+
+	/**
+	 * Merge extension metadata without discarding bundled identifiers.
+	 *
+	 * @param array<string,mixed> $base     Bundled record.
+	 * @param array<string,mixed> $metadata Registered metadata.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function merge_item( $base, $metadata ) {
+		$merged = array_merge( $base, $metadata );
+
+		foreach ( [ 'plugin_basenames', 'license_shortnames', 'classes', 'constants' ] as $key ) {
+			$merged[ $key ] = array_values(
+				array_unique(
+					array_merge(
+						(array) ( $base[ $key ] ?? [] ),
+						(array) ( $metadata[ $key ] ?? [] )
+					)
+				)
+			);
+		}
+
+		return $merged;
+	}
+
+	/**
+	 * Normalize a local metadata record.
+	 *
+	 * @param array<string,mixed> $item Candidate record.
+	 * @return array<string,mixed>|null
+	 */
+	private function normalize_item( $item ) {
+		$feature_name = isset( $item['feature_name'] ) ? trim( wp_strip_all_tags( (string) $item['feature_name'] ) ) : '';
+		$basenames    = $this->normalize_basenames( $item['plugin_basenames'] ?? [] );
+
+		if ( '' === $feature_name || empty( $basenames ) ) {
+			return null;
+		}
+
+		return [
+			'feature_name'       => $feature_name,
+			'plugin_basenames'   => $basenames,
+			'license_shortnames' => $this->normalize_identifiers( $item['license_shortnames'] ?? [], '/^popmake_[a-z0-9_]+$/' ),
+			'classes'            => $this->normalize_identifiers( $item['classes'] ?? [], '/^[A-Za-z_\\\\][A-Za-z0-9_\\\\]*$/' ),
+			'constants'          => $this->normalize_identifiers( $item['constants'] ?? [], '/^[A-Z][A-Z0-9_]*$/' ),
+			'priority'           => isset( $item['priority'] ) ? (int) $item['priority'] : 50,
+		];
+	}
+
+	/**
+	 * Normalize exact plugin basenames.
+	 *
+	 * @param mixed $basenames Candidate basenames.
+	 * @return string[]
+	 */
+	private function normalize_basenames( $basenames ) {
+		$out = [];
+		foreach ( (array) $basenames as $basename ) {
+			if (
+				is_string( $basename )
+				&& '' !== $basename
+				&& false !== strpos( $basename, '/' )
+				&& false === strpos( $basename, '..' )
+				&& false === strpos( $basename, '\\' )
+				&& '/' !== substr( $basename, 0, 1 )
+			) {
+				$out[] = $basename;
+			}
+		}
+
+		return array_values( array_unique( $out ) );
+	}
+
+	/**
+	 * Normalize class, constant, or option-prefix identifiers.
+	 *
+	 * @param mixed  $identifiers Candidate identifiers.
+	 * @param string $pattern     Validation pattern.
+	 * @return string[]
+	 */
+	private function normalize_identifiers( $identifiers, $pattern ) {
+		$out = [];
+		foreach ( (array) $identifiers as $identifier ) {
+			if ( is_string( $identifier ) && preg_match( $pattern, $identifier ) ) {
+				$out[] = $identifier;
+			}
+		}
+
+		return array_values( array_unique( $out ) );
+	}
+
+	/**
+	 * Whether a stable identifier proves the extension is currently loaded.
+	 *
+	 * @param array<string,mixed> $item Catalog record.
+	 * @return bool
+	 */
+	private function is_loaded( $item ) {
+		foreach ( (array) ( $item['classes'] ?? [] ) as $class ) {
+			if ( class_exists( $class, false ) ) {
+				return true;
+			}
+		}
+
+		foreach ( (array) ( $item['constants'] ?? [] ) as $constant ) {
+			if ( defined( $constant ) ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Load WordPress plugin helpers.
+	 *
+	 * @return void
+	 */
+	private function load_plugin_dependencies() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+	}
+}

--- a/classes/Services/Notifications/LegacyExtensionGuidance.php
+++ b/classes/Services/Notifications/LegacyExtensionGuidance.php
@@ -1,0 +1,393 @@
+<?php
+/**
+ * Legacy extension to Pro guidance.
+ *
+ * @package PopupMaker\Services\Notifications
+ */
+
+namespace PopupMaker\Services\Notifications;
+
+use PopupMaker\Base\Service;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Adds one local, aggregated notice for installed retired extensions.
+ */
+class LegacyExtensionGuidance extends Service implements Provider {
+
+	/**
+	 * Canonical Pro plugin basename.
+	 *
+	 * @var string
+	 */
+	const PRO_BASENAME = 'popup-maker-pro/popup-maker-pro.php';
+
+	/**
+	 * Wire local notification behavior.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		$this->remove_legacy_framework_offers();
+		add_filter( 'pum_alert_list', [ $this, 'register_alert' ], 14 );
+	}
+
+	/**
+	 * Register the appropriate locally generated alert.
+	 *
+	 * @param array<int,array<string,mixed>> $alerts Existing alerts.
+	 * @return array<int,array<string,mixed>>
+	 */
+	public function register_alert( $alerts ) {
+		if ( ! is_array( $alerts ) ) {
+			$alerts = [];
+		}
+
+		if ( ! current_user_can( $this->container->get_permission( 'manage_settings' ) ) ) {
+			return $alerts;
+		}
+
+		$extensions = $this->container->get( 'legacy_extension_catalog' )->get_installed_items();
+		if ( empty( $extensions ) ) {
+			return $alerts;
+		}
+
+		$pro_state = $this->get_pro_plugin_state();
+		$alert     = $this->build_alert( $extensions, $pro_state, $this->get_local_pro_license_state( $pro_state ) );
+
+		if ( null !== $alert ) {
+			$alerts[] = $alert;
+		}
+
+		return $alerts;
+	}
+
+	/**
+	 * Build the state-specific, aggregated alert.
+	 *
+	 * @param array<int,array<string,mixed>>         $extensions        Installed legacy extensions.
+	 * @param 'active'|'inactive'|'missing'          $pro_state         Local Pro plugin state.
+	 * @param 'valid'|'expired'|'inactive'|'missing' $pro_license_state Local Pro license state.
+	 *
+	 * @return array<string,mixed>|null
+	 */
+	public function build_alert( $extensions, $pro_state, $pro_license_state ) {
+		if ( empty( $extensions ) ) {
+			return null;
+		}
+
+		$features       = $this->format_feature_names( wp_list_pluck( $extensions, 'feature_name' ) );
+		$has_active     = in_array( true, wp_list_pluck( $extensions, 'active' ), true );
+		$has_valid      = in_array( 'valid', wp_list_pluck( $extensions, 'license_state' ), true );
+		$base_priority  = $has_active ? 72 : 45;
+		$action         = null;
+		$notice_variant = '';
+
+		if ( 'active' === $pro_state ) {
+			if ( 'expired' !== $pro_license_state ) {
+				return null;
+			}
+
+			$notice_variant = 'renew';
+			$title          = __( 'Review your Popup Maker Pro license', 'popup-maker' );
+			$message        = sprintf(
+				/* translators: %s: comma-separated feature names. */
+				__( 'Your installed legacy features (%s) are already included in Popup Maker Pro. The locally stored Pro license is expired; review it to keep updates and support current.', 'popup-maker' ),
+				esc_html( $features )
+			);
+			$subtitle      = __( 'Pro is active; license needs attention', 'popup-maker' );
+			$action        = [
+				'text'    => __( 'Review Pro license', 'popup-maker' ),
+				'type'    => 'link',
+				'action'  => '',
+				'href'    => $this->get_license_settings_url(),
+				'primary' => true,
+			];
+			$base_priority = max( 76, $base_priority );
+		} elseif ( 'inactive' === $pro_state ) {
+			$activation_url = $this->get_pro_activation_url();
+			if ( '' === $activation_url ) {
+				return null;
+			}
+
+			$notice_variant = 'activate';
+			$title          = __( 'Activate Popup Maker Pro', 'popup-maker' );
+			$message        = sprintf(
+				/* translators: %s: comma-separated feature names. */
+				__( 'Popup Maker Pro is installed but inactive. Activate it to use %s from the single maintained Pro plugin.', 'popup-maker' ),
+				esc_html( $features )
+			);
+			$subtitle      = __( 'Pro is already installed', 'popup-maker' );
+			$action        = [
+				'text'    => __( 'Activate Popup Maker Pro', 'popup-maker' ),
+				'type'    => 'link',
+				'action'  => '',
+				'href'    => $activation_url,
+				'primary' => true,
+			];
+			$base_priority = max( 78, $base_priority );
+		} elseif ( $has_valid ) {
+			$notice_variant = 'consolidate';
+			$title          = __( 'Your legacy extensions are available in Popup Maker Pro', 'popup-maker' );
+			$message        = sprintf(
+				/* translators: %s: comma-separated feature names. */
+				__( 'You currently use %s through standalone legacy extensions. Popup Maker Pro combines these features in one maintained plugin when you are ready to consolidate.', 'popup-maker' ),
+				esc_html( $features )
+			);
+			$subtitle = __( 'Evergreen consolidation guidance', 'popup-maker' );
+			$action   = $this->get_pro_page_action();
+		} else {
+			$notice_variant = 'included';
+			$title          = __( 'These legacy features are included in Popup Maker Pro', 'popup-maker' );
+			$message        = sprintf(
+				/* translators: %s: comma-separated feature names. */
+				__( 'We found %s installed as legacy extensions. These features are now included in the maintained Popup Maker Pro plugin.', 'popup-maker' ),
+				esc_html( $features )
+			);
+			$subtitle = __( 'Based on plugins installed on this site', 'popup-maker' );
+			$action   = $this->get_pro_page_action();
+		}
+
+		return [
+			'code'           => 'pm_legacy_extensions_to_pro_' . $notice_variant . '_v1',
+			'category'       => 'recommendation',
+			'priority'       => $base_priority,
+			'dismissible'    => true,
+			'display_inline' => true,
+			'type'           => 'info',
+			'title'          => $title,
+			'message'        => $message,
+			'subtitle'       => $subtitle,
+			'icon'           => 'awards',
+			'actions'        => [
+				$action,
+				[
+					'text'   => __( 'Dismiss', 'popup-maker' ),
+					'type'   => 'action',
+					'action' => 'dismiss',
+				],
+			],
+		];
+	}
+
+	/**
+	 * Remove offer callbacks registered by already-shipped framework copies.
+	 *
+	 * Those copies cannot be updated on sites with expired extension licenses.
+	 * Removing only the known ProUpsell controller callbacks lets a Core update
+	 * take ownership without disabling unrelated Core recommendations.
+	 *
+	 * @return void
+	 */
+	public function remove_legacy_framework_offers() {
+		global $wp_filter;
+
+		$hooks = [
+			'admin_notices',
+			'admin_enqueue_scripts',
+			'plugin_row_meta',
+			'pum_alert_list',
+		];
+
+		foreach ( $hooks as $hook_name ) {
+			if ( empty( $wp_filter[ $hook_name ] ) || ! $wp_filter[ $hook_name ] instanceof \WP_Hook ) {
+				continue;
+			}
+
+			foreach ( $wp_filter[ $hook_name ]->callbacks as $priority => $callbacks ) {
+				foreach ( $callbacks as $callback ) {
+					$function = $callback['function'] ?? null;
+					if ( ! $this->is_legacy_framework_offer_callback( $function ) ) {
+						continue;
+					}
+
+					remove_filter( $hook_name, $function, $priority );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Identify only Extension Framework ProUpsell callbacks.
+	 *
+	 * @param mixed $callback WordPress callback.
+	 * @return bool
+	 */
+	private function is_legacy_framework_offer_callback( $callback ) {
+		if ( ! is_array( $callback ) || ! isset( $callback[0], $callback[1] ) || ! is_object( $callback[0] ) ) {
+			return false;
+		}
+
+		$class   = get_class( $callback[0] );
+		$methods = [ 'admin_notice', 'enqueue_dismiss_script', 'plugin_row_meta', 'register_panel_notification' ];
+
+		return in_array( $callback[1], $methods, true )
+			&& (bool) preg_match( '/\\\\ExtensionFramework\\\\Controllers\\\\Admin\\\\ProUpsell$/', $class );
+	}
+
+	/**
+	 * Resolve Pro's local plugin state.
+	 *
+	 * @return 'active'|'inactive'|'missing'
+	 */
+	private function get_pro_plugin_state() {
+		$this->load_plugin_dependencies();
+
+		$plugins = get_plugins();
+		if ( ! isset( $plugins[ self::PRO_BASENAME ] ) ) {
+			return 'missing';
+		}
+
+		$is_active = is_plugin_active( self::PRO_BASENAME )
+			|| ( is_multisite() && is_plugin_active_for_network( self::PRO_BASENAME ) );
+
+		return $is_active ? 'active' : 'inactive';
+	}
+
+	/**
+	 * Read Pro license state only from existing local options.
+	 *
+	 * @param 'active'|'inactive'|'missing' $pro_state Pro plugin state.
+	 * @return 'valid'|'expired'|'inactive'|'missing'
+	 */
+	private function get_local_pro_license_state( $pro_state ) {
+		if ( 'missing' === $pro_state ) {
+			return 'missing';
+		}
+
+		$data   = get_option( 'popup_maker_license', [] );
+		$data   = is_array( $data ) ? $data : [];
+		$key    = isset( $data['key'] ) ? trim( (string) $data['key'] ) : '';
+		$status = isset( $data['status'] ) && is_array( $data['status'] ) ? $data['status'] : [];
+
+		if ( empty( $status ) ) {
+			$legacy_status = get_option( 'popup_maker_pro_license_active' );
+			$status        = is_object( $legacy_status ) ? get_object_vars( $legacy_status ) : $legacy_status;
+		}
+
+		if ( is_string( $status ) ) {
+			if ( 'expired' === $status ) {
+				return 'expired';
+			}
+			return '' !== $key && 'valid' === $status ? 'valid' : ( '' !== $key ? 'inactive' : 'missing' );
+		}
+
+		$status = is_array( $status ) ? $status : [];
+		if (
+			( isset( $status['error'] ) && 'expired' === $status['error'] )
+			|| ( isset( $status['license'] ) && 'expired' === $status['license'] )
+		) {
+			return 'expired';
+		}
+
+		if ( '' !== $key && ! empty( $status['success'] ) && isset( $status['license'] ) && 'valid' === $status['license'] ) {
+			return 'valid';
+		}
+
+		return '' !== $key ? 'inactive' : 'missing';
+	}
+
+	/**
+	 * Build a nonce-protected activation URL for the installed Pro plugin.
+	 *
+	 * @return string
+	 */
+	private function get_pro_activation_url() {
+		if ( is_multisite() ) {
+			if ( ! current_user_can( 'manage_network_plugins' ) ) {
+				return '';
+			}
+
+			$url = add_query_arg(
+				[
+					'action'      => 'activate',
+					'plugin'      => self::PRO_BASENAME,
+					'networkwide' => 1,
+				],
+				network_admin_url( 'plugins.php' )
+			);
+		} else {
+			if ( ! current_user_can( 'activate_plugins' ) ) {
+				return '';
+			}
+
+			$url = add_query_arg(
+				[
+					'action' => 'activate',
+					'plugin' => self::PRO_BASENAME,
+				],
+				admin_url( 'plugins.php' )
+			);
+		}
+
+		return wp_nonce_url( $url, 'activate-plugin_' . self::PRO_BASENAME );
+	}
+
+	/**
+	 * Local Popup Maker license settings URL.
+	 *
+	 * @return string
+	 */
+	private function get_license_settings_url() {
+		return admin_url( 'edit.php?post_type=popup&page=pum-settings#go-pro' );
+	}
+
+	/**
+	 * Public Pro page action with static UTM parameters.
+	 *
+	 * @return array<string,mixed>
+	 */
+	private function get_pro_page_action() {
+		return [
+			'text'     => __( 'See what is included in Pro', 'popup-maker' ),
+			'type'     => 'link',
+			'action'   => '',
+			'href'     => \PopupMaker\generate_upgrade_url( 'legacy-extension-guidance', 'legacy-to-pro', 'notification' ),
+			'primary'  => true,
+			'external' => true,
+		];
+	}
+
+	/**
+	 * Format a translated human-readable feature list.
+	 *
+	 * @param string[] $features Feature names.
+	 * @return string
+	 */
+	private function format_feature_names( $features ) {
+		$features = array_values( array_unique( array_filter( array_map( 'strval', $features ) ) ) );
+
+		if ( count( $features ) < 2 ) {
+			return isset( $features[0] ) ? $features[0] : '';
+		}
+
+		$last = array_pop( $features );
+		if ( 1 === count( $features ) ) {
+			return sprintf(
+				/* translators: 1: first feature name, 2: second feature name. */
+				__( '%1$s and %2$s', 'popup-maker' ),
+				$features[0],
+				$last
+			);
+		}
+
+		return sprintf(
+			/* translators: 1: comma-separated feature names, 2: final feature name. */
+			__( '%1$s, and %2$s', 'popup-maker' ),
+			implode( ', ', $features ),
+			$last
+		);
+	}
+
+	/**
+	 * Load WordPress plugin helpers.
+	 *
+	 * @return void
+	 */
+	private function load_plugin_dependencies() {
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+	}
+}

--- a/classes/Services/Notifications/Manager.php
+++ b/classes/Services/Notifications/Manager.php
@@ -167,6 +167,7 @@ class Manager extends Service {
 	protected function resolve_providers() {
 		$core = [
 			new WhatsNew( $this->container ),
+			new LegacyExtensionGuidance( $this->container ),
 			new FeatureAnnouncements( $this->container ),
 		];
 

--- a/tests/php/fixtures/class-pum-test-legacy-pro-upsell.php
+++ b/tests/php/fixtures/class-pum-test-legacy-pro-upsell.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Already-shipped Extension Framework offer callback fixture.
+ *
+ * @package PopupMaker
+ */
+
+namespace PopupMaker\ExtensionFramework\Controllers\Admin;
+
+if ( ! class_exists( __NAMESPACE__ . '\\ProUpsell', false ) ) {
+	/**
+	 * Minimal callback fixture matching the historical controller class.
+	 */
+	class ProUpsell {
+
+		/** @return void */
+		public function admin_notice() {}
+
+		/** @return void */
+		public function enqueue_dismiss_script() {}
+
+		/** @return void */
+		public function plugin_row_meta() {}
+
+		/** @return void */
+		public function register_panel_notification() {}
+	}
+}

--- a/tests/php/tests/Legacy_Extension_Catalog_Test.php
+++ b/tests/php/tests/Legacy_Extension_Catalog_Test.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Local legacy extension catalog tests.
+ *
+ * @package PopupMaker
+ */
+
+/**
+ * Validates the bundled legacy-to-Pro compatibility catalog.
+ */
+class Legacy_Extension_Catalog_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var \PopupMaker\Services\LegacyExtensionCatalog
+	 */
+	private $catalog;
+
+	/** Set up the catalog. */
+	public function setUp(): void {
+		parent::setUp();
+		$this->catalog = new \PopupMaker\Services\LegacyExtensionCatalog();
+	}
+
+	/** Old versions remain detectable without registering metadata. */
+	public function test_bundled_catalog_contains_retired_pro_features() {
+		$items = $this->catalog->get_bundled_items();
+
+		$this->assertCount( 8, $items );
+		$this->assertSame( 'Exit Intent', $items['exit-intent-popups']['feature_name'] );
+		$this->assertContains(
+			'popup-maker-terms-conditions-popups/popup-maker-terms-conditions-popups.php',
+			$items['terms-conditions-popups']['plugin_basenames']
+		);
+		$this->assertContains(
+			'pum-scheduling/pum-scheduling.php',
+			$items['scheduling']['plugin_basenames']
+		);
+	}
+
+	/** Newer local registration enhances rather than replaces compatibility. */
+	public function test_local_metadata_registration_preserves_bundled_identifiers() {
+		$filter = static function ( $items ) {
+			$items['terms-conditions-popups'] = [
+				'feature_name'       => 'Terms Acceptance',
+				'plugin_basenames'   => [ 'custom-terms/custom-terms.php' ],
+				'license_shortnames' => [ 'popmake_custom_terms' ],
+			];
+
+			return $items;
+		};
+
+		add_filter( 'popup_maker/legacy_extension_catalog', $filter );
+
+		try {
+			$item = $this->catalog->get_items()['terms-conditions-popups'];
+			$this->assertSame( 'Terms Acceptance', $item['feature_name'] );
+			$this->assertContains( 'custom-terms/custom-terms.php', $item['plugin_basenames'] );
+			$this->assertContains(
+				'popup-maker-terms-conditions-popups/popup-maker-terms-conditions-popups.php',
+				$item['plugin_basenames']
+			);
+		} finally {
+			remove_filter( 'popup_maker/legacy_extension_catalog', $filter );
+		}
+	}
+
+	/** A broken callback cannot erase Core's backwards-compatibility catalog. */
+	public function test_bundled_catalog_cannot_be_filtered_away() {
+		$filter = static function () {
+			return [];
+		};
+		add_filter( 'popup_maker/legacy_extension_catalog', $filter );
+
+		try {
+			$this->assertCount( 8, $this->catalog->get_items() );
+		} finally {
+			remove_filter( 'popup_maker/legacy_extension_catalog', $filter );
+		}
+	}
+
+	/** Site and network activation are resolved from local WordPress state. */
+	public function test_installed_context_aggregates_active_and_inactive_extensions() {
+		$plugins = [
+			'popup-maker-exit-intent-popups/popup-maker-exit-intent-popups.php' => [ 'Version' => '1.4.0' ],
+			'popup-maker-terms-conditions-popups/popup-maker-terms-conditions-popups.php' => [ 'Version' => '1.1.2' ],
+		];
+
+		$items = $this->catalog->get_installed_items(
+			$plugins,
+			[],
+			[ 'popup-maker-exit-intent-popups/popup-maker-exit-intent-popups.php' => 123 ],
+			[],
+			[]
+		);
+
+		$this->assertCount( 2, $items );
+		$this->assertSame( 'exit-intent-popups', $items[0]['slug'] );
+		$this->assertTrue( $items[0]['active'] );
+		$this->assertTrue( $items[0]['network_active'] );
+		$this->assertSame( 'terms-conditions-popups', $items[1]['slug'] );
+		$this->assertFalse( $items[1]['active'] );
+	}
+
+	/** Stored key and status determine state without a remote check. */
+	public function test_license_state_uses_only_injected_local_options() {
+		$item = $this->catalog->get_items()['exit-intent-popups'];
+
+		$this->assertSame(
+			'valid',
+			$this->catalog->get_license_state(
+				$item,
+				[ 'popmake_exit_intent_popups_license_key' => 'local-key' ],
+				[
+					'popmake_exit_intent_popups' => (object) [
+						'success' => true,
+						'license' => 'valid',
+					],
+				]
+			)
+		);
+
+		$this->assertSame(
+			'expired',
+			$this->catalog->get_license_state(
+				$item,
+				[ 'popmake_exit_intent_popups_license_key' => 'local-key' ],
+				[
+					'popmake_exit_intent_popups' => [
+						'success' => false,
+						'license' => 'invalid',
+						'error'   => 'expired',
+					],
+				]
+			)
+		);
+
+		$this->assertSame( 'missing', $this->catalog->get_license_state( $item, [], [] ) );
+	}
+}

--- a/tests/php/tests/Legacy_Extension_Guidance_Test.php
+++ b/tests/php/tests/Legacy_Extension_Guidance_Test.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ * Local legacy extension notification tests.
+ *
+ * @package PopupMaker
+ */
+
+require_once dirname( __DIR__ ) . '/fixtures/class-pum-test-legacy-pro-upsell.php';
+
+/**
+ * Validates the aggregated Legacy to Pro notification state machine.
+ */
+class Legacy_Extension_Guidance_Test extends WP_UnitTestCase {
+
+	/**
+	 * @var \PopupMaker\Services\Notifications\LegacyExtensionGuidance
+	 */
+	private $guidance;
+
+	/** Set up an administrator and provider. */
+	public function setUp(): void {
+		parent::setUp();
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+		$this->guidance = new \PopupMaker\Services\Notifications\LegacyExtensionGuidance( \PopupMaker\plugin() );
+	}
+
+	/** Pro-active sites suppress sales guidance. */
+	public function test_active_pro_suppresses_sales_guidance() {
+		$this->assertNull( $this->guidance->build_alert( $this->extensions(), 'active', 'valid' ) );
+		$this->assertNull( $this->guidance->build_alert( $this->extensions(), 'active', 'missing' ) );
+	}
+
+	/** An expired local Pro license gets a local management action, not a sale. */
+	public function test_expired_active_pro_uses_local_license_action() {
+		$alert = $this->guidance->build_alert( $this->extensions(), 'active', 'expired' );
+
+		$this->assertSame( 'pm_legacy_extensions_to_pro_renew_v1', $alert['code'] );
+		$this->assertStringContainsString( 'page=pum-settings', $alert['actions'][0]['href'] );
+		$this->assertStringNotContainsString( 'utm_', $alert['actions'][0]['href'] );
+	}
+
+	/** Installed inactive Pro receives a nonce-protected activation action. */
+	public function test_inactive_pro_uses_activation_action() {
+		$alert = $this->guidance->build_alert( $this->extensions(), 'inactive', 'expired' );
+
+		$this->assertSame( 'pm_legacy_extensions_to_pro_activate_v1', $alert['code'] );
+		$this->assertStringContainsString( 'action=activate', html_entity_decode( $alert['actions'][0]['href'] ) );
+		$this->assertStringContainsString( '_wpnonce=', html_entity_decode( $alert['actions'][0]['href'] ) );
+	}
+
+	/** Valid legacy licenses receive evergreen consolidation copy. */
+	public function test_valid_legacy_license_uses_consolidation_message() {
+		$extensions                     = $this->extensions();
+		$extensions[0]['license_state'] = 'valid';
+		$alert                          = $this->guidance->build_alert( $extensions, 'missing', 'missing' );
+
+		$this->assertSame( 'pm_legacy_extensions_to_pro_consolidate_v1', $alert['code'] );
+		$this->assertStringContainsString( 'Exit Intent', $alert['message'] );
+		$this->assertStringContainsString( 'Terms &amp; Conditions', $alert['message'] );
+		$this->assertStringNotContainsString( '$', $alert['message'] );
+		$this->assertTrue( $alert['display_inline'] );
+	}
+
+	/** Expired/missing licenses receive included-in-Pro guidance. */
+	public function test_missing_legacy_license_uses_included_message() {
+		$alert = $this->guidance->build_alert( $this->extensions(), 'missing', 'missing' );
+
+		$this->assertSame( 'pm_legacy_extensions_to_pro_included_v1', $alert['code'] );
+		$this->assertSame( 72, $alert['priority'] );
+		$this->assertSame( 'dismiss', $alert['actions'][1]['action'] );
+		$this->assertArrayNotHasKey( 'expires', $alert['actions'][1] );
+	}
+
+	/** A fully deactivated installation is deliberately lower priority. */
+	public function test_deactivated_extensions_are_lower_priority() {
+		$extensions = $this->extensions();
+		foreach ( $extensions as &$extension ) {
+			$extension['active'] = false;
+		}
+		unset( $extension );
+
+		$alert = $this->guidance->build_alert( $extensions, 'missing', 'missing' );
+		$this->assertSame( 45, $alert['priority'] );
+	}
+
+	/** Core removes only the known shipped framework offer callbacks. */
+	public function test_removes_shipped_framework_offer_callbacks() {
+		$legacy    = new \PopupMaker\ExtensionFramework\Controllers\Admin\ProUpsell();
+		$unrelated = static function ( $value = null ) {
+			return $value;
+		};
+
+		add_action( 'admin_notices', [ $legacy, 'admin_notice' ] );
+		add_action( 'admin_enqueue_scripts', [ $legacy, 'enqueue_dismiss_script' ] );
+		add_filter( 'plugin_row_meta', [ $legacy, 'plugin_row_meta' ], 10, 2 );
+		add_filter( 'pum_alert_list', [ $legacy, 'register_panel_notification' ] );
+		add_filter( 'pum_alert_list', $unrelated );
+
+		$this->guidance->remove_legacy_framework_offers();
+
+		$this->assertFalse( has_action( 'admin_notices', [ $legacy, 'admin_notice' ] ) );
+		$this->assertFalse( has_action( 'admin_enqueue_scripts', [ $legacy, 'enqueue_dismiss_script' ] ) );
+		$this->assertFalse( has_filter( 'plugin_row_meta', [ $legacy, 'plugin_row_meta' ] ) );
+		$this->assertFalse( has_filter( 'pum_alert_list', [ $legacy, 'register_panel_notification' ] ) );
+		$this->assertSame( 10, has_filter( 'pum_alert_list', $unrelated ) );
+
+		remove_filter( 'pum_alert_list', $unrelated );
+	}
+
+	/** Representative aggregate context. */
+	private function extensions() {
+		return [
+			[
+				'feature_name'  => 'Exit Intent',
+				'active'        => true,
+				'license_state' => 'expired',
+			],
+			[
+				'feature_name'  => 'Terms & Conditions',
+				'active'        => false,
+				'license_state' => 'missing',
+			],
+		];
+	}
+}


### PR DESCRIPTION
## Summary

Move all Legacy → Pro guidance into Popup Maker Core so sites with old or expired standalone extensions receive locally generated guidance by updating Core alone.

## Why

The extension framework previously rendered its own Pro offer. That cannot cover an expired legacy extension that will never receive a newer framework copy. Core still updates through WordPress.org, so it must own backward-compatible detection and rendering.

## What changed

- Add a bundled catalog for eight retired standalone extensions and their stable local identifiers.
- Detect installed, active, inactive, and network-active extensions without remote requests.
- Read only existing locally stored extension and Pro license state.
- Aggregate multiple legacy features into one capability-gated, dismissible Core notification.
- Handle active Pro, inactive installed Pro, expired Pro license, valid legacy licenses, and expired/missing legacy licenses separately.
- Keep deactivated legacy extensions at a lower notice priority.
- Remove already-registered callbacks from older framework `ProUpsell` controllers so Core remains the sole renderer.
- Permit newer extensions to enhance local metadata while preserving the bundled compatibility catalog.

## Privacy and product boundaries

- No remote configuration or offer requests
- No pricing or discount lookup
- No impression, dismissal, or license-state telemetry
- No fake plugin updates or entitlement changes
- No dynamic remote HTML or copy
- Only static, user-clicked Pro links use UTM parameters

## Validation

- PHPUnit: 1,177 tests, 2,878 assertions, 20 skipped
- New coverage: 12 tests, 40 assertions
- PHPCS: passed for all affected files
- PHPStan: passed for the new catalog and notification provider
- PHP syntax and `git diff --check`: passed

## Coordinated changes

- PopupMaker/extension-framework#1 removes its renderer and retains metadata registration only.
- PopupMaker/Terms-Conditions#12 disables the legacy renderer immediately and registers optional feature metadata for the newer framework.
