### PR TITLE
Fix remaining release workflow review gaps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,12 @@ name: CI - Code Quality
 on:
   pull_request:
   workflow_dispatch:
+    inputs:
+      back_sync:
+        description: Run code-quality validation for a release back-sync merge.
+        required: false
+        default: false
+        type: boolean
 
 env:
   WP_VERSION: '7.1'
@@ -32,16 +38,16 @@ jobs:
   detect-changes:
     name: Detect Changes
     runs-on: ubuntu-latest
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' || inputs.back_sync == true }}
     # NOTE: With files_yaml:, outputs are {category}_any_changed
     outputs:
-      php: ${{ steps.changes.outputs.php_any_changed }}
-      js: ${{ steps.changes.outputs.js_any_changed }}           # All JS/TS (for ESLint)
-      js_src: ${{ steps.changes.outputs.js_src_any_changed }}   # All source JS/TS (for build)
-      ts_src: ${{ steps.changes.outputs.ts_src_any_changed }}   # TypeScript only (for tsc)
-      css: ${{ steps.changes.outputs.css_any_changed }}
-      npm_deps: ${{ steps.changes.outputs.npm_deps_any_changed }}
-      php_deps: ${{ steps.changes.outputs.php_deps_any_changed }}
+      php: ${{ inputs.back_sync == true || steps.changes.outputs.php_any_changed }}
+      js: ${{ inputs.back_sync == true || steps.changes.outputs.js_any_changed }}           # All JS/TS (for ESLint)
+      js_src: ${{ inputs.back_sync == true || steps.changes.outputs.js_src_any_changed }}   # All source JS/TS (for build)
+      ts_src: ${{ inputs.back_sync == true || steps.changes.outputs.ts_src_any_changed }}   # TypeScript only (for tsc)
+      css: ${{ inputs.back_sync == true || steps.changes.outputs.css_any_changed }}
+      npm_deps: ${{ inputs.back_sync == true || steps.changes.outputs.npm_deps_any_changed }}
+      php_deps: ${{ inputs.back_sync == true || steps.changes.outputs.php_deps_any_changed }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -100,7 +106,7 @@ jobs:
     name: PHP ${{ matrix.php-version }} - Code Quality
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: ${{ github.event_name == 'pull_request' && needs.detect-changes.outputs.php == 'true' }}
+    if: ${{ (github.event_name == 'pull_request' || inputs.back_sync == true) && needs.detect-changes.outputs.php == 'true' }}
 
     strategy:
       fail-fast: false
@@ -189,7 +195,7 @@ jobs:
     name: JS/TS Code Quality
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: ${{ github.event_name == 'pull_request' && (needs.detect-changes.outputs.js == 'true' || needs.detect-changes.outputs.css == 'true') }}
+    if: ${{ (github.event_name == 'pull_request' || inputs.back_sync == true) && (needs.detect-changes.outputs.js == 'true' || needs.detect-changes.outputs.css == 'true') }}
 
     steps:
       - name: Checkout code
@@ -291,7 +297,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: detect-changes
     # Only build when source files change (not config/tooling JS)
-    if: ${{ github.event_name == 'pull_request' && (needs.detect-changes.outputs.js_src == 'true' || needs.detect-changes.outputs.npm_deps == 'true') }}
+    if: ${{ (github.event_name == 'pull_request' || inputs.back_sync == true) && (needs.detect-changes.outputs.js_src == 'true' || needs.detect-changes.outputs.npm_deps == 'true') }}
 
     steps:
       - name: Checkout code
@@ -450,7 +456,7 @@ jobs:
     name: pnpm Security Audit
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: ${{ github.event_name == 'pull_request' && needs.detect-changes.outputs.npm_deps == 'true' }}
+    if: ${{ (github.event_name == 'pull_request' || inputs.back_sync == true) && needs.detect-changes.outputs.npm_deps == 'true' }}
 
     steps:
       - name: Checkout code
@@ -479,7 +485,7 @@ jobs:
     name: Composer Security Audit
     runs-on: ubuntu-latest
     needs: detect-changes
-    if: ${{ github.event_name == 'pull_request' && needs.detect-changes.outputs.php_deps == 'true' }}
+    if: ${{ (github.event_name == 'pull_request' || inputs.back_sync == true) && needs.detect-changes.outputs.php_deps == 'true' }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.checkout_ref || github.sha }}
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Detect file changes
@@ -134,6 +135,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.checkout_ref || github.sha }}
+          persist-credentials: false
           fetch-depth: 0
 
       # NOTE: Using `files:` (not files_yaml) → outputs are just `any_changed`
@@ -217,6 +219,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.checkout_ref || github.sha }}
+          persist-credentials: false
           fetch-depth: 0
 
       # NOTE: Using `files:` (not files_yaml) → outputs are just `any_changed`
@@ -320,6 +323,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.checkout_ref || github.sha }}
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -382,6 +386,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.checkout_ref || github.sha }}
+          persist-credentials: false
           fetch-depth: 0
 
       - name: Setup PHP
@@ -482,6 +487,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.checkout_ref || github.sha }}
+          persist-credentials: false
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -513,6 +519,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.checkout_ref || github.sha }}
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -554,6 +561,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ inputs.checkout_ref || github.sha }}
+          persist-credentials: false
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,7 @@
 name: CI - Code Quality
 
+run-name: CI - Code Quality (${{ inputs.validation_id || github.ref_name }})
+
 on:
   pull_request:
   workflow_dispatch:
@@ -9,6 +11,17 @@ on:
         required: false
         default: false
         type: boolean
+      checkout_ref:
+        description: Commit to validate while using the trusted workflow from master.
+        required: false
+        type: string
+      validation_id:
+        description: Correlation ID for a release back-sync validation run.
+        required: false
+        type: string
+
+permissions:
+  contents: read
 
 env:
   WP_VERSION: '7.1'
@@ -16,7 +29,7 @@ env:
 
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.validation_id || github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -52,6 +65,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           fetch-depth: 0
 
       - name: Detect file changes
@@ -119,6 +133,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           fetch-depth: 0
 
       # NOTE: Using `files:` (not files_yaml) → outputs are just `any_changed`
@@ -201,6 +216,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           fetch-depth: 0
 
       # NOTE: Using `files:` (not files_yaml) → outputs are just `any_changed`
@@ -302,6 +318,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -363,6 +381,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
           fetch-depth: 0
 
       - name: Setup PHP
@@ -461,6 +480,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -490,6 +511,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
@@ -529,6 +552,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.checkout_ref || github.sha }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/deploy-readme-assets.yml
+++ b/.github/workflows/deploy-readme-assets.yml
@@ -4,12 +4,8 @@ on:
     pull_request_target:
         branches: [master]
         types: [closed]
-    workflow_dispatch:
-        inputs:
-            pull_request_number:
-                description: Merged readme/assets PR number to retry.
-                required: true
-                type: number
+    repository_dispatch:
+        types: [retry_approved_readme_assets_pr]
 
 permissions:
     contents: read
@@ -32,13 +28,19 @@ jobs:
             - name: Verify merged PR, approval, and exact file scope
               id: authorize
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  RETRY_PULL_REQUEST_NUMBER: ${{ github.event.client_payload.pull_request_number }}
               with:
                   script: |
                       const owner = context.repo.owner;
                       const repo = context.repo.repo;
-                      const number = context.eventName === 'workflow_dispatch'
-                        ? Number('${{ inputs.pull_request_number }}')
+                      const number = context.eventName === 'repository_dispatch'
+                        ? Number(process.env.RETRY_PULL_REQUEST_NUMBER)
                         : context.payload.pull_request.number;
+                      if (!Number.isSafeInteger(number) || number < 1) {
+                        core.setFailed('A valid merged readme/assets PR number is required.');
+                        return;
+                      }
                       const { data: pull } = await github.rest.pulls.get({ owner, repo, pull_number: number });
 
                       core.setOutput('should_sync', 'false');
@@ -143,6 +145,20 @@ jobs:
                     echo 'A newer readme or asset change exists on master. Refusing to publish stale files.'
                     exit 1
                   fi
+
+            - name: Validate the stable tag
+              run: |
+                  node <<'NODE'
+                  const fs = require('fs');
+                  const packageVersion = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
+                  const stableTag = fs.readFileSync('readme.txt', 'utf8')
+                    .match(/^Stable tag:\s*([^\s]+)\s*$/m)?.[1];
+                  if (stableTag !== packageVersion) {
+                    throw new Error(
+                      `readme.txt Stable tag ${stableTag || '(missing)'} does not match package.json ${packageVersion}.`
+                    );
+                  }
+                  NODE
 
             - name: Reject symlinked publication files
               run: |

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -2,9 +2,13 @@ name: PR target check
 
 on:
     pull_request_target:
-        types: [opened, edited]
+        types: [opened, edited, synchronize]
         branches:
             - master
+
+permissions:
+    contents: read
+    pull-requests: write
 
 jobs:
     redirect:
@@ -15,7 +19,51 @@ jobs:
           !(github.event.pull_request.head.repo.full_name == github.repository &&
             startsWith(github.event.pull_request.head.ref, 'release/'))
         steps:
+            - name: Check for an authorized readme/assets PR
+              id: target
+              uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              with:
+                  result-encoding: string
+                  script: |
+                      const pull = context.payload.pull_request;
+                      if (pull.head.repo?.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+                        return 'retarget';
+                      }
+
+                      let permission = '';
+                      try {
+                        const response = await github.rest.repos.getCollaboratorPermissionLevel({
+                          ...context.repo,
+                          username: pull.user.login,
+                        });
+                        permission = response.data.permission;
+                      } catch (error) {
+                        if (error.status !== 404) throw error;
+                      }
+                      if (!['admin', 'maintain', 'write'].includes(permission)) {
+                        return 'retarget';
+                      }
+
+                      const files = await github.paginate(github.rest.pulls.listFiles, {
+                        ...context.repo,
+                        pull_number: pull.number,
+                        per_page: 100,
+                      });
+                      const isAllowedPath = (filename) =>
+                        filename === 'readme.txt' || filename.startsWith('.wordpress-org/');
+                      const removesReadme = files.some((file) =>
+                        (file.filename === 'readme.txt' && file.status === 'removed') ||
+                        (file.status === 'renamed' && file.previous_filename === 'readme.txt')
+                      );
+                      const readmeAssetsOnly = files.length > 0 && !removesReadme && files.every((file) =>
+                        isAllowedPath(file.filename) &&
+                        (file.status !== 'renamed' || isAllowedPath(file.previous_filename || ''))
+                      );
+
+                      return readmeAssetsOnly ? 'allow' : 'retarget';
+
             - name: Retarget to develop
+              if: steps.target.outputs.result == 'retarget'
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -14,8 +14,6 @@ jobs:
     redirect:
         runs-on: ubuntu-latest
         if: >-
-          github.event.pull_request.author_association != 'OWNER' &&
-          github.event.pull_request.author_association != 'MEMBER' &&
           !(github.event.pull_request.head.repo.full_name == github.repository &&
             startsWith(github.event.pull_request.head.ref, 'release/'))
         steps:

--- a/.github/workflows/pr-target-check.yml
+++ b/.github/workflows/pr-target-check.yml
@@ -2,7 +2,7 @@ name: PR target check
 
 on:
     pull_request_target:
-        types: [opened, edited, synchronize]
+        types: [opened, reopened, edited, synchronize]
         branches:
             - master
 

--- a/.github/workflows/publication-gate.yml
+++ b/.github/workflows/publication-gate.yml
@@ -61,6 +61,21 @@ jobs:
                     echo "type=none" >> "${GITHUB_OUTPUT}"
                   fi
 
+            - name: Validate readme stable tag
+              if: steps.publication.outputs.type == 'readme-assets'
+              run: |
+                  node <<'NODE'
+                  const fs = require('fs');
+                  const packageVersion = JSON.parse(fs.readFileSync('package.json', 'utf8')).version;
+                  const stableTag = fs.readFileSync('readme.txt', 'utf8')
+                    .match(/^Stable tag:\s*([^\s]+)\s*$/m)?.[1];
+                  if (stableTag !== packageVersion) {
+                    throw new Error(
+                      `readme.txt Stable tag ${stableTag || '(missing)'} does not match package.json ${packageVersion}.`
+                    );
+                  }
+                  NODE
+
             - name: Set up PHP
               if: steps.publication.outputs.type == 'release'
               uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -498,10 +498,13 @@ jobs:
                   gh api --method POST "repos/${REPO}/git/refs" \
                     -f ref="refs/heads/${VALIDATION_BRANCH}" \
                     -f sha="${MERGE_SHA}" >/dev/null
+                  VALIDATION_ID="back-sync-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
                   gh workflow run ci.yml \
                     --repo "${REPO}" \
-                    --ref "${VALIDATION_BRANCH}" \
-                    -f back_sync=true
+                    --ref master \
+                    -f back_sync=true \
+                    -f checkout_ref="${MERGE_SHA}" \
+                    -f validation_id="${VALIDATION_ID}"
                   gh workflow run tests.yml \
                     --repo "${REPO}" \
                     --ref "${VALIDATION_BRANCH}" \
@@ -513,11 +516,12 @@ jobs:
                     CI_RUN_ID=$(gh run list \
                       --repo "${REPO}" \
                       --workflow ci.yml \
-                      --branch "${VALIDATION_BRANCH}" \
+                      --branch master \
                       --event workflow_dispatch \
-                      --limit 1 \
-                      --json databaseId \
-                      --jq '.[0].databaseId // ""')
+                      --limit 20 \
+                      --json databaseId,displayTitle \
+                      --jq ".[] | select(.displayTitle == \"CI - Code Quality (${VALIDATION_ID})\") | .databaseId" \
+                      | head -n 1)
                     TEST_RUN_ID=$(gh run list \
                       --repo "${REPO}" \
                       --workflow tests.yml \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,12 +4,8 @@ on:
     pull_request_target:
         branches: [master]
         types: [closed]
-    workflow_dispatch:
-        inputs:
-            pull_request_number:
-                description: Merged release PR number to retry.
-                required: true
-                type: number
+    repository_dispatch:
+        types: [retry_approved_release_pr]
 
 permissions:
     contents: read
@@ -28,7 +24,7 @@ jobs:
     authorize:
         name: Authorize approved release PR
         if: >-
-            github.event_name == 'workflow_dispatch' ||
+            github.event_name == 'repository_dispatch' ||
             (github.event.pull_request.merged == true &&
              startsWith(github.event.pull_request.head.ref, 'release/'))
         runs-on: ubuntu-latest
@@ -42,13 +38,19 @@ jobs:
             - name: Verify merged PR, approval, branch, and tag
               id: authorize
               uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+              env:
+                  RETRY_PULL_REQUEST_NUMBER: ${{ github.event.client_payload.pull_request_number }}
               with:
                   script: |
                       const owner = context.repo.owner;
                       const repo = context.repo.repo;
-                      const number = context.eventName === 'workflow_dispatch'
-                        ? Number('${{ inputs.pull_request_number }}')
+                      const number = context.eventName === 'repository_dispatch'
+                        ? Number(process.env.RETRY_PULL_REQUEST_NUMBER)
                         : context.payload.pull_request.number;
+                      if (!Number.isSafeInteger(number) || number < 1) {
+                        core.setFailed('A valid merged release PR number is required.');
+                        return;
+                      }
                       const { data: pull } = await github.rest.pulls.get({ owner, repo, pull_number: number });
 
                       if (!pull.merged || pull.base.ref !== 'master') {
@@ -496,13 +498,26 @@ jobs:
                   gh api --method POST "repos/${REPO}/git/refs" \
                     -f ref="refs/heads/${VALIDATION_BRANCH}" \
                     -f sha="${MERGE_SHA}" >/dev/null
+                  gh workflow run ci.yml \
+                    --repo "${REPO}" \
+                    --ref "${VALIDATION_BRANCH}" \
+                    -f back_sync=true
                   gh workflow run tests.yml \
                     --repo "${REPO}" \
                     --ref "${VALIDATION_BRANCH}" \
                     -f back_sync=true
 
+                  CI_RUN_ID=""
                   TEST_RUN_ID=""
                   for _ in {1..30}; do
+                    CI_RUN_ID=$(gh run list \
+                      --repo "${REPO}" \
+                      --workflow ci.yml \
+                      --branch "${VALIDATION_BRANCH}" \
+                      --event workflow_dispatch \
+                      --limit 1 \
+                      --json databaseId \
+                      --jq '.[0].databaseId // ""')
                     TEST_RUN_ID=$(gh run list \
                       --repo "${REPO}" \
                       --workflow tests.yml \
@@ -511,16 +526,22 @@ jobs:
                       --limit 1 \
                       --json databaseId \
                       --jq '.[0].databaseId // ""')
-                    [ -n "${TEST_RUN_ID}" ] && break
+                    [ -n "${CI_RUN_ID}" ] && [ -n "${TEST_RUN_ID}" ] && break
                     sleep 2
                   done
-                  if [ -z "${TEST_RUN_ID}" ]; then
-                    echo 'The back-sync validation workflow did not start.'
+                  if [ -z "${CI_RUN_ID}" ] || [ -z "${TEST_RUN_ID}" ]; then
+                    echo 'The back-sync validation workflows did not start.'
                     exit 1
                   fi
 
-                  echo "Waiting for back-sync validation run ${TEST_RUN_ID}."
-                  gh run watch "${TEST_RUN_ID}" --repo "${REPO}" --exit-status
+                  echo "Waiting for back-sync CI run ${CI_RUN_ID} and test run ${TEST_RUN_ID}."
+                  VALIDATION_FAILED=0
+                  gh run watch "${CI_RUN_ID}" --repo "${REPO}" --exit-status || VALIDATION_FAILED=1
+                  gh run watch "${TEST_RUN_ID}" --repo "${REPO}" --exit-status || VALIDATION_FAILED=1
+                  if [ "${VALIDATION_FAILED}" -ne 0 ]; then
+                    echo 'Back-sync validation failed.'
+                    exit 1
+                  fi
 
     slack-success:
         name: Slack success notification

--- a/bin/prepare-release.js
+++ b/bin/prepare-release.js
@@ -238,6 +238,12 @@ function getReleasePullRequestDisposition( pullRequest ) {
 	}
 }
 
+/**
+ * Select the authoritative release PR when a branch has PR history.
+ *
+ * @param {Array<{state: string}>} pullRequests Release PR candidates.
+ * @return {Object|null} The selected release PR, if one exists.
+ */
 function selectReleasePullRequest( pullRequests ) {
 	if ( ! Array.isArray( pullRequests ) ) {
 		return null;

--- a/bin/prepare-release.js
+++ b/bin/prepare-release.js
@@ -238,6 +238,23 @@ function getReleasePullRequestDisposition( pullRequest ) {
 	}
 }
 
+function selectReleasePullRequest( pullRequests ) {
+	if ( ! Array.isArray( pullRequests ) ) {
+		return null;
+	}
+
+	return (
+		pullRequests.find(
+			( pullRequest ) => pullRequest.state === 'MERGED'
+		) ||
+		pullRequests.find( ( pullRequest ) => pullRequest.state === 'OPEN' ) ||
+		pullRequests.find(
+			( pullRequest ) => pullRequest.state === 'CLOSED'
+		) ||
+		null
+	);
+}
+
 // Check git status.
 function checkGitStatus() {
 	const status = execCommand( 'git status --porcelain', { silent: true } );
@@ -423,12 +440,14 @@ async function stageFinish() {
 		return;
 	}
 
-	const existingPullRequest = execCommand(
-		'gh pr view --json number,state,baseRefName,url',
+	const existingPullRequests = execCommand(
+		`gh pr list --head release/${ version } --base master --state all --limit 100 --json number,state,baseRefName,url`,
 		{ silent: true, allowFailure: true }
 	);
-	if ( existingPullRequest ) {
-		const pullRequest = JSON.parse( existingPullRequest );
+	if ( existingPullRequests ) {
+		const pullRequest = selectReleasePullRequest(
+			JSON.parse( existingPullRequests )
+		);
 		const disposition = getReleasePullRequestDisposition( pullRequest );
 
 		if ( disposition === 'reuse' ) {
@@ -515,6 +534,7 @@ if ( require.main === module ) {
 
 module.exports = {
 	getReleasePullRequestDisposition,
+	selectReleasePullRequest,
 };
 
 /* eslint-enable no-console */

--- a/bin/prepare-release.js
+++ b/bin/prepare-release.js
@@ -221,6 +221,23 @@ function getCurrentBranch() {
 	return branch.trim();
 }
 
+function getReleasePullRequestDisposition( pullRequest ) {
+	if ( ! pullRequest || pullRequest.baseRefName !== 'master' ) {
+		return 'create';
+	}
+
+	switch ( pullRequest.state ) {
+		case 'OPEN':
+			return 'reuse';
+		case 'CLOSED':
+			return 'reopen';
+		case 'MERGED':
+			return 'merged';
+		default:
+			return 'create';
+	}
+}
+
 // Check git status.
 function checkGitStatus() {
 	const status = execCommand( 'git status --porcelain', { silent: true } );
@@ -407,12 +424,29 @@ async function stageFinish() {
 	}
 
 	const existingPullRequest = execCommand(
-		'gh pr view --json url --jq .url',
+		'gh pr view --json number,state,baseRefName,url',
 		{ silent: true, allowFailure: true }
 	);
 	if ( existingPullRequest ) {
-		success( `Release PR already exists: ${ existingPullRequest.trim() }` );
-		return;
+		const pullRequest = JSON.parse( existingPullRequest );
+		const disposition = getReleasePullRequestDisposition( pullRequest );
+
+		if ( disposition === 'reuse' ) {
+			success( `Release PR already exists: ${ pullRequest.url }` );
+			return;
+		}
+
+		if ( disposition === 'reopen' ) {
+			log( `Reopening release PR #${ pullRequest.number }`, 'cyan' );
+			execCommand( `gh pr reopen ${ pullRequest.number }` );
+			success( `Release PR reopened: ${ pullRequest.url }` );
+			return;
+		}
+
+		if ( disposition === 'merged' ) {
+			error( `Release PR already merged: ${ pullRequest.url }` );
+			process.exit( 1 );
+		}
 	}
 
 	const pullRequestUrl = execCommand(
@@ -467,16 +501,20 @@ async function main() {
 	}
 }
 
-// Handle Ctrl+C gracefully.
-process.on( 'SIGINT', () => {
-	console.log( '' );
-	warn( 'Release process interrupted by user' );
-	process.exit( 130 );
-} );
-
 // Run the script.
 if ( require.main === module ) {
+	// Handle Ctrl+C gracefully.
+	process.on( 'SIGINT', () => {
+		console.log( '' );
+		warn( 'Release process interrupted by user' );
+		process.exit( 130 );
+	} );
+
 	main();
 }
+
+module.exports = {
+	getReleasePullRequestDisposition,
+};
 
 /* eslint-enable no-console */

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -29,15 +29,31 @@ After those checks pass, `release.yml` builds one canonical ZIP and uses that sa
 -   the review-required visual changelog draft; and
 -   Slack status.
 
-It also opens or reuses a `master` to `develop` back-sync PR, tests that PR's proposed merge, and waits for those tests before reporting success. A failed downstream step is visible and can be retried by manually running the workflow with the original merged PR number.
+It also opens or reuses a `master` to `develop` back-sync PR, runs both code-quality and test workflows against that PR's proposed merge, and waits for both before reporting success.
+
+A failed release can be retried through the default-branch-only repository dispatch event with the original merged PR number:
+
+```bash
+gh api --method POST repos/PopupMaker/Popup-Maker/dispatches \
+  -f event_type=retry_approved_release_pr \
+  -F 'client_payload[pull_request_number]=123'
+```
 
 Direct tags and direct pushes to `master` do not publish a plugin release. A merged release PR publishes only when authorized by a current maintainer approval or an authorized maintainer merge.
 
 ## WordPress.org readme and assets
 
-A same-repository PR containing only `readme.txt` and/or files below `.wordpress-org/` may be opened against `master`. After a current maintainer approves it or an authorized maintainer merges it, `deploy-readme-assets.yml` re-checks the authorization and exact file list, then syncs only those files to WordPress.org.
+A same-repository PR containing only `readme.txt` and/or files below `.wordpress-org/` may be opened against `master`. After a current maintainer approves it or an authorized maintainer merges it, `deploy-readme-assets.yml` re-checks the authorization, exact file list, and stable tag before syncing only those files to WordPress.org.
 
 A mixed code/readme PR never enters this narrow path. Release PRs deploy their readme and assets with the full canonical package.
+
+Retry an approved readme/assets sync through its default-branch-only repository dispatch event:
+
+```bash
+gh api --method POST repos/PopupMaker/Popup-Maker/dispatches \
+  -f event_type=retry_approved_readme_assets_pr \
+  -F 'client_payload[pull_request_number]=123'
+```
 
 ## PR publication preview
 
@@ -47,7 +63,7 @@ A mixed code/readme PR never enters this narrow path. Release PRs deploy their r
 -   readme/assets-only update; or
 -   no publication.
 
-Release PRs also build and verify a downloadable candidate ZIP before approval.
+Release PRs also build and verify a downloadable candidate ZIP before approval. Readme/assets PRs must keep the stable tag aligned with the canonical package version.
 
 ## Development builds
 

--- a/docs/github-actions.md
+++ b/docs/github-actions.md
@@ -29,7 +29,7 @@ After those checks pass, `release.yml` builds one canonical ZIP and uses that sa
 -   the review-required visual changelog draft; and
 -   Slack status.
 
-It also opens or reuses a `master` to `develop` back-sync PR, runs both code-quality and test workflows against that PR's proposed merge, and waits for both before reporting success.
+It also opens or reuses a `master` to `develop` back-sync PR, runs both code-quality and test workflows against that PR's proposed merge, and waits for both before reporting success. Code-quality validation uses the trusted workflow definition from `master` and checks out the proposed merge SHA as data.
 
 A failed release can be retried through the default-branch-only repository dispatch event with the original merged PR number:
 

--- a/tests/unit/bin/prepare-release.test.js
+++ b/tests/unit/bin/prepare-release.test.js
@@ -1,0 +1,27 @@
+const {
+	getReleasePullRequestDisposition,
+} = require( '../../../bin/prepare-release' );
+
+describe( 'release PR disposition', () => {
+	test.each( [
+		[ 'OPEN', 'reuse' ],
+		[ 'CLOSED', 'reopen' ],
+		[ 'MERGED', 'merged' ],
+	] )( 'classifies a %s PR targeting master', ( state, expected ) => {
+		expect(
+			getReleasePullRequestDisposition( {
+				state,
+				baseRefName: 'master',
+			} )
+		).toBe( expected );
+	} );
+
+	test( 'creates a master PR when the existing PR targets another branch', () => {
+		expect(
+			getReleasePullRequestDisposition( {
+				state: 'OPEN',
+				baseRefName: 'develop',
+			} )
+		).toBe( 'create' );
+	} );
+} );

--- a/tests/unit/bin/prepare-release.test.js
+++ b/tests/unit/bin/prepare-release.test.js
@@ -1,5 +1,6 @@
 const {
 	getReleasePullRequestDisposition,
+	selectReleasePullRequest,
 } = require( '../../../bin/prepare-release' );
 
 describe( 'release PR disposition', () => {
@@ -23,5 +24,15 @@ describe( 'release PR disposition', () => {
 				baseRefName: 'develop',
 			} )
 		).toBe( 'create' );
+	} );
+
+	test( 'selects the master PR safely when a branch has multiple PRs', () => {
+		expect(
+			selectReleasePullRequest( [
+				{ number: 10, state: 'CLOSED' },
+				{ number: 11, state: 'MERGED' },
+				{ number: 12, state: 'OPEN' },
+			] )
+		).toEqual( { number: 11, state: 'MERGED' } );
 	} );
 } );


### PR DESCRIPTION
## Summary

Follow-up to #1384 after auditing every conversation comment, review body, and inline thread against the merged code.

- run production retries through default-branch `repository_dispatch` events instead of branch-selectable workflow code
- validate retry PR numbers without interpolating event input into GitHub Script source
- run and await both CI quality and test workflows against the proposed back-sync merge
- reopen a matching closed release PR instead of silently treating it as active
- validate `readme.txt` Stable tag against the canonical package version before merge and before WordPress.org sync
- keep authorized same-repository readme/assets PRs on `master`, while rechecking their scope on every update

The audit also confirmed that the pinned 10up WordPress.org deploy action already treats an existing SVN version tag as a successful idempotent retry, so no change was made for that invalid finding.

## Validation

- 10 focused Jest assertions passed
- changed JavaScript passed ESLint
- changed YAML parsed with `yq`
- embedded GitHub Script bodies passed Node syntax checks in async wrappers
- stable-tag steps executed successfully against the current repository state
- readme/assets target classification passed 7 allow/retarget cases
- Prettier passed for newly formatted files
- `git diff --check` passed

No release or WordPress.org publication path is eligible from this non-`release/*`, mixed-file infrastructure PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Process**
  - Improved release pull request handling, including reopening eligible closed requests and preventing reuse of merged or incorrectly targeted requests.
  - Added more reliable retry support for releases and readme/asset synchronizations.
  - Back-sync operations now validate code-quality and test checks before completing.

- **Validation**
  - Readme/assets publication verifies that the stable tag matches the package version.
  - Pull request targeting rules are stricter, while eligible documentation-only updates are handled automatically.

- **Documentation**
  - Updated release workflow guidance to reflect the new checks and retry process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->