### PR TITLE
Fix Bit Form create-only submission dispatch

### DIFF
--- a/classes/Integration/Form/BitForm.php
+++ b/classes/Integration/Form/BitForm.php
@@ -187,7 +187,7 @@ class PUM_Integration_Form_BitForm extends PUM_Abstract_Integration_Form {
 	 * @param mixed $form_data Form data.
 	 */
 	public function on_success( $form_id, $entry_id, $form_data ) {
-		if ( ! $this->should_process_submission() ) {
+		if ( $this->is_entry_update_request() || ! $this->should_process_submission() ) {
 			return;
 		}
 
@@ -201,5 +201,23 @@ class PUM_Integration_Form_BitForm extends PUM_Abstract_Integration_Form {
 				'submission_id' => is_scalar( $entry_id ) ? $entry_id : null,
 			]
 		);
+	}
+
+	/**
+	 * Whether Bit Form is reporting a frontend entry update rather than a create.
+	 *
+	 * Bit Form 3.2.2 fires its generic submit-success action for both transports.
+	 * The dedicated update hook runs afterward, too late to prevent a conversion.
+	 *
+	 * @return bool
+	 */
+	protected function is_entry_update_request() {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Provider validates the request; this only classifies its transport.
+		$action = isset( $_REQUEST['action'] ) && is_scalar( $_REQUEST['action'] )
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			? sanitize_key( wp_unslash( (string) $_REQUEST['action'] ) )
+			: '';
+
+		return in_array( $action, [ 'bitforms_entry_update', 'bitforms_update_form_entry' ], true );
 	}
 }

--- a/tests/php/tests/FormSubmissionPhases_Test.php
+++ b/tests/php/tests/FormSubmissionPhases_Test.php
@@ -24,6 +24,7 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 	public function tearDown(): void {
 		PUM_Integrations::$form_submission = null;
 		unset( $_REQUEST['pum_form_popup_id'] );
+		unset( $_REQUEST['action'] );
 		unset( $_POST['gform_ajax'] );
 
 		if ( $this->observation_action ) {
@@ -37,6 +38,35 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 		}
 
 		parent::tearDown();
+	}
+
+	/**
+	 * Bit Form creates emit once while entry-update transports emit nothing.
+	 */
+	public function test_bit_form_requires_a_create_success_receipt() {
+		if ( ! class_exists( 'PUM_Integration_Form_BitForm' ) ) {
+			require_once PUM_PATH . 'classes/Integration/Form/BitForm.php';
+		}
+
+		$observed                 = 0;
+		$this->observation_action = static function () use ( &$observed ) {
+			++$observed;
+		};
+		add_action( 'pum_integrated_form_submission', $this->observation_action );
+
+		$integration = new PUM_Integration_Form_BitForm();
+		foreach ( [ 'bitforms_entry_update', 'bitforms_update_form_entry' ] as $action ) {
+			$_REQUEST['action'] = $action;
+			$integration->on_success( 7, 41, [ 'email' => 'updated@example.test' ] );
+		}
+		$this->assertSame( 0, $observed );
+
+		// A provider validation failure never fires bitform_submit_success.
+		unset( $_REQUEST['action'] );
+		$this->assertSame( 0, $observed );
+
+		$integration->on_success( 7, 42, [ 'email' => 'created@example.test' ] );
+		$this->assertSame( 1, $observed );
 	}
 
 	/**


### PR DESCRIPTION
Stacks on #1364 and supports PopupMaker/Pro#144.

Bit Form 3.2.2 fires `bitform_submit_success` for both new submissions and frontend entry updates. This guard preserves the normalized event for successful creates, including no-storage forms, while excluding both native update AJAX actions. Validation failures remain excluded because the provider never fires its success hook.

Tests:
- `vendor/bin/phpunit --configuration tests/php/phpunit.xml --filter FormSubmissionPhases_Test` (16 tests, 52 assertions)
- focused PHPCS on changed files

No new hook or public API.