### PR TITLE
fix(admin): let core wire up the settings/tools notice dismiss button

### DIFF
--- a/classes/Admin/Settings.php
+++ b/classes/Admin/Settings.php
@@ -81,9 +81,6 @@ class PUM_Admin_Settings {
 					echo esc_html( $notice['message'] );
 					?>
 					</strong></p>
-					<button type="button" class="notice-dismiss">
-						<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'popup-maker' ); ?></span>
-					</button>
 				</div>
 				<?php
 			}

--- a/classes/Admin/Tools.php
+++ b/classes/Admin/Tools.php
@@ -64,9 +64,6 @@ class PUM_Admin_Tools {
 				?>
 				<div class="notice notice-<?php echo esc_attr( $notice['type'] ); ?> is-dismissible">
 					<p><strong><?php esc_html( $notice['message'] ); ?></strong></p>
-					<button type="button" class="notice-dismiss">
-						<span class="screen-reader-text"><?php esc_html_e( 'Dismiss this notice.', 'popup-maker' ); ?></span>
-					</button>
 				</div>
 				<?php
 			}


### PR DESCRIPTION
## Summary

Fixes #1385.

`Settings.php` and `Tools.php` both hand-render their own `<button class="notice-dismiss">` inside their admin notices, but never bind a click handler to it.

WordPress core's `makeNoticesDismissible()` in `wp-admin/js/common.js` skips wiring up its own dismiss handler whenever a `.notice-dismiss` element already exists in the notice, on the assumption something else owns it:

```js
if ( $el.find( '.notice-dismiss' ).length ) {
    return;
}
```

With nothing else binding a handler, the X button rendered but did nothing.

## Fix

Remove the hand-rendered `<button class="notice-dismiss">…</button>` block from both files. `Popups.php` and `Subscribers/Table.php` already render the same `notice.is-dismissible` pattern without a pre-rendered button, and core auto-injects a working one for those. This matches that pattern instead of adding new JavaScript.

## Test plan

- [x] Built a clean production zip (`pnpm run release`) from this branch and installed on a local test site.
- [x] Saved settings on the Settings page, confirmed the success notice's X button dismisses it.
- [x] Confirmed no other PHP or JavaScript in the plugin references the removed button markup.
- [ ] Confirm the error-styled notice variant on the Settings page (license activation failure) also dismisses correctly — same code path, no type-specific logic, but not independently exercised.
- [ ] Confirm the Tools page's Easy Modal import notice also dismisses correctly — same code path as Settings.php, not independently exercised.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated admin notices to display without dismiss buttons.
  * Removed associated screen-reader dismissal text from admin notices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->