### PR TITLE
Use endpoint-scoped changelog token workflow

### DIFF
--- a/.github/workflows/changelog-backfill.yml
+++ b/.github/workflows/changelog-backfill.yml
@@ -25,7 +25,7 @@ permissions:
 jobs:
   backfill:
     name: Review or run Core changelog backfill
-    uses: code-atlantic/release-changelog-action/.github/workflows/backfill-releases.yml@7af898299ba0704f385b236569ead17850388437
+    uses: code-atlantic/release-changelog-action/.github/workflows/backfill-releases.yml@e21a0260c19a4723ffe1145014a916d3c48936e2
     with:
       product-key: core
       expected-repository: PopupMaker/Popup-Maker
@@ -34,5 +34,6 @@ jobs:
       dry-run: ${{ inputs.dry_run }}
     secrets:
       WORDPRESS_URL: ${{ secrets.WORDPRESS_URL }}
+      WORDPRESS_ACCESS_TOKEN: ${{ secrets.WORDPRESS_ACCESS_TOKEN }}
       WORDPRESS_USERNAME: ${{ secrets.WORDPRESS_USERNAME }}
       WORDPRESS_APPLICATION_PASSWORD: ${{ secrets.WORDPRESS_APPLICATION_PASSWORD }}

--- a/.github/workflows/changelog-sync.yml
+++ b/.github/workflows/changelog-sync.yml
@@ -16,12 +16,13 @@ permissions:
 jobs:
   changelog:
     name: Sync review-required WordPress draft
-    uses: code-atlantic/release-changelog-action/.github/workflows/sync-release.yml@7af898299ba0704f385b236569ead17850388437
+    uses: code-atlantic/release-changelog-action/.github/workflows/sync-release.yml@e21a0260c19a4723ffe1145014a916d3c48936e2
     with:
       product-key: core
       expected-repository: PopupMaker/Popup-Maker
       release-id: ${{ format('{0}', github.event.release.id || inputs.release_id) }}
     secrets:
       WORDPRESS_URL: ${{ secrets.WORDPRESS_URL }}
+      WORDPRESS_ACCESS_TOKEN: ${{ secrets.WORDPRESS_ACCESS_TOKEN }}
       WORDPRESS_USERNAME: ${{ secrets.WORDPRESS_USERNAME }}
       WORDPRESS_APPLICATION_PASSWORD: ${{ secrets.WORDPRESS_APPLICATION_PASSWORD }}


### PR DESCRIPTION
Pins the changelog sync and backfill callers to the token-aware public reusable workflows.

Adds an explicit WORDPRESS_ACCESS_TOKEN mapping while retaining the existing username and Application Password mappings for a no-downtime compatibility transition. The public action prefers the endpoint token whenever it is present.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release changelog automation to use a newer workflow revision.
  * Added secure WordPress access credentials to support changelog backfill and synchronization.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->