### PR TITLE
Guard provider submission success callbacks

### DIFF
--- a/assets/js/src/integration/wsforms.js
+++ b/assets/js/src/integration/wsforms.js
@@ -7,15 +7,8 @@
 	const $ = window.jQuery;
 
 	$( document ).on(
-		'wsf-submit-success wsf-save-success',
-		function (
-			event,
-			formObject,
-			formId,
-			formInstanceId,
-			formEl,
-			formCanvasEl
-		) {
+		'wsf-submit-success',
+		function ( event, formObject, formId, formInstanceId, formEl ) {
 			// All the magic happens here.
 			window.PUM.integrations.formSubmission( $( formEl ), {
 				formProvider,

--- a/classes/Integration/Form/Forminator.php
+++ b/classes/Integration/Form/Forminator.php
@@ -120,8 +120,16 @@ class PUM_Integration_Form_Forminator extends PUM_Abstract_Integration_Form {
 	 */
 	public function on_success( $entry, $form_id, $field_data_array ) {
 		$status = is_object( $entry ) && isset( $entry->status ) ? $entry->status : ( is_array( $entry ) && isset( $entry['status'] ) ? $entry['status'] : null );
-		if ( 'active' !== $status ) {
+		if ( null !== $status && 'active' !== $status ) {
 			return;
+		}
+
+		if ( null === $status ) {
+			$is_spam  = is_object( $entry ) && isset( $entry->is_spam ) ? $entry->is_spam : ( is_array( $entry ) && isset( $entry['is_spam'] ) ? $entry['is_spam'] : false );
+			$draft_id = is_object( $entry ) && isset( $entry->draft_id ) ? $entry->draft_id : ( is_array( $entry ) && isset( $entry['draft_id'] ) ? $entry['draft_id'] : null );
+			if ( $is_spam || ! empty( $draft_id ) ) {
+				return;
+			}
 		}
 
 		if ( ! $this->should_process_submission() ) {

--- a/classes/Integration/Form/Forminator.php
+++ b/classes/Integration/Form/Forminator.php
@@ -119,6 +119,10 @@ class PUM_Integration_Form_Forminator extends PUM_Abstract_Integration_Form {
 	 * @param array  $field_data_array Field data array.
 	 */
 	public function on_success( $entry, $form_id, $field_data_array ) {
+		if ( ! is_object( $entry ) && ! is_array( $entry ) ) {
+			return;
+		}
+
 		$status = is_object( $entry ) && isset( $entry->status ) ? $entry->status : ( is_array( $entry ) && isset( $entry['status'] ) ? $entry['status'] : null );
 		if ( null !== $status && 'active' !== $status ) {
 			return;

--- a/classes/Integration/Form/Forminator.php
+++ b/classes/Integration/Form/Forminator.php
@@ -119,6 +119,11 @@ class PUM_Integration_Form_Forminator extends PUM_Abstract_Integration_Form {
 	 * @param array  $field_data_array Field data array.
 	 */
 	public function on_success( $entry, $form_id, $field_data_array ) {
+		$status = is_object( $entry ) && isset( $entry->status ) ? $entry->status : ( is_array( $entry ) && isset( $entry['status'] ) ? $entry['status'] : null );
+		if ( 'active' !== $status ) {
+			return;
+		}
+
 		if ( ! $this->should_process_submission() ) {
 			return;
 		}

--- a/classes/Integration/Form/WSForms.php
+++ b/classes/Integration/Form/WSForms.php
@@ -88,6 +88,18 @@ class PUM_Integration_Form_WSForms extends PUM_Abstract_Integration_Form {
 	 * @param \WS_Form_Submit $submit
 	 */
 	public function on_success( $submit ) {
+		if ( ! is_object( $submit )
+			|| ! isset( $submit->post_mode )
+			|| 'submit' !== $submit->post_mode
+			|| ! empty( $submit->error )
+			|| ! empty( $submit->error_validation_actions )
+			|| ! isset( $submit->form_id )
+			|| ! is_numeric( $submit->form_id )
+			|| $submit->form_id <= 0
+		) {
+			return;
+		}
+
 		if ( ! $this->should_process_submission() ) {
 			return;
 		}

--- a/tests/php/tests/FormSubmissionPhases_Test.php
+++ b/tests/php/tests/FormSubmissionPhases_Test.php
@@ -346,6 +346,57 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Forminator drafts and abandoned entries are not successful submissions.
+	 */
+	public function test_forminator_requires_active_entry_status() {
+		$observed                 = 0;
+		$this->observation_action = static function () use ( &$observed ) {
+			++$observed;
+		};
+		add_action( 'pum_integrated_form_submission', $this->observation_action );
+
+		$integration = new PUM_Integration_Form_Forminator();
+		foreach ( [ 'draft', 'abandoned', 'spam' ] as $status ) {
+			$integration->on_success( (object) [ 'status' => $status ], 7, [] );
+		}
+		$integration->on_success( new stdClass(), 7, [] );
+
+		$this->assertSame( 0, $observed );
+
+		$integration->on_success( (object) [ 'status' => 'active' ], 7, [] );
+		$this->assertSame( 1, $observed );
+	}
+
+	/**
+	 * WS Form saves and failed validation never become conversions.
+	 */
+	public function test_ws_form_requires_one_valid_submit_receipt() {
+		$observed                 = 0;
+		$this->observation_action = static function () use ( &$observed ) {
+			++$observed;
+		};
+		add_action( 'pum_integrated_form_submission', $this->observation_action );
+
+		$integration = new PUM_Integration_Form_WSForms();
+		$valid       = [
+			'form_id'                  => 7,
+			'post_mode'                => 'submit',
+			'error'                    => false,
+			'error_validation_actions' => [],
+		];
+
+		$integration->on_success( (object) array_merge( $valid, [ 'post_mode' => 'save' ] ) );
+		$integration->on_success( (object) array_merge( $valid, [ 'error' => true ] ) );
+		$integration->on_success( (object) array_merge( $valid, [ 'error_validation_actions' => [ 'field_1' => 'Required' ] ] ) );
+		$integration->on_success( (object) array_merge( $valid, [ 'form_id' => 0 ] ) );
+
+		$this->assertSame( 0, $observed );
+
+		$integration->on_success( (object) $valid );
+		$this->assertSame( 1, $observed );
+	}
+
+	/**
 	 * Non-AJAX callbacks increment each Core metric exactly once.
 	 *
 	 * @runInSeparateProcess

--- a/tests/php/tests/FormSubmissionPhases_Test.php
+++ b/tests/php/tests/FormSubmissionPhases_Test.php
@@ -346,9 +346,9 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Forminator drafts and abandoned entries are not successful submissions.
+	 * Forminator rejects explicit failures and legacy spam/draft entries.
 	 */
-	public function test_forminator_requires_active_entry_status() {
+	public function test_forminator_requires_active_or_legacy_success_entry() {
 		$observed                 = 0;
 		$this->observation_action = static function () use ( &$observed ) {
 			++$observed;
@@ -359,12 +359,14 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 		foreach ( [ 'draft', 'abandoned', 'spam' ] as $status ) {
 			$integration->on_success( (object) [ 'status' => $status ], 7, [] );
 		}
-		$integration->on_success( new stdClass(), 7, [] );
+		$integration->on_success( (object) [ 'is_spam' => true ], 7, [] );
+		$integration->on_success( (object) [ 'draft_id' => 'draft-7' ], 7, [] );
 
 		$this->assertSame( 0, $observed );
 
 		$integration->on_success( (object) [ 'status' => 'active' ], 7, [] );
-		$this->assertSame( 1, $observed );
+		$integration->on_success( new stdClass(), 7, [] );
+		$this->assertSame( 2, $observed );
 	}
 
 	/**

--- a/tests/php/tests/FormSubmissionPhases_Test.php
+++ b/tests/php/tests/FormSubmissionPhases_Test.php
@@ -359,6 +359,8 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 		foreach ( [ 'draft', 'abandoned', 'spam' ] as $status ) {
 			$integration->on_success( (object) [ 'status' => $status ], 7, [] );
 		}
+		$integration->on_success( null, 7, [] );
+		$integration->on_success( 'invalid-entry', 7, [] );
 		$integration->on_success( (object) [ 'is_spam' => true ], 7, [] );
 		$integration->on_success( (object) [ 'draft_id' => 'draft-7' ], 7, [] );
 

--- a/tests/unit/wsforms-integration.test.js
+++ b/tests/unit/wsforms-integration.test.js
@@ -1,0 +1,34 @@
+describe( 'WS Form success integration', () => {
+	let eventName;
+	let handler;
+	let formSubmission;
+
+	beforeEach( () => {
+		jest.resetModules();
+		formSubmission = jest.fn();
+		window.PUM = { integrations: { formSubmission } };
+		window.jQuery = jest.fn( () => ( {
+			on: jest.fn( ( registeredEvent, callback ) => {
+				eventName = registeredEvent;
+				handler = callback;
+			} ),
+		} ) );
+
+		require( '../../assets/js/src/integration/wsforms' );
+	} );
+
+	test( 'observes submit success and never registers save success', () => {
+		expect( eventName ).toBe( 'wsf-submit-success' );
+		expect( eventName ).not.toContain( 'wsf-save-success' );
+
+		const formElement = document.createElement( 'form' );
+		handler( {}, {}, 7, 'instance-1', formElement, {} );
+
+		expect( formSubmission ).toHaveBeenCalledTimes( 1 );
+		expect( formSubmission ).toHaveBeenCalledWith( expect.anything(), {
+			formProvider: 'wsforms',
+			formId: 7,
+			formInstanceId: 'instance-1',
+		} );
+	} );
+} );


### PR DESCRIPTION
## Summary

Forminator and WS Form expose callbacks for intermediate persistence states as well as completed submissions. Popup Maker previously treated those callbacks uniformly, so Forminator drafts/abandoned entries and WS Form saves or failed validation could enter the normalized success flow and be counted as conversions.

This stacked correctness patch narrows the existing integrations to authoritative success states:

- Forminator dispatches only persisted entries whose native status is exactly `active`.
- WS Form dispatches only `submit` receipts with a valid form ID and no native error or validation failures.
- The browser observer listens only to `wsf-submit-success`; save receipts no longer produce normalized observations.

The change intentionally adds no new public hook and does not alter action execution. It provides the correctness boundary required by the Pro provider capability adapters in PopupMaker/Pro#142.

## Validation

- `vendor/bin/phpunit -c tests/php/phpunit.xml tests/php/tests/FormSubmissionPhases_Test.php` — 13 tests, 41 assertions
- `pnpm test:unit -- --runInBand tests/unit/wsforms-integration.test.js` — 1 test passed
- focused PHPCS on the changed PHP files
- focused WordPress JS lint and Prettier on the changed JS files
- `git diff --check`

## Stack

Base: `feature/form-submission-phases`

Related Pro issue: PopupMaker/Pro#142
