### PR TITLE
Normalize builder and MC4WP server success

### DIFF
--- a/classes/Integration/Form/BeaverBuilder.php
+++ b/classes/Integration/Form/BeaverBuilder.php
@@ -12,6 +12,15 @@
 class PUM_Integration_Form_BeaverBuilder extends PUM_Abstract_Integration_Form {
 
 	/**
+	 * Register Beaver Builder's server-authoritative success hooks.
+	 */
+	public function __construct() {
+		add_action( 'fl_module_contact_form_after_send', [ $this, 'on_contact_success' ], 10, 6 );
+		add_action( 'fl_builder_subscribe_form_submission_complete', [ $this, 'on_subscribe_success' ], 10, 6 );
+		add_action( 'fl_builder_login_form_submission_complete', [ $this, 'on_login_success' ], 10, 5 );
+	}
+
+	/**
 	 * Integration key.
 	 *
 	 * @var string
@@ -89,6 +98,74 @@ class PUM_Integration_Form_BeaverBuilder extends PUM_Abstract_Integration_Form {
 			'subscribe_any' => __( 'Any Subscribe Form', 'popup-maker' ),
 			'login_any'     => __( 'Any Login Form', 'popup-maker' ),
 		];
+	}
+
+	/**
+	 * Normalize a Contact Form only after its native mail action succeeds.
+	 *
+	 * @param mixed $mailto   Recipient.
+	 * @param mixed $subject  Subject.
+	 * @param mixed $template Message template.
+	 * @param mixed $headers  Mail headers.
+	 * @param mixed $settings Module settings.
+	 * @param mixed $result   Native wp_mail() result.
+	 */
+	public function on_contact_success( $mailto, $subject, $template, $headers, $settings, $result ) {
+		if ( true !== $result ) {
+			return;
+		}
+
+		$this->dispatch_success( 'contact' );
+	}
+
+	/**
+	 * Normalize a Subscribe Form after Beaver Builder reports success.
+	 *
+	 * @param mixed $response    Native response.
+	 * @param mixed $settings    Module settings.
+	 * @param mixed $email       Submitted email.
+	 * @param mixed $name        Submitted name.
+	 * @param mixed $template_id Template ID.
+	 * @param mixed $post_id     Post ID.
+	 */
+	public function on_subscribe_success( $response, $settings, $email, $name, $template_id, $post_id ) {
+		$this->dispatch_success( 'subscribe' );
+	}
+
+	/**
+	 * Normalize a Login Form after Beaver Builder reports success.
+	 *
+	 * @param mixed $settings    Module settings.
+	 * @param mixed $password    Submitted password.
+	 * @param mixed $name        Submitted username.
+	 * @param mixed $template_id Template ID.
+	 * @param mixed $post_id     Post ID.
+	 */
+	public function on_login_success( $settings, $password, $name, $template_id, $post_id ) {
+		$this->dispatch_success( 'login' );
+	}
+
+	/**
+	 * Dispatch one normalized receipt for the successful native module request.
+	 *
+	 * Beaver Builder verifies its AJAX request before firing these hooks. The
+	 * node ID therefore identifies the same module instance used by Core's
+	 * browser observation without adding a second transport or provider action.
+	 *
+	 * @param string $type Native module type.
+	 */
+	private function dispatch_success( $type ) {
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Beaver Builder verifies the native AJAX request before its success hooks fire.
+		$node_id = isset( $_REQUEST['node_id'] ) && is_scalar( $_REQUEST['node_id'] ) ? sanitize_key( wp_unslash( $_REQUEST['node_id'] ) ) : '';
+		$form_id = $type . '_' . ( '' !== $node_id ? $node_id : 'any' );
+
+		pum_integrated_form_submission(
+			[
+				'popup_id'      => $this->get_popup_id(),
+				'form_provider' => $this->key,
+				'form_id'       => $form_id,
+			]
+		);
 	}
 
 	/**

--- a/classes/Integration/Form/BricksBuilder.php
+++ b/classes/Integration/Form/BricksBuilder.php
@@ -17,12 +17,54 @@ class PUM_Integration_Form_BricksBuilder extends PUM_Abstract_Integration_Form {
 	 * Constructor - Set up cache invalidation hooks.
 	 */
 	public function __construct() {
+		add_filter( 'bricks/form/response', [ $this, 'on_response' ], 10, 2 );
+
 		// Clear cache when Bricks content is updated.
 		add_action( 'updated_post_meta', [ $this, 'maybe_clear_cache' ], 10, 4 );
 		add_action( 'added_post_meta', [ $this, 'maybe_clear_cache' ], 10, 4 );
 		add_action( 'deleted_post_meta', [ $this, 'maybe_clear_cache' ], 10, 4 );
 		add_action( 'wp_trash_post', [ $this, 'clear_forms_cache' ] );
 		add_action( 'untrash_post', [ $this, 'clear_forms_cache' ] );
+	}
+
+	/**
+	 * Normalize the final successful Bricks response.
+	 *
+	 * Bricks applies this filter after validation and configured form actions.
+	 * Failed responses remain untouched and never become normalized receipts.
+	 *
+	 * @param mixed $response Native response.
+	 * @param mixed $form     Native form runtime.
+	 * @return mixed
+	 */
+	public function on_response( $response, $form ) {
+		if (
+			! is_array( $response ) ||
+			'success' !== ( $response['type'] ?? null ) ||
+			! is_object( $form ) ||
+			! method_exists( $form, 'get_fields' )
+		) {
+			return $response;
+		}
+
+		$fields  = $form->get_fields();
+		$form_id = is_array( $fields ) && isset( $fields['formId'] ) && is_scalar( $fields['formId'] )
+			? sanitize_key( (string) $fields['formId'] )
+			: '';
+
+		if ( '' === $form_id ) {
+			return $response;
+		}
+
+		pum_integrated_form_submission(
+			[
+				'popup_id'      => $this->get_popup_id(),
+				'form_provider' => $this->key,
+				'form_id'       => $form_id,
+			]
+		);
+
+		return $response;
 	}
 
 	/**

--- a/classes/Integration/Form/MC4WP.php
+++ b/classes/Integration/Form/MC4WP.php
@@ -9,6 +9,13 @@
 class PUM_Integration_Form_MC4WP extends PUM_Abstract_Integration_Form {
 
 	/**
+	 * Register the provider's server-authoritative accepted-subscription hook.
+	 */
+	public function __construct() {
+		add_action( 'mc4wp_form_subscribed', [ $this, 'on_subscribed' ], 10, 4 );
+	}
+
+	/**
 	 * Unique key identifier for this provider.
 	 *
 	 * @var string
@@ -71,6 +78,32 @@ class PUM_Integration_Form_MC4WP extends PUM_Abstract_Integration_Form {
 		}
 
 		return $form_selectlist;
+	}
+
+	/**
+	 * Normalize a subscription only after Mailchimp accepted it.
+	 *
+	 * API errors and blocked duplicate attempts do not fire this hook.
+	 *
+	 * @param mixed $form  Submitted MC4WP form.
+	 * @param mixed $email Accepted subscriber email.
+	 * @param mixed $data  Submitted merge fields.
+	 * @param mixed $map   Subscriber map keyed by list ID.
+	 * @return void
+	 */
+	public function on_subscribed( $form, $email, $data, $map ) {
+		$form_id = is_object( $form ) && isset( $form->ID ) && is_scalar( $form->ID ) ? absint( $form->ID ) : 0;
+		if ( 0 === $form_id ) {
+			return;
+		}
+
+		pum_integrated_form_submission(
+			[
+				'popup_id'      => $this->get_popup_id(),
+				'form_provider' => $this->key,
+				'form_id'       => $form_id,
+			]
+		);
 	}
 
 	/**

--- a/tests/php/tests/FormSubmissionPhases_Test.php
+++ b/tests/php/tests/FormSubmissionPhases_Test.php
@@ -26,6 +26,7 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 		unset( $_REQUEST['pum_form_popup_id'] );
 		unset( $_REQUEST['_wp_http_referer'] );
 		unset( $_REQUEST['action'] );
+		unset( $_REQUEST['node_id'] );
 		unset( $_POST['gform_ajax'] );
 
 		if ( $this->observation_action ) {
@@ -39,6 +40,120 @@ class FormSubmissionPhases_Test extends WP_UnitTestCase {
 		}
 
 		parent::tearDown();
+	}
+
+	/**
+	 * Beaver Builder's native success hooks dispatch each module once.
+	 */
+	public function test_beaver_builder_native_success_hooks_dispatch_once() {
+		if ( ! class_exists( 'PUM_Integration_Form_BeaverBuilder' ) ) {
+			require_once PUM_PATH . 'classes/Integration/Form/BeaverBuilder.php';
+		}
+
+		$observed                 = [];
+		$actions                  = 0;
+		$this->observation_action = static function ( $args ) use ( &$observed ) {
+			if ( 'beaverbuilder' === $args['form_provider'] ) {
+				$observed[] = $args;
+			}
+		};
+		$this->runner_action      = static function ( $args ) use ( &$actions ) {
+			if ( 'beaverbuilder' === $args['form_provider'] ) {
+				++$actions;
+			}
+		};
+		add_action( 'pum_integrated_form_submission', $this->observation_action );
+		add_action( 'pum_integrated_form_submission_actions', $this->runner_action );
+
+		$integration = new PUM_Integration_Form_BeaverBuilder();
+		$this->assertSame( 10, has_action( 'fl_module_contact_form_after_send', [ $integration, 'on_contact_success' ] ) );
+		$this->assertSame( 10, has_action( 'fl_builder_subscribe_form_submission_complete', [ $integration, 'on_subscribe_success' ] ) );
+		$this->assertSame( 10, has_action( 'fl_builder_login_form_submission_complete', [ $integration, 'on_login_success' ] ) );
+
+		$_REQUEST['node_id'] = 'contact-node';
+		$integration->on_contact_success( null, null, null, null, null, false );
+		$integration->on_contact_success( null, null, null, null, null, true );
+		$_REQUEST['node_id'] = 'subscribe-node';
+		$integration->on_subscribe_success( [], null, 'person@example.test', 'Person', 1, 2 );
+		$_REQUEST['node_id'] = 'login-node';
+		$integration->on_login_success( null, null, 'person', 1, 2 );
+
+		$this->assertSame( [ 'contact_contact-node', 'subscribe_subscribe-node', 'login_login-node' ], wp_list_pluck( $observed, 'form_id' ) );
+		$this->assertSame( 3, $actions );
+	}
+
+	/**
+	 * Bricks dispatches only a final successful response with native identity.
+	 */
+	public function test_bricks_native_response_dispatches_one_valid_success() {
+		if ( ! class_exists( 'PUM_Integration_Form_BricksBuilder' ) ) {
+			require_once PUM_PATH . 'classes/Integration/Form/BricksBuilder.php';
+		}
+
+		$observed                 = [];
+		$actions                  = 0;
+		$this->observation_action = static function ( $args ) use ( &$observed ) {
+			if ( 'bricksbuilder' === $args['form_provider'] ) {
+				$observed[] = $args;
+			}
+		};
+		$this->runner_action      = static function ( $args ) use ( &$actions ) {
+			if ( 'bricksbuilder' === $args['form_provider'] ) {
+				++$actions;
+			}
+		};
+		add_action( 'pum_integrated_form_submission', $this->observation_action );
+		add_action( 'pum_integrated_form_submission_actions', $this->runner_action );
+
+		$form        = new class() {
+			/** @return array<string,string> */
+			public function get_fields() {
+				return [ 'formId' => 'Bricks-42' ];
+			}
+		};
+		$integration = new PUM_Integration_Form_BricksBuilder();
+		$this->assertSame( 10, has_filter( 'bricks/form/response', [ $integration, 'on_response' ] ) );
+
+		$error   = [
+			'type'    => 'error',
+			'message' => 'Nope',
+		];
+		$success = [
+			'type'    => 'success',
+			'message' => 'Sent',
+		];
+		$this->assertSame( $error, $integration->on_response( $error, $form ) );
+		$this->assertSame( $success, $integration->on_response( $success, new stdClass() ) );
+		$this->assertSame( $success, $integration->on_response( $success, $form ) );
+
+		$this->assertCount( 1, $observed );
+		$this->assertSame( 'bricks-42', $observed[0]['form_id'] );
+		$this->assertSame( 1, $actions );
+	}
+
+	/**
+	 * MC4WP dispatches only its accepted server-side subscription hook.
+	 */
+	public function test_mc4wp_accepted_subscription_dispatches_once() {
+		if ( ! class_exists( 'PUM_Integration_Form_MC4WP' ) ) {
+			require_once PUM_PATH . 'classes/Integration/Form/MC4WP.php';
+		}
+
+		$observed                 = [];
+		$this->observation_action = static function ( $args ) use ( &$observed ) {
+			if ( 'mc4wp' === $args['form_provider'] ) {
+				$observed[] = $args;
+			}
+		};
+		add_action( 'pum_integrated_form_submission', $this->observation_action );
+
+		$integration = new PUM_Integration_Form_MC4WP();
+		$this->assertSame( 10, has_action( 'mc4wp_form_subscribed', [ $integration, 'on_subscribed' ] ) );
+		$integration->on_subscribed( (object) [ 'ID' => null ], 'invalid@example.test', [], [] );
+		$integration->on_subscribed( (object) [ 'ID' => 23 ], 'accepted@example.test', [], [] );
+
+		$this->assertCount( 1, $observed );
+		$this->assertSame( 23, $observed[0]['form_id'] );
 	}
 
 	/**


### PR DESCRIPTION
Adds the minimal Core-owned server dispatches required by Pro provider capabilities.

- Bricks: final successful response only
- Beaver Builder: successful Contact, Subscribe, and Login module callbacks
- MC4WP: accepted remote subscription only
- One normalized dispatch; Pro enriches at priority 9

Focused PHPCS and syntax checks pass. Linked Pro issues: PopupMaker/Pro#146 and PopupMaker/Pro#147.