### PR TITLE
fix(site): avoid forced-reflow race when multiple popups auto-open together

### DIFF
--- a/assets/js/src/site/plugins/pum.js
+++ b/assets/js/src/site/plugins/pum.js
@@ -872,12 +872,18 @@
 
 			if ( $popup.is( ':hidden' ) ) {
 				opacity.overlay = $popup.css( 'opacity' );
-				$popup.css( { opacity: 0 } ).show( 0 );
+				// Use a plain display write rather than .show(0): jQuery's
+				// show/hide are fx-queued and resolve on the next
+				// requestAnimationFrame tick even at duration 0, which left
+				// a pending queue entry on $popup that raced with the
+				// open() animation flow when multiple popups opened in the
+				// same tick.
+				$popup.css( { opacity: 0, display: 'block' } );
 			}
 
 			if ( $container.is( ':hidden' ) ) {
 				opacity.container = $container.css( 'opacity' );
-				$container.css( { opacity: 0 } ).show( 0 );
+				$container.css( { opacity: 0, display: 'block' } );
 			}
 
 			if ( settings.position_fixed ) {
@@ -940,10 +946,10 @@
 			}
 
 			if ( opacity.overlay ) {
-				$popup.css( { opacity: opacity.overlay } ).hide( 0 );
+				$popup.css( { opacity: opacity.overlay, display: 'none' } );
 			}
 			if ( opacity.container ) {
-				$container.css( { opacity: opacity.container } ).hide( 0 );
+				$container.css( { opacity: opacity.container, display: 'none' } );
 			}
 			return this;
 		},

--- a/assets/js/src/site/plugins/pum.js
+++ b/assets/js/src/site/plugins/pum.js
@@ -520,10 +520,20 @@
 				// TODO: Move this to its own event binding to keep this method clean and simple.
 				// This prevents animations from failing due to browser race conditions & styling queues.
 				.queue( function () {
-					var $container = $popup.popmake( 'getContainer' );
+					var el = this,
+						$container = $popup.popmake( 'getContainer' );
 					$popup.css( { display: 'block', opacity: 0 } );
 					$container.css( { display: 'block', opacity: 0 } );
-					$( this ).dequeue();
+
+					// Wait a frame so the browser paints the opacity:0 state
+					// before the animation starts. Using requestAnimationFrame
+					// instead of a synchronous forced reflow (offsetHeight)
+					// avoids one popup's unpainted style changes interleaving
+					// with another popup's open() call in the same tick, e.g.
+					// two Auto Open triggers with the same delay.
+					window.requestAnimationFrame( function () {
+						$( el ).dequeue();
+					} );
 				} )
 				.popmake( 'animate', settings.animation_type, function () {
 					/**
@@ -582,10 +592,6 @@
 				height: '',
 				width: '',
 			} );
-
-			// Force browser to drop any cached values
-			$popup[ 0 ].offsetHeight;
-			$container[ 0 ].offsetHeight;
 
 			return this;
 		},


### PR DESCRIPTION
## Summary

Fixes #1377.

`initializeState()` forced a synchronous browser reflow on every popup open, by reading `offsetHeight` right after clearing inline styles. When two Auto Open triggers share the same delay, they fire in the same script tick. The second popup's forced reflow flushes the first popup's pending `opacity: 0` style before the browser paints it. That breaks the first popup's animation start state, and it can stay hidden or skip its animation.

This forced reflow was added in v1.21.0 to fix a different set of animation bugs. It fixed those, but it opened this new race for popups that open together.

## Fix

- Removed the forced `offsetHeight` reflow from `initializeState()`.
- The open queue step now waits one `requestAnimationFrame` before it starts the animation, instead of forcing a reflow. This still gives the browser a paint boundary between resetting styles and starting the animation. It does not force a page-wide layout pass that can catch other popups mid-update.
- A second, separate async race in the same open flow was also found and fixed in a follow-up commit.

## Test plan

- [ ] Create two popups, both with the Auto Open trigger and the same delay.
- [ ] Load a page where both are active. Confirm both open and animate in.
- [ ] Create three or more popups with staggered delays. Confirm each still opens correctly.
- [ ] Confirm a single popup with Auto Open still opens and animates as before.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popup opening animations for smoother, more reliable behavior.
  * Prevented animation queue conflicts that could cause popups or overlays to display incorrectly.
  * Reduced unnecessary visual flickering during popup repositioning and initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->