### PR TITLE
Normalize HappyForms native form IDs

### DIFF
--- a/classes/Integration/Form/HappyForms.php
+++ b/classes/Integration/Form/HappyForms.php
@@ -120,8 +120,8 @@ class PUM_Integration_Form_HappyForms extends PUM_Abstract_Integration_Form {
 	/**
 	 * Hooks in a success function specific to this provider for non-AJAX submission handling.
 	 *
-	 * @param array $submission The submission data.
-	 * @param array $form       The form data.
+	 * @param mixed $submission The submission data.
+	 * @param mixed $form       The form data.
 	 */
 	public function on_success( $submission, $form ) {
 		if ( ! $this->should_process_submission() ) {
@@ -130,7 +130,15 @@ class PUM_Integration_Form_HappyForms extends PUM_Abstract_Integration_Form {
 
 		$popup_id = $this->get_popup_id();
 
-		$form_id = isset( $form['id'] ) ? (string) $form['id'] : null;
+		if ( ! is_array( $form ) ) {
+			return;
+		}
+
+		$form_id = isset( $form['ID'] ) ? $form['ID'] : ( $form['id'] ?? null );
+		if ( ! is_scalar( $form_id ) || ! ctype_digit( (string) $form_id ) || (int) $form_id < 1 ) {
+			return;
+		}
+		$form_id = (string) $form_id;
 
 		pum_integrated_form_submission(
 			[

--- a/tests/php/tests/FormSubmissionPhases_Test.php
+++ b/tests/php/tests/FormSubmissionPhases_Test.php
@@ -71,6 +71,32 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * HappyForms normalizes its native uppercase form ID without inventing one.
+	 */
+	public function test_happyforms_requires_a_valid_native_form_id() {
+		if ( ! class_exists( 'PUM_Integration_Form_HappyForms' ) ) {
+			require_once PUM_PATH . 'classes/Integration/Form/HappyForms.php';
+		}
+
+		$observed                 = [];
+		$this->observation_action = static function ( $args ) use ( &$observed ) {
+			if ( 'happyforms' === $args['form_provider'] ) {
+				$observed[] = $args;
+			}
+		};
+		add_action( 'pum_integrated_form_submission', $this->observation_action );
+
+		new PUM_Integration_Form_HappyForms();
+		do_action( 'happyforms_submission_success', [], [ 'ID' => 701 ], [] );
+		do_action( 'happyforms_submission_success', [], [ 'id' => 702 ], [] );
+		do_action( 'happyforms_submission_success', [], [ 'ID' => [] ], [] );
+
+		$this->assertCount( 2, $observed );
+		$this->assertSame( '701', $observed[0]['form_id'] );
+		$this->assertSame( '702', $observed[1]['form_id'] );
+	}
+
+	/**
 	 * Normal requests authorize every phase by default.
 	 */
 	public function test_normal_request_defaults_authorize_all_phases() {


### PR DESCRIPTION
## Summary
- read HappyForms 1.26.15's authoritative uppercase `ID` form key
- retain a defensive lowercase fallback for compatible integrations
- reject malformed/missing form identities before normalized dispatch
- add regression coverage for one dispatch per valid native form ID

This is the minimal Core correctness dependency discovered by the real-provider smoke for PopupMaker/Pro#145. Pro does not guess or emit a second submission.

## Tests
- `vendor/bin/phpunit --configuration tests/php/phpunit.xml --filter FormSubmissionPhases_Test` (17 tests, 62 assertions)
- focused PHPStan and PHPCS clean
- real HappyForms 1.26.15 hook smoke continues in the stacked Pro PR
