### PR TITLE
Harden WordPress.org release packaging and status reporting

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -317,6 +317,7 @@ jobs:
         needs: [authorize, build, github-release]
         runs-on: ubuntu-latest
         env:
+            CANONICAL_BUILD_DIR: ${{ github.workspace }}/.canonical-build/popup-maker
             BUILD_DIR: ${{ github.workspace }}/.wordpress-org-build/popup-maker
 
         steps:
@@ -336,9 +337,18 @@ jobs:
                   ZIP_NAME: ${{ needs.build.outputs.zip_name }}
               run: |
                   node bin/verify-release-artifact.js "${ZIP_NAME}"
-                  mkdir -p "$(dirname "${BUILD_DIR}")"
-                  unzip -o "${ZIP_NAME}" -d "$(dirname "${BUILD_DIR}")"
-                  test -f "${BUILD_DIR}/popup-maker.php"
+                  mkdir -p "$(dirname "${CANONICAL_BUILD_DIR}")"
+                  unzip -o "${ZIP_NAME}" -d "$(dirname "${CANONICAL_BUILD_DIR}")"
+                  test -f "${CANONICAL_BUILD_DIR}/popup-maker.php"
+
+            - name: Prepare and verify WordPress.org artifact
+              run: |
+                  mkdir -p "${BUILD_DIR}"
+                  rsync -a --delete \
+                    --exclude-from='.wordpress-org-excludes' \
+                    "${CANONICAL_BUILD_DIR}/" "${BUILD_DIR}/"
+                  node bin/verify-wordpress-org-artifact.js \
+                    "${BUILD_DIR}" '.wordpress-org-excludes'
 
             - name: Run WordPress Plugin Check
               uses: wordpress/plugin-check-action@10857da14b6c2246d15402b3e69f777edcf8c12e # v1
@@ -480,8 +490,11 @@ jobs:
 
                   MERGE_SHA=""
                   for _ in {1..30}; do
-                    MERGE_SHA=$(gh api "repos/${REPO}/git/ref/pull/${PR_NUMBER}/merge" --jq '.object.sha' 2>/dev/null || true)
-                    [ -n "${MERGE_SHA}" ] && break
+                    MERGE_SHA=$(gh api "repos/${REPO}/git/ref/pull/${PR_NUMBER}/merge" --jq '.object.sha // empty' 2>/dev/null | tail -n 1 || true)
+                    if [[ "${MERGE_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+                      break
+                    fi
+                    MERGE_SHA=""
                     sleep 2
                   done
                   if [ -z "${MERGE_SHA}" ]; then
@@ -562,12 +575,8 @@ jobs:
             ]
         if: >-
             always() &&
-            needs.github-release.result == 'success' &&
             needs.wordpress-org.result == 'success' &&
-            needs.edd-webhook.result == 'success' &&
-            needs.google-drive-upload.result == 'success' &&
-            needs.changelog.result == 'success' &&
-            needs.back-sync.result == 'success'
+            needs.edd-webhook.result == 'success'
         runs-on: ubuntu-latest
         steps:
             - name: Send success notification
@@ -576,15 +585,39 @@ jobs:
                   VERSION: ${{ needs.authorize.outputs.version }}
                   RELEASE_URL: ${{ needs.github-release.outputs.release_url }}
                   DRIVE_URL: ${{ needs.google-drive-upload.outputs.download_link }}
+                  DRIVE_RESULT: ${{ needs.google-drive-upload.result }}
+                  CHANGELOG_RESULT: ${{ needs.changelog.result }}
+                  BACK_SYNC_RESULT: ${{ needs.back-sync.result }}
               run: |
                   if [ -z "${SLACK_WEBHOOK_URL}" ]; then
                     exit 0
+                  fi
+                  STATUS_LINES=$'✅ WordPress.org\n✅ EDD\n✅ GitHub release'
+                  FOLLOW_UP=""
+                  if [ "${DRIVE_RESULT}" = 'success' ]; then
+                    STATUS_LINES+=$'\n✅ Google Drive'
+                  else
+                    FOLLOW_UP+=$'\n• Google Drive ('"${DRIVE_RESULT}"$')'
+                  fi
+                  if [ "${CHANGELOG_RESULT}" = 'success' ]; then
+                    STATUS_LINES+=$'\n✅ Changelog draft'
+                  else
+                    FOLLOW_UP+=$'\n• Changelog draft ('"${CHANGELOG_RESULT}"$')'
+                  fi
+                  if [ "${BACK_SYNC_RESULT}" != 'success' ]; then
+                    FOLLOW_UP+=$'\n• Back-sync PR ('"${BACK_SYNC_RESULT}"$')'
+                  fi
+                  ADDENDUM=""
+                  if [ -n "${FOLLOW_UP}" ]; then
+                    ADDENDUM=$'\n\n⚠️ Follow-up needed:'"${FOLLOW_UP}"
                   fi
                   PAYLOAD=$(jq -n \
                     --arg version "${VERSION}" \
                     --arg release_url "${RELEASE_URL}" \
                     --arg drive_url "${DRIVE_URL}" \
-                    '{text: ("🚀 *Popup Maker " + $version + " released*\n\n✅ GitHub release\n✅ WordPress.org\n✅ EDD\n✅ Google Drive\n✅ Changelog draft\n\n<" + $release_url + "|View release>" + (if $drive_url != "" then " · <" + $drive_url + "|Download ZIP>" else "" end)), username: "Release Bot", icon_emoji: ":package:"}')
+                    --arg status_lines "${STATUS_LINES}" \
+                    --arg addendum "${ADDENDUM}" \
+                    '{text: ("🚀 *Popup Maker " + $version + " released*\n\n" + $status_lines + $addendum + "\n\n<" + $release_url + "|View release>" + (if $drive_url != "" then " · <" + $drive_url + "|Download ZIP>" else "" end)), username: "Release Bot", icon_emoji: ":package:"}')
                   curl -sS --fail -X POST "${SLACK_WEBHOOK_URL}" \
                     -H 'Content-Type: application/json' \
                     -d "${PAYLOAD}"
@@ -605,14 +638,8 @@ jobs:
         if: >-
             always() &&
             needs.authorize.result != 'skipped' &&
-            (needs.authorize.result == 'failure' ||
-             needs.build.result == 'failure' ||
-             needs.github-release.result == 'failure' ||
-             needs.wordpress-org.result == 'failure' ||
-             needs.edd-webhook.result == 'failure' ||
-             needs.google-drive-upload.result == 'failure' ||
-             needs.changelog.result == 'failure' ||
-             needs.back-sync.result == 'failure')
+            !(needs.wordpress-org.result == 'success' &&
+              needs.edd-webhook.result == 'success')
         runs-on: ubuntu-latest
         steps:
             - name: Send failure notification

--- a/.wordpress-org-excludes
+++ b/.wordpress-org-excludes
@@ -1,0 +1,6 @@
+# Translation catalogs are generated and tracked for non-WordPress.org builds.
+# WordPress.org distributes these files through translate.wordpress.org language packs.
+/languages/*.po
+/languages/*.mo
+/languages/*.json
+/languages/*.l10n.php

--- a/bin/verify-wordpress-org-artifact.js
+++ b/bin/verify-wordpress-org-artifact.js
@@ -1,0 +1,197 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+const fs = require( 'fs' );
+const path = require( 'path' );
+
+const requiredPaths = [
+	'popup-maker.php',
+	'readme.txt',
+	'languages/index.php',
+	'languages/popup-maker.pot',
+];
+
+/**
+ * Load the WordPress.org-only exclusion patterns.
+ *
+ * @param {string} manifestPath Exclusion manifest path.
+ * @return {string[]} Exclusion patterns.
+ */
+function loadExcludePatterns( manifestPath ) {
+	if ( ! fs.existsSync( manifestPath ) ) {
+		throw new Error(
+			`WordPress.org exclusion manifest not found: ${ manifestPath }`
+		);
+	}
+
+	const patterns = fs
+		.readFileSync( manifestPath, 'utf8' )
+		.split( /\r?\n/ )
+		.map( ( line ) => line.trim() )
+		.filter( ( line ) => line && ! line.startsWith( '#' ) );
+
+	if ( ! patterns.length ) {
+		throw new Error( 'WordPress.org exclusion manifest is empty.' );
+	}
+
+	for ( const pattern of patterns ) {
+		const normalized = pattern.replace( /^\//, '' );
+
+		if (
+			path.isAbsolute( normalized ) ||
+			normalized.split( '/' ).includes( '..' )
+		) {
+			throw new Error(
+				`Unsafe WordPress.org exclusion pattern: ${ pattern }`
+			);
+		}
+	}
+
+	return patterns;
+}
+
+/**
+ * Convert a Git-style exclusion glob to a regular expression.
+ *
+ * @param {string} pattern Exclusion pattern.
+ * @return {RegExp} Matching expression.
+ */
+function globPatternToRegExp( pattern ) {
+	let expression = '^';
+	const normalized = pattern.replace( /^\//, '' );
+
+	for ( let index = 0; index < normalized.length; index++ ) {
+		const character = normalized[ index ];
+
+		if ( '*' === character ) {
+			if ( '*' === normalized[ index + 1 ] ) {
+				expression += '.*';
+				index++;
+			} else {
+				expression += '[^/]*';
+			}
+		} else if ( '?' === character ) {
+			expression += '[^/]';
+		} else {
+			expression += character.replace( /[|\\{}()[\]^$+?.]/g, '\\$&' );
+		}
+	}
+
+	return new RegExp( `${ expression }$` );
+}
+
+/**
+ * List files beneath a build directory.
+ *
+ * @param {string} directory Directory to inspect.
+ * @param {string} prefix    Relative path prefix.
+ * @return {string[]} Relative file paths.
+ */
+function listFiles( directory, prefix = '' ) {
+	const files = [];
+
+	for ( const entry of fs.readdirSync( directory, {
+		withFileTypes: true,
+	} ) ) {
+		const relativePath = prefix
+			? `${ prefix }/${ entry.name }`
+			: entry.name;
+		const absolutePath = path.join( directory, entry.name );
+
+		if ( entry.isDirectory() ) {
+			files.push( ...listFiles( absolutePath, relativePath ) );
+		} else {
+			files.push( relativePath );
+		}
+	}
+
+	return files;
+}
+
+/**
+ * Find files forbidden by the WordPress.org exclusion contract.
+ *
+ * @param {string}   buildDir Build directory.
+ * @param {string[]} patterns Exclusion patterns.
+ * @return {string[]} Forbidden relative paths.
+ */
+function findExcludedPaths( buildDir, patterns ) {
+	const expressions = patterns.map( globPatternToRegExp );
+
+	return listFiles( buildDir )
+		.filter( ( relativePath ) =>
+			expressions.some( ( expression ) =>
+				expression.test( relativePath )
+			)
+		)
+		.sort();
+}
+
+/**
+ * Verify the staged WordPress.org artifact.
+ *
+ * @param {string} buildDir     Build directory.
+ * @param {string} manifestPath Exclusion manifest path.
+ * @return {string[]} Failures.
+ */
+function verifyWordPressOrgArtifact( buildDir, manifestPath ) {
+	if (
+		! fs.existsSync( buildDir ) ||
+		! fs.statSync( buildDir ).isDirectory()
+	) {
+		return [ `WordPress.org build directory not found: ${ buildDir }` ];
+	}
+
+	const patterns = loadExcludePatterns( manifestPath );
+	const failures = findExcludedPaths( buildDir, patterns ).map(
+		( relativePath ) =>
+			`excluded WordPress.org path present: ${ relativePath }`
+	);
+
+	for ( const requiredPath of requiredPaths ) {
+		if ( ! fs.existsSync( path.join( buildDir, requiredPath ) ) ) {
+			failures.push( `missing WordPress.org path: ${ requiredPath }` );
+		}
+	}
+
+	return failures;
+}
+
+function main() {
+	const buildDir = process.argv[ 2 ];
+	const manifestPath = process.argv[ 3 ] || '.wordpress-org-excludes';
+
+	if ( ! buildDir ) {
+		console.error(
+			'Usage: node bin/verify-wordpress-org-artifact.js <build-dir> [manifest]'
+		);
+		process.exitCode = 1;
+		return;
+	}
+
+	const failures = verifyWordPressOrgArtifact( buildDir, manifestPath );
+	if ( failures.length ) {
+		console.error( 'WordPress.org artifact verification failed:' );
+		for ( const failure of failures ) {
+			console.error( `- ${ failure }` );
+		}
+		process.exitCode = 1;
+		return;
+	}
+
+	console.log( 'WordPress.org artifact verification passed.' );
+}
+
+if ( require.main === module ) {
+	main();
+}
+
+module.exports = {
+	findExcludedPaths,
+	globPatternToRegExp,
+	listFiles,
+	loadExcludePatterns,
+	verifyWordPressOrgArtifact,
+};
+
+/* eslint-enable no-console */

--- a/package.json
+++ b/package.json
@@ -137,6 +137,7 @@
 		"start:hot": "wp-scripts start --hot --config webpack.config.js",
 		"release": "node bin/build-release.js",
 		"verify:release-artifact": "node bin/verify-release-artifact.js",
+		"verify:wordpress-org-artifact": "node bin/verify-wordpress-org-artifact.js",
 		"prepare-release": "node bin/prepare-release.js",
 		"prepare-release:patch": "node bin/prepare-release.js --patch",
 		"prepare-release:minor": "node bin/prepare-release.js --minor",

--- a/tests/unit/bin/verify-wordpress-org-artifact.test.js
+++ b/tests/unit/bin/verify-wordpress-org-artifact.test.js
@@ -1,0 +1,111 @@
+const fs = require( 'fs' );
+const os = require( 'os' );
+const path = require( 'path' );
+
+const {
+	findExcludedPaths,
+	globPatternToRegExp,
+	loadExcludePatterns,
+	verifyWordPressOrgArtifact,
+} = require( '../../../bin/verify-wordpress-org-artifact' );
+
+describe( 'WordPress.org artifact verifier', () => {
+	let temporaryRoot;
+	let buildDir;
+	let manifestPath;
+
+	beforeEach( () => {
+		temporaryRoot = fs.mkdtempSync(
+			path.join( os.tmpdir(), 'popup-maker-wordpress-org-verifier-' )
+		);
+		buildDir = path.join( temporaryRoot, 'popup-maker' );
+		manifestPath = path.join( temporaryRoot, '.wordpress-org-excludes' );
+
+		fs.mkdirSync( path.join( buildDir, 'languages' ), { recursive: true } );
+		for ( const relativePath of [
+			'popup-maker.php',
+			'readme.txt',
+			'languages/index.php',
+			'languages/popup-maker.pot',
+		] ) {
+			fs.writeFileSync( path.join( buildDir, relativePath ), 'fixture' );
+		}
+		fs.writeFileSync(
+			manifestPath,
+			'/languages/*.po\n/languages/*.mo\n/languages/*.json\n/languages/*.l10n.php\n'
+		);
+	} );
+
+	afterEach( () => {
+		fs.rmSync( temporaryRoot, { recursive: true, force: true } );
+	} );
+
+	test( 'accepts the WordPress.org payload without bundled language packs', () => {
+		expect( verifyWordPressOrgArtifact( buildDir, manifestPath ) ).toEqual(
+			[]
+		);
+	} );
+
+	test( 'rejects PO, MO, and JavaScript translation catalogs', () => {
+		for ( const fileName of [
+			'popup-maker-de_DE.po',
+			'popup-maker-de_DE.mo',
+			'popup-maker-de_DE-a1b2c3.json',
+			'popup-maker-de_DE.l10n.php',
+		] ) {
+			fs.writeFileSync(
+				path.join( buildDir, 'languages', fileName ),
+				'fixture'
+			);
+		}
+
+		const patterns = loadExcludePatterns( manifestPath );
+		expect( findExcludedPaths( buildDir, patterns ) ).toEqual( [
+			'languages/popup-maker-de_DE-a1b2c3.json',
+			'languages/popup-maker-de_DE.l10n.php',
+			'languages/popup-maker-de_DE.mo',
+			'languages/popup-maker-de_DE.po',
+		] );
+		expect(
+			verifyWordPressOrgArtifact( buildDir, manifestPath )
+		).toHaveLength( 4 );
+	} );
+
+	test( 'matches nested and single-directory exclusion globs', () => {
+		expect(
+			globPatternToRegExp( '/languages/*.json' ).test(
+				'languages/popup-maker-de_DE-hash.json'
+			)
+		).toBe( true );
+		expect(
+			globPatternToRegExp( '/languages/*.json' ).test(
+				'languages/nested/popup-maker-de_DE-hash.json'
+			)
+		).toBe( false );
+		expect(
+			globPatternToRegExp( '/languages/**/*.json' ).test(
+				'languages/nested/popup-maker-de_DE-hash.json'
+			)
+		).toBe( true );
+	} );
+
+	test( 'requires the POT template and directory guard', () => {
+		fs.rmSync( path.join( buildDir, 'languages', 'index.php' ) );
+		fs.rmSync( path.join( buildDir, 'languages', 'popup-maker.pot' ) );
+
+		expect( verifyWordPressOrgArtifact( buildDir, manifestPath ) ).toEqual(
+			expect.arrayContaining( [
+				'missing WordPress.org path: languages/index.php',
+				'missing WordPress.org path: languages/popup-maker.pot',
+			] )
+		);
+	} );
+
+	test( 'rejects unsafe exclusion patterns', () => {
+		fs.writeFileSync( manifestPath, '../languages/*.po\n' );
+
+		expect( () => loadExcludePatterns( manifestPath ) ).toThrow(
+			'Unsafe WordPress.org exclusion pattern'
+		);
+	} );
+} );


### PR DESCRIPTION
## Summary

- keep tracked/generated translation catalogs in the canonical GitHub/EDD package while stripping `.po`, `.mo`, hashed translation JSON, and future `.l10n.php` catalogs from the WordPress.org-only staging directory
- add an explicit `.wordpress-org-excludes` manifest and a dependency-free verifier that blocks SVN deployment when an excluded file survives staging
- validate merge SHAs before creating back-sync validation refs
- treat WordPress.org + EDD as the release-success gate and report Drive/changelog/back-sync failures as follow-up items instead of a failed release

## Evidence

- focused Jest: 10 tests passed
- JS lint: passed
- Prettier: passed
- actionlint: passed
- dependency-free verifier executed with Node only
- real 1.25 staging simulation: 364 translation catalogs in canonical source, 0 in WordPress.org stage; `languages/index.php` and `languages/popup-maker.pot` retained

## 1.25 note

The already-published 1.25.0 WordPress.org ZIP contains 28 PO, 28 MO, and 308 JSON files. This PR prevents recurrence; it does not rewrite the public 1.25.0 tag.