### PR TITLE
Reject Formidable draft and child conversions

### DIFF
--- a/assets/js/src/integration/formidableforms.js
+++ b/assets/js/src/integration/formidableforms.js
@@ -8,6 +8,13 @@
 
 	$( document ).on( 'frmFormComplete', function ( event, form, response ) {
 		const $form = $( form );
+
+		// Formidable Pro renders draft saves as a completion message too. Its
+		// native request marker remains on the submitted form when this event runs.
+		if ( '1' === $form.find( 'input[name="frm_saving_draft"]' ).val() ) {
+			return;
+		}
+
 		const formId = $form.find( 'input[name="form_id"]' ).val();
 		const $popup = window.PUM.getPopup(
 			$form.find( 'input[name="pum_form_popup_id"]' ).val()

--- a/classes/Integration/Form/FormidableForms.php
+++ b/classes/Integration/Form/FormidableForms.php
@@ -140,7 +140,8 @@ class PUM_Integration_Form_FormidableForms extends PUM_Abstract_Integration_Form
 
 		unset( $this->draft_transitions[ $normalized_id ] );
 
-		if ( 1 === (int) ( isset( $values['frm_saving_draft'] ) ? $values['frm_saving_draft'] : 0 ) || ! empty( $values['is_draft'] ) ) {
+		$draft_marker = isset( $values['frm_saving_draft'] ) ? $values['frm_saving_draft'] : 0;
+		if ( ! is_scalar( $draft_marker ) || 1 === (int) $draft_marker || ! empty( $values['is_draft'] ) ) {
 			return $values;
 		}
 

--- a/classes/Integration/Form/FormidableForms.php
+++ b/classes/Integration/Form/FormidableForms.php
@@ -26,7 +26,7 @@ class PUM_Integration_Form_FormidableForms extends PUM_Abstract_Integration_Form
 	 * Could be used for other initiations as well where needed.
 	 */
 	public function __construct() {
-		add_action( 'frm_after_create_entry', [ $this, 'on_success' ], 1, 3 );
+		add_action( 'frm_after_create_entry', [ $this, 'on_success' ], 10, 3 );
 	}
 
 	/**

--- a/classes/Integration/Form/FormidableForms.php
+++ b/classes/Integration/Form/FormidableForms.php
@@ -125,13 +125,19 @@ class PUM_Integration_Form_FormidableForms extends PUM_Abstract_Integration_Form
 	 * @return bool
 	 */
 	protected function is_successful_entry( $entry_id, $args ) {
-		if ( ! empty( $args['is_child'] ) ) {
+		if (
+			! ( is_int( $entry_id ) || ( is_string( $entry_id ) && ctype_digit( $entry_id ) ) )
+			|| (int) $entry_id < 1
+			|| ! empty( $args['is_child'] )
+		) {
 			return false;
 		}
 
-		$entry = $this->get_entry( $entry_id );
+		$entry = $this->get_entry( (int) $entry_id );
 
-		return is_object( $entry ) && empty( $entry->is_draft );
+		return is_object( $entry )
+			&& empty( $entry->is_draft )
+			&& empty( $entry->parent_item_id );
 	}
 
 	/**

--- a/classes/Integration/Form/FormidableForms.php
+++ b/classes/Integration/Form/FormidableForms.php
@@ -26,7 +26,7 @@ class PUM_Integration_Form_FormidableForms extends PUM_Abstract_Integration_Form
 	 * Could be used for other initiations as well where needed.
 	 */
 	public function __construct() {
-		add_action( 'frm_after_create_entry', [ $this, 'on_success' ], 1, 2 );
+		add_action( 'frm_after_create_entry', [ $this, 'on_success' ], 1, 3 );
 	}
 
 	/**
@@ -88,12 +88,13 @@ class PUM_Integration_Form_FormidableForms extends PUM_Abstract_Integration_Form
 	/**
 	 * Hooks in a success functions specific to this provider for non AJAX submission handling.
 	 *
-	 * @param int $entry_id The ID of the entry added.
-	 * @param int $form_id The ID of the form.
+	 * @param int   $entry_id The ID of the entry added.
+	 * @param int   $form_id  The ID of the form.
+	 * @param array $args     Provider callback context.
 	 */
-	public function on_success( $entry_id, $form_id ) {
+	public function on_success( $entry_id, $form_id, $args = [] ) {
 
-		if ( ! $this->should_process_submission() ) {
+		if ( ! $this->should_process_submission() || ! $this->is_successful_entry( $entry_id, $args ) ) {
 			return;
 		}
 
@@ -114,6 +115,33 @@ class PUM_Integration_Form_FormidableForms extends PUM_Abstract_Integration_Form
 				'ajax'          => $is_ajax,
 			]
 		);
+	}
+
+	/**
+	 * Confirm this is the submitted parent entry rather than a draft or repeater child.
+	 *
+	 * @param int   $entry_id The ID of the entry added.
+	 * @param array $args     Provider callback context.
+	 * @return bool
+	 */
+	protected function is_successful_entry( $entry_id, $args ) {
+		if ( ! empty( $args['is_child'] ) ) {
+			return false;
+		}
+
+		$entry = $this->get_entry( $entry_id );
+
+		return is_object( $entry ) && empty( $entry->is_draft );
+	}
+
+	/**
+	 * Load the native entry for submission-state verification.
+	 *
+	 * @param int $entry_id Entry ID.
+	 * @return object|null
+	 */
+	protected function get_entry( $entry_id ) {
+		return is_callable( [ 'FrmEntry', 'getOne' ] ) ? FrmEntry::getOne( $entry_id ) : null;
 	}
 
 	/**

--- a/classes/Integration/Form/FormidableForms.php
+++ b/classes/Integration/Form/FormidableForms.php
@@ -14,6 +14,13 @@
 class PUM_Integration_Form_FormidableForms extends PUM_Abstract_Integration_Form {
 
 	/**
+	 * Draft entries awaiting a successful update in the current request.
+	 *
+	 * @var array<int,bool>
+	 */
+	private $draft_transitions = [];
+
+	/**
 	 * Unique key identifier for this provider.
 	 *
 	 * @var string
@@ -21,12 +28,12 @@ class PUM_Integration_Form_FormidableForms extends PUM_Abstract_Integration_Form
 	public $key = 'formidableforms';
 
 	/**
-	 * Only used to hook in a custom action for non AJAX based submissions.
-	 *
-	 * Could be used for other initiations as well where needed.
+	 * Register native success hooks for new and resumed submissions.
 	 */
 	public function __construct() {
 		add_action( 'frm_after_create_entry', [ $this, 'on_success' ], 10, 3 );
+		add_filter( 'frm_pre_update_entry', [ $this, 'capture_draft_transition' ], 9, 2 );
+		add_action( 'frm_after_update_entry', [ $this, 'on_update_success' ], 10, 2 );
 	}
 
 	/**
@@ -118,26 +125,83 @@ class PUM_Integration_Form_FormidableForms extends PUM_Abstract_Integration_Form
 	}
 
 	/**
+	 * Remember a frontend draft-to-submitted transition before Formidable persists it.
+	 *
+	 * @param mixed $values   Updated entry values.
+	 * @param mixed $entry_id Native entry ID.
+	 * @return mixed
+	 */
+	public function capture_draft_transition( $values, $entry_id ) {
+		$normalized_id = $this->normalize_entry_id( $entry_id );
+		$is_admin      = is_callable( [ 'FrmAppHelper', 'is_admin' ] ) && FrmAppHelper::is_admin();
+		if ( null === $normalized_id || ! is_array( $values ) || $is_admin ) {
+			return $values;
+		}
+
+		unset( $this->draft_transitions[ $normalized_id ] );
+
+		if ( 1 === (int) ( isset( $values['frm_saving_draft'] ) ? $values['frm_saving_draft'] : 0 ) || ! empty( $values['is_draft'] ) ) {
+			return $values;
+		}
+
+		$entry = $this->get_entry( $normalized_id );
+		if ( is_object( $entry ) && ! empty( $entry->is_draft ) && empty( $entry->parent_item_id ) ) {
+			$this->draft_transitions[ $normalized_id ] = true;
+		}
+
+		return $values;
+	}
+
+	/**
+	 * Normalize a resumed draft after Formidable has persisted its submitted state.
+	 *
+	 * @param mixed $entry_id Native entry ID.
+	 * @param mixed $form_id  Native form ID.
+	 * @return void
+	 */
+	public function on_update_success( $entry_id, $form_id ) {
+		$normalized_id = $this->normalize_entry_id( $entry_id );
+		if ( null === $normalized_id || empty( $this->draft_transitions[ $normalized_id ] ) ) {
+			return;
+		}
+
+		unset( $this->draft_transitions[ $normalized_id ] );
+		$this->on_success( $normalized_id, $form_id );
+	}
+
+	/**
 	 * Confirm this is the submitted parent entry rather than a draft or repeater child.
 	 *
 	 * @param int   $entry_id The ID of the entry added.
-	 * @param array $args     Provider callback context.
+	 * @param mixed $args     Provider callback context.
 	 * @return bool
 	 */
 	protected function is_successful_entry( $entry_id, $args ) {
-		if (
-			! ( is_int( $entry_id ) || ( is_string( $entry_id ) && ctype_digit( $entry_id ) ) )
-			|| (int) $entry_id < 1
-			|| ! empty( $args['is_child'] )
-		) {
+		$entry_id = $this->normalize_entry_id( $entry_id );
+		$args     = is_array( $args ) ? $args : [];
+		if ( null === $entry_id || ! empty( $args['is_child'] ) ) {
 			return false;
 		}
 
-		$entry = $this->get_entry( (int) $entry_id );
+		$entry = $this->get_entry( $entry_id );
 
 		return is_object( $entry )
 			&& empty( $entry->is_draft )
 			&& empty( $entry->parent_item_id );
+	}
+
+	/**
+	 * Normalize a native positive-integer entry ID.
+	 *
+	 * @param mixed $entry_id Entry ID.
+	 * @return int|null
+	 */
+	private function normalize_entry_id( $entry_id ) {
+		if ( ! ( is_int( $entry_id ) || ( is_string( $entry_id ) && ctype_digit( $entry_id ) ) ) || (int) $entry_id < 1 ) {
+			return null;
+		}
+
+		return (int) $entry_id;
 	}
 
 	/**

--- a/tests/php/tests/FormSubmissionPhases_Test.php
+++ b/tests/php/tests/FormSubmissionPhases_Test.php
@@ -461,6 +461,19 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 			'form_id'  => 7,
 			'is_draft' => 0,
 		];
+		$malformed_values   = [ 'frm_saving_draft' => new stdClass() ];
+		$this->assertSame( $malformed_values, $integration->capture_draft_transition( $malformed_values, 105 ) );
+		$integration->entry = (object) [
+			'is_draft'       => 0,
+			'parent_item_id' => 0,
+		];
+		$integration->on_update_success( 105, 7 );
+		$this->assertSame( 0, $observed );
+
+		$integration->entry = (object) [
+			'is_draft'       => 1,
+			'parent_item_id' => 0,
+		];
 		$this->assertSame( $values, $integration->capture_draft_transition( $values, 105 ) );
 
 		$integration->entry = (object) [

--- a/tests/php/tests/FormSubmissionPhases_Test.php
+++ b/tests/php/tests/FormSubmissionPhases_Test.php
@@ -329,6 +329,16 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 			public function get_form( $id ) {
 				return (object) [ 'options' => [ 'ajax_submit' => true ] ];
 			}
+
+			/**
+			 * Treat the synthetic entry as a submitted parent entry.
+			 *
+			 * @param int $entry_id Entry ID.
+			 * @return object
+			 */
+			protected function get_entry( $entry_id ) {
+				return (object) [ 'is_draft' => 0 ];
+			}
 		};
 		$integration->on_success( 'entry-95', 7 );
 
@@ -343,6 +353,51 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 			$observed['phases']
 		);
 		$this->assertNull( PUM_Integrations::$form_submission );
+	}
+
+	/**
+	 * Formidable drafts and repeater children never become conversions.
+	 */
+	public function test_formidable_requires_submitted_parent_entry() {
+		$observed                 = 0;
+		$this->observation_action = static function () use ( &$observed ) {
+			++$observed;
+		};
+		add_action( 'pum_integrated_form_submission', $this->observation_action );
+
+		$integration = new class() extends PUM_Integration_Form_FormidableForms {
+			/** @var object|null */
+			public $entry;
+
+			/**
+			 * Return a non-AJAX synthetic form.
+			 *
+			 * @param string $id Form ID.
+			 * @return object
+			 */
+			public function get_form( $id ) {
+				return (object) [ 'options' => [] ];
+			}
+
+			/**
+			 * Verify provider callback state through a controlled entry seam.
+			 *
+			 * @param int $entry_id Entry ID.
+			 * @return object|null
+			 */
+			protected function get_entry( $entry_id ) {
+				return $this->entry;
+			}
+		};
+
+		$integration->entry = (object) [ 'is_draft' => 1 ];
+		$integration->on_success( 101, 7, [ 'is_child' => false ] );
+		$integration->entry = (object) [ 'is_draft' => 0 ];
+		$integration->on_success( 102, 7, [ 'is_child' => true ] );
+		$this->assertSame( 0, $observed );
+
+		$integration->on_success( 103, 7, [ 'is_child' => false ] );
+		$this->assertSame( 1, $observed );
 	}
 
 	/**

--- a/tests/php/tests/FormSubmissionPhases_Test.php
+++ b/tests/php/tests/FormSubmissionPhases_Test.php
@@ -414,7 +414,73 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 			'is_draft'       => 0,
 			'parent_item_id' => 0,
 		];
-		$integration->on_success( '104', 7, [ 'is_child' => false ] );
+		$integration->on_success( '104', 7, new stdClass() );
+		$this->assertSame( 1, $observed );
+	}
+
+	/**
+	 * A frontend draft becoming submitted emits once from Formidable's update path.
+	 */
+	public function test_formidable_draft_to_submitted_update_emits_once() {
+		$observed                 = 0;
+		$this->observation_action = static function () use ( &$observed ) {
+			++$observed;
+		};
+		add_action( 'pum_integrated_form_submission', $this->observation_action );
+
+		$integration = new class() extends PUM_Integration_Form_FormidableForms {
+			/** @var object|null */
+			public $entry;
+
+			/**
+			 * Return a non-AJAX synthetic form.
+			 *
+			 * @param string $id Form ID.
+			 * @return object
+			 */
+			public function get_form( $id ) {
+				return (object) [ 'options' => [] ];
+			}
+
+			/**
+			 * Return controlled persisted entry state.
+			 *
+			 * @param int $entry_id Entry ID.
+			 * @return object|null
+			 */
+			protected function get_entry( $entry_id ) {
+				return $this->entry;
+			}
+		};
+
+		$integration->entry = (object) [
+			'is_draft'       => 1,
+			'parent_item_id' => 0,
+		];
+		$values             = [
+			'form_id'  => 7,
+			'is_draft' => 0,
+		];
+		$this->assertSame( $values, $integration->capture_draft_transition( $values, 105 ) );
+
+		$integration->entry = (object) [
+			'is_draft'       => 0,
+			'parent_item_id' => 0,
+		];
+		$integration->on_update_success( 105, 7 );
+		$integration->on_update_success( 105, 7 );
+		$this->assertSame( 1, $observed );
+
+		$integration->entry = (object) [
+			'is_draft'       => 1,
+			'parent_item_id' => 0,
+		];
+		$integration->capture_draft_transition( [ 'frm_saving_draft' => 1 ], 106 );
+		$integration->entry = (object) [
+			'is_draft'       => 0,
+			'parent_item_id' => 0,
+		];
+		$integration->on_update_success( 106, 7 );
 		$this->assertSame( 1, $observed );
 	}
 

--- a/tests/php/tests/FormSubmissionPhases_Test.php
+++ b/tests/php/tests/FormSubmissionPhases_Test.php
@@ -340,9 +340,9 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 				return (object) [ 'is_draft' => 0 ];
 			}
 		};
-		$integration->on_success( 'entry-95', 7 );
+		$integration->on_success( 95, 7 );
 
-		$this->assertSame( 'entry-95', $observed['submission_id'] );
+		$this->assertSame( 95, $observed['submission_id'] );
 		$this->assertTrue( $observed['ajax'] );
 		$this->assertSame(
 			[
@@ -369,6 +369,9 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 			/** @var object|null */
 			public $entry;
 
+			/** @var int */
+			public $entry_loads = 0;
+
 			/**
 			 * Return a non-AJAX synthetic form.
 			 *
@@ -386,17 +389,32 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 			 * @return object|null
 			 */
 			protected function get_entry( $entry_id ) {
+				++$this->entry_loads;
 				return $this->entry;
 			}
 		};
+
+		foreach ( [ null, [], new stdClass(), 0, -1, 1.5, 'entry-100' ] as $invalid_entry_id ) {
+			$integration->on_success( $invalid_entry_id, 7, [ 'is_child' => false ] );
+		}
+		$this->assertSame( 0, $integration->entry_loads );
 
 		$integration->entry = (object) [ 'is_draft' => 1 ];
 		$integration->on_success( 101, 7, [ 'is_child' => false ] );
 		$integration->entry = (object) [ 'is_draft' => 0 ];
 		$integration->on_success( 102, 7, [ 'is_child' => true ] );
+		$integration->entry = (object) [
+			'is_draft'       => 0,
+			'parent_item_id' => 101,
+		];
+		$integration->on_success( 103, 7, [ 'is_child' => false ] );
 		$this->assertSame( 0, $observed );
 
-		$integration->on_success( 103, 7, [ 'is_child' => false ] );
+		$integration->entry = (object) [
+			'is_draft'       => 0,
+			'parent_item_id' => 0,
+		];
+		$integration->on_success( '104', 7, [ 'is_child' => false ] );
 		$this->assertSame( 1, $observed );
 	}
 

--- a/tests/unit/formidableforms-integration.test.js
+++ b/tests/unit/formidableforms-integration.test.js
@@ -1,0 +1,66 @@
+describe( 'Formidable Forms success integration', () => {
+	let handler;
+	let formSubmission;
+	let savingDraft;
+
+	beforeEach( () => {
+		jest.resetModules();
+		formSubmission = jest.fn();
+		savingDraft = undefined;
+		window.PUM = {
+			getPopup: jest.fn( () => 'popup' ),
+			integrations: { formSubmission },
+		};
+		window.jQuery = jest.fn( ( target ) => {
+			if ( target === document ) {
+				return {
+					on: jest.fn( ( _eventName, callback ) => {
+						handler = callback;
+					} ),
+				};
+			}
+
+			return {
+				find: jest.fn( ( selector ) => ( {
+					val: () => {
+						if ( 'input[name="frm_saving_draft"]' === selector ) {
+							return savingDraft;
+						}
+						return 'form_id' ===
+							selector.match( /name="([^"]+)"/ )?.[ 1 ]
+							? '7'
+							: '42';
+					},
+				} ) ),
+			};
+		} );
+
+		require( '../../assets/js/src/integration/formidableforms' );
+	} );
+
+	test( 'ignores AJAX draft completion messages', () => {
+		savingDraft = '1';
+		handler( {}, document.createElement( 'form' ), {
+			content: '<div class="frm_message">Draft saved</div>',
+		} );
+
+		expect( formSubmission ).not.toHaveBeenCalled();
+		expect( window.PUM.getPopup ).not.toHaveBeenCalled();
+	} );
+
+	test( 'observes submitted parent completion messages once', () => {
+		handler( {}, document.createElement( 'form' ), {
+			content: '<div class="frm_message">Success</div>',
+		} );
+
+		expect( formSubmission ).toHaveBeenCalledTimes( 1 );
+		expect( formSubmission ).toHaveBeenCalledWith( expect.anything(), {
+			popup: 'popup',
+			formProvider: 'formidableforms',
+			formId: '7',
+			extras: {
+				response: { content: '<div class="frm_message">Success</div>' },
+			},
+		} );
+	} );
+} );


### PR DESCRIPTION
## Outcome

Keeps Core as the sole normalized Formidable submission dispatcher while accepting only the submitted top-level entry. Draft entries and repeater/embedded child entries can no longer become independent popup conversions or action dispatches.

This is the linked correctness prerequisite for PopupMaker/Pro#143. Pro only enriches the one Core envelope at priority 9; it does not redispatch provider success.

## Validation

- `composer tests -- --filter FormSubmissionPhases_Test` — 14 tests, 43 assertions
- focused PHPCS — clean
- `git diff --check` — clean

## API impact

No new public hook or filter. The existing provider callback now accepts Formidable’s documented third context argument and verifies the native entry state before dispatch.

## Stack

Base: #1363 (`feature/form-provider-success-guards`)

Related Pro issue: PopupMaker/Pro#143