### PR TITLE
fix(assets): restore admin localization of package vars

### DIFF
--- a/classes/Controllers/Assets.php
+++ b/classes/Controllers/Assets.php
@@ -625,7 +625,7 @@ class Assets extends Controller {
 					}
 				}
 
-				if ( isset( $package_data['varsName'] ) && ! empty( $package_data['vars'] ) && ! isset( $this->localized_packages[ $package ] ) && 'admin_print_scripts' !== current_filter() ) {
+				if ( isset( $package_data['varsName'] ) && ! empty( $package_data['vars'] ) && ! isset( $this->localized_packages[ $package ] ) ) {
 					$localized_vars = is_callable( $package_data['vars'] ) ?
 					call_user_func( $package_data['vars'] ) :
 					$package_data['vars'];


### PR DESCRIPTION
## Summary

Fixes #1379.

`autoload_styles_for_scripts()` in `classes/Controllers/Assets.php` is only ever hooked to `wp_print_scripts` (front end) and `admin_print_scripts` (wp-admin). A guard added in `52a17cb1` (#1316) skipped the localization branch whenever the current hook was `admin_print_scripts`. Since that's the only wp-admin hook this method runs on, the guard stopped `wp_localize_script()` / `pum_localize_script()` from ever running in wp-admin, for every non-bundled admin package (block editor, admin bar, CTA admin, CTA editor, dashboard).

In the block editor, this left `window.popupMakerBlockEditor` undefined. A module reads `popupTriggerExcludedBlocks` off that object at the top of the file, with no fallback, so it throws right away. The build bundles every module into one file, so the error stopped the rest of that file from running, including the line that registers the Popup Title sidebar panel.

## Fix

Drop the `'admin_print_scripts' !== current_filter()` check. The `$this->localized_packages` per-request cache added in the same commit already stops duplicate localization, so the hook-name check was redundant, and wrong.

## Test plan

- [x] Built a clean production zip (`pnpm run release`) from this branch and installed on a local test site.
- [x] Opened a popup in the block editor. Confirmed the console error is gone.
- [x] Confirmed the Popup Title panel shows in the sidebar again.
- [x] Confirmed the Popup Title panel shows as an option in the editor's Preferences panel list.
- [ ] Confirm other admin packages that use `varsName`/`vars` (admin bar, CTA admin, CTA editor, dashboard) still localize correctly in wp-admin.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Package variables are now correctly available on administrative pages, improving script behavior across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->