### PR TITLE
Refactor notification boot lifecycle

### DIFF
--- a/classes/Plugin/Core.php
+++ b/classes/Plugin/Core.php
@@ -352,9 +352,12 @@ final class Core extends \PopupMaker\Plugin\Container {
 		 * integrations) load at priority 12+ and need a window to register
 		 * their own providers and deferred trigger hooks before the Manager
 		 * resolves the provider list or registers frontend lazy boot hooks.
+		 *
+		 * How notifications actually come up — immediately in wp-admin, or
+		 * lazily on the frontend — is the Manager's decision, not ours.
 		 */
 		add_action( 'init', function () {
-			$this->get( 'notifications' )->register_lazy_boot();
+			$this->get( 'notifications' )->init();
 		}, 5 );
 	}
 

--- a/classes/Services/Notifications/Manager.php
+++ b/classes/Services/Notifications/Manager.php
@@ -36,6 +36,12 @@ defined( 'ABSPATH' ) || exit;
  * its own hooks (typically into `pum_alert_list`) inside its own
  * `init()` method.
  *
+ * Lifecycle: Core calls `init()` once on `init` priority 5 — late enough
+ * that addons loading on `plugins_loaded` priority 12+ have already had
+ * their window to register providers and deferred boot hooks. From there
+ * this class owns the boot decision: immediate in wp-admin, lazy on the
+ * frontend. Provider resolution itself happens once, in `boot()`.
+ *
  * @since 1.23.0
  */
 class Manager extends Service {
@@ -48,18 +54,33 @@ class Manager extends Service {
 	protected $providers = [];
 
 	/**
-	 * Guard so `init()` is idempotent — defensive against multiple `init`
-	 * action fires or repeated manual calls.
+	 * Guard so provider resolution happens at most once per request —
+	 * defensive against multiple `init` action fires or repeated manual calls.
 	 *
 	 * @var bool
 	 */
 	protected $booted = false;
 
 	/**
-	 * Boot the service — gather providers and wire each one.
+	 * Hooks this service registered for deferred frontend boot, so they can
+	 * be released once the manager actually boots.
 	 *
-	 * Safe to call multiple times; the guard ensures providers only hook
-	 * their WordPress events on the first call.
+	 * @var string[]
+	 */
+	protected $deferred_hooks = [];
+
+	/**
+	 * Initialize the notifications lifecycle.
+	 *
+	 * This is the single entry point Core calls (on `init` priority 5). The
+	 * manager — not the caller — decides how notifications come up:
+	 *
+	 * - wp-admin: boot immediately, since something is about to render alerts.
+	 * - Frontend: stay dormant and boot lazily if a notification-relevant
+	 *   event actually fires, so the typical frontend request never pays for
+	 *   provider construction.
+	 *
+	 * Safe to call repeatedly; provider hooks are only wired on first boot.
 	 *
 	 * @return void
 	 */
@@ -68,7 +89,33 @@ class Manager extends Service {
 			return;
 		}
 
+		if ( is_admin() ) {
+			$this->boot();
+			return;
+		}
+
+		$this->register_deferred_boot();
+	}
+
+	/**
+	 * Resolve and initialize providers exactly once.
+	 *
+	 * Every path that needs live providers funnels through here — immediate
+	 * admin boot, a deferred frontend hook, or an explicit `get_providers()`
+	 * call — so provider resolution has one home and one guard.
+	 *
+	 * @return void
+	 */
+	protected function boot() {
+		if ( $this->booted ) {
+			return;
+		}
+
 		$this->booted = true;
+
+		// Deferred triggers have done their job; stop listening so later hook
+		// fires don't keep calling back into an already-booted manager.
+		$this->release_deferred_boot();
 
 		$this->providers = $this->resolve_providers();
 
@@ -80,27 +127,43 @@ class Manager extends Service {
 	}
 
 	/**
-	 * Boot notifications immediately in wp-admin or defer them to relevant frontend hooks.
+	 * Listen for the frontend events that justify booting notifications.
 	 *
 	 * @return void
 	 */
-	public function register_lazy_boot() {
-		if ( is_admin() ) {
-			$this->init();
-			return;
-		}
+	protected function register_deferred_boot() {
+		$hooks = $this->get_deferred_boot_hooks();
 
-		foreach ( $this->get_deferred_boot_hooks() as $hook ) {
+		/*
+		 * An event may already have fired earlier in this request — an upgrade
+		 * dispatches popup_maker/update_version during plugins_loaded, before
+		 * init@5 gets here. Check every hook before registering any, so a late
+		 * match can't leave half the list wired to a booted manager.
+		 */
+		foreach ( $hooks as $hook ) {
 			if ( did_action( $hook ) || did_filter( $hook ) ) {
-				// The event already fired earlier in this request — e.g. an
-				// upgrade dispatches popup_maker/update_version during
-				// plugins_loaded, before this registration runs on init.
-				$this->init();
+				$this->boot();
 				return;
 			}
+		}
 
+		foreach ( $hooks as $hook ) {
+			$this->deferred_hooks[] = $hook;
 			add_filter( $hook, [ $this, 'boot_on_demand' ], PHP_INT_MIN );
 		}
+	}
+
+	/**
+	 * Detach the deferred boot listeners registered for this request.
+	 *
+	 * @return void
+	 */
+	protected function release_deferred_boot() {
+		foreach ( $this->deferred_hooks as $hook ) {
+			remove_filter( $hook, [ $this, 'boot_on_demand' ], PHP_INT_MIN );
+		}
+
+		$this->deferred_hooks = [];
 	}
 
 	/**
@@ -136,13 +199,27 @@ class Manager extends Service {
 	/**
 	 * Boot notification providers when a frontend request reaches a relevant hook.
 	 *
+	 * Hooked to arbitrary third-party-reachable filters, so it stays
+	 * permissive about its argument and returns it untouched.
+	 *
 	 * @param mixed $value Current filter value, if any.
 	 * @return mixed
 	 */
 	public function boot_on_demand( $value = null ) {
-		$this->init();
+		$this->boot();
 
 		return $value;
+	}
+
+	/**
+	 * Boot notifications immediately in wp-admin or defer them to relevant frontend hooks.
+	 *
+	 * @deprecated 1.25.0 Use `init()`, which now owns this decision.
+	 *
+	 * @return void
+	 */
+	public function register_lazy_boot() {
+		$this->init();
 	}
 
 	/**
@@ -151,10 +228,15 @@ class Manager extends Service {
 	 * Useful for debugging and for addons that want to swap or decorate
 	 * specific providers after registration.
 	 *
+	 * Asking for the providers is an explicit demand for them, so this forces
+	 * a boot rather than going through `init()` — on a frontend request
+	 * `init()` would only arm the deferred listeners and hand back an empty
+	 * list.
+	 *
 	 * @return array<int,Provider>
 	 */
 	public function get_providers() {
-		$this->init();
+		$this->boot();
 
 		return $this->providers;
 	}

--- a/tests/php/tests/Notification_Manager_Lifecycle_Test.php
+++ b/tests/php/tests/Notification_Manager_Lifecycle_Test.php
@@ -1,0 +1,423 @@
+<?php
+/**
+ * Tests for the Notifications Manager boot lifecycle.
+ *
+ * The Manager owns the decision of *how* notifications come up — immediately
+ * in wp-admin, lazily on the frontend — so these tests exercise that decision
+ * directly rather than through Core's wiring.
+ *
+ * @package Popup_Maker
+ */
+
+require_once dirname( __DIR__ ) . '/fixtures/class-pum-test-deferred-notification-provider.php';
+
+/**
+ * Verify boot behavior, idempotency, and the addon registration window.
+ */
+class Notification_Manager_Lifecycle_Test extends WP_UnitTestCase {
+
+	/**
+	 * Manager under test.
+	 *
+	 * @var \PopupMaker\Services\Notifications\Manager
+	 */
+	protected $manager;
+
+	/**
+	 * Provider registered through the public filter.
+	 *
+	 * @var PUM_Test_Deferred_Notification_Provider
+	 */
+	protected $provider;
+
+	/**
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->manager  = new \PopupMaker\Services\Notifications\Manager( \PopupMaker\plugin() );
+		$this->provider = new PUM_Test_Deferred_Notification_Provider();
+	}
+
+	/**
+	 * @return void
+	 */
+	public function tear_down() {
+		if ( isset( $GLOBALS['current_screen'] ) ) {
+			unset( $GLOBALS['current_screen'] );
+		}
+
+		parent::tear_down();
+	}
+
+	/**
+	 * Restrict the deferred boot list to hooks that have not fired yet.
+	 *
+	 * The WordPress test environment fires several of the default triggers
+	 * before a test body runs — `popup_maker/update_version` on the fresh
+	 * install, and `deleted_post` during fixture cleanup — which correctly
+	 * makes the manager boot immediately. Tests that need to observe the
+	 * dormant frontend state therefore pin the trigger list to hooks that are
+	 * genuinely unfired in this request.
+	 *
+	 * @param string[] $hooks Hooks to use as the complete trigger list.
+	 * @return void
+	 */
+	protected function use_unfired_boot_hooks( array $hooks ) {
+		foreach ( $hooks as $hook ) {
+			$this->assertFalse(
+				did_action( $hook ) > 0 || did_filter( $hook ) > 0,
+				sprintf( 'Guard: %s must not have fired yet for this test to be meaningful.', $hook )
+			);
+		}
+
+		add_filter(
+			'popup_maker/notifications/deferred_boot_hooks',
+			static function () use ( $hooks ) {
+				return $hooks;
+			}
+		);
+	}
+
+	/**
+	 * Register the test provider via the public addon filter.
+	 *
+	 * @return void
+	 */
+	protected function register_test_provider() {
+		$provider = $this->provider;
+
+		add_filter(
+			'popup_maker/notification_providers',
+			static function ( $providers ) use ( $provider ) {
+				$providers[] = $provider;
+				return $providers;
+			}
+		);
+	}
+
+	/**
+	 * Read the Manager's private boot guard.
+	 *
+	 * @return bool
+	 */
+	protected function is_booted() {
+		$booted = new ReflectionProperty( $this->manager, 'booted' );
+
+		if ( PHP_VERSION_ID < 80100 ) {
+			// Required before PHP 8.1, deprecated no-op on PHP 8.5+.
+			$booted->setAccessible( true );
+		}
+
+		return (bool) $booted->getValue( $this->manager );
+	}
+
+	/**
+	 * wp-admin has something about to render alerts, so init() should resolve
+	 * providers straight away rather than arming deferred listeners.
+	 *
+	 * @return void
+	 */
+	public function test_admin_request_boots_providers_immediately() {
+		set_current_screen( 'dashboard' );
+		$this->assertTrue( is_admin(), 'Guard: this test requires an admin request.' );
+
+		$this->register_test_provider();
+
+		$this->manager->init();
+
+		$this->assertTrue( $this->is_booted(), 'init() should boot immediately in wp-admin.' );
+		$this->assertContains( $this->provider, $this->manager->get_providers() );
+		$this->assertFalse(
+			has_filter( 'pum_alert_list', [ $this->manager, 'boot_on_demand' ] ),
+			'Admin boot should not leave deferred listeners registered.'
+		);
+	}
+
+	/**
+	 * A frontend request should stay dormant until something actually asks for
+	 * notifications — init() arms the listeners without constructing providers.
+	 *
+	 * @return void
+	 */
+	public function test_frontend_request_defers_boot_until_a_trigger_fires() {
+		$this->assertFalse( is_admin(), 'Guard: this test requires a frontend request.' );
+
+		$this->use_unfired_boot_hooks( [ 'pum_alert_list' ] );
+		$this->register_test_provider();
+
+		$this->manager->init();
+
+		$this->assertFalse( $this->is_booted(), 'Frontend init() should not resolve providers yet.' );
+		$this->assertSame(
+			PHP_INT_MIN,
+			has_filter( 'pum_alert_list', [ $this->manager, 'boot_on_demand' ] ),
+			'Frontend init() should arm the deferred boot listener.'
+		);
+
+		// The trigger fires — now providers come up, and the alert lands in
+		// the same filter iteration that woke the manager.
+		$alerts = apply_filters( 'pum_alert_list', [] );
+
+		$this->assertTrue( $this->is_booted() );
+		$this->assertContains( 'deferred_test_provider', wp_list_pluck( $alerts, 'code' ) );
+	}
+
+	/**
+	 * An ordinary frontend request that never touches a notification hook must
+	 * not pay for provider construction.
+	 *
+	 * @return void
+	 */
+	public function test_unrelated_frontend_request_never_boots() {
+		$this->assertFalse( is_admin(), 'Guard: this test requires a frontend request.' );
+
+		$this->use_unfired_boot_hooks( [ 'pum_alert_list' ] );
+		$this->register_test_provider();
+
+		$this->manager->init();
+
+		// Traffic that has nothing to do with notifications.
+		do_action( 'wp_enqueue_scripts' );
+		do_action( 'wp_head' );
+		apply_filters( 'the_content', 'irrelevant' );
+
+		$this->assertFalse( $this->is_booted(), 'Unrelated frontend traffic must not boot notifications.' );
+		$this->assertSame( [], $this->readProviders(), 'No providers should have been resolved.' );
+	}
+
+	/**
+	 * Read the resolved provider list without forcing a boot.
+	 *
+	 * @return array<int,mixed>
+	 */
+	protected function readProviders() {
+		$providers = new ReflectionProperty( $this->manager, 'providers' );
+
+		if ( PHP_VERSION_ID < 80100 ) {
+			// Required before PHP 8.1, deprecated no-op on PHP 8.5+.
+			$providers->setAccessible( true );
+		}
+
+		return (array) $providers->getValue( $this->manager );
+	}
+
+	/**
+	 * An upgrade dispatches popup_maker/update_version during plugins_loaded,
+	 * before init@5 runs. The manager must notice and boot immediately.
+	 *
+	 * @return void
+	 */
+	public function test_already_fired_trigger_boots_immediately() {
+		$this->assertFalse( is_admin(), 'Guard: this test requires a frontend request.' );
+
+		$this->register_test_provider();
+
+		do_action( 'popup_maker/update_version', '1.0.0', '0.9.0' );
+
+		$this->manager->init();
+
+		$this->assertTrue( $this->is_booted(), 'An already-fired trigger should boot the manager.' );
+		$this->assertContains( $this->provider, $this->manager->get_providers() );
+	}
+
+	/**
+	 * When a *later* hook in the list already fired, the earlier hooks must not
+	 * be left wired to an already-booted manager.
+	 *
+	 * @return void
+	 */
+	public function test_already_fired_late_trigger_leaves_no_stale_listeners() {
+		$this->assertFalse( is_admin(), 'Guard: this test requires a frontend request.' );
+
+		$this->register_test_provider();
+
+		// `deactivated_plugin` sits near the end of the default hook list,
+		// well after `pum_alert_list`.
+		do_action( 'deactivated_plugin', 'some-plugin/some-plugin.php', false );
+
+		$this->manager->init();
+
+		$this->assertTrue( $this->is_booted() );
+		$this->assertFalse(
+			has_filter( 'pum_alert_list', [ $this->manager, 'boot_on_demand' ] ),
+			'A late already-fired trigger must not leave earlier hooks registered.'
+		);
+	}
+
+	/**
+	 * Once booted through a trigger, the deferred listeners should be released
+	 * rather than firing a no-op boot on every later hook.
+	 *
+	 * @return void
+	 */
+	public function test_deferred_listeners_are_released_after_boot() {
+		$this->assertFalse( is_admin(), 'Guard: this test requires a frontend request.' );
+
+		$this->use_unfired_boot_hooks( [ 'pum_alert_list', 'pum_alert_dismissed', 'deactivated_plugin' ] );
+		$this->register_test_provider();
+		$this->manager->init();
+
+		$this->assertNotFalse( has_filter( 'pum_alert_list', [ $this->manager, 'boot_on_demand' ] ) );
+
+		apply_filters( 'pum_alert_list', [] );
+
+		$this->assertTrue( $this->is_booted() );
+
+		foreach ( [ 'pum_alert_list', 'pum_alert_dismissed', 'deactivated_plugin' ] as $hook ) {
+			$this->assertFalse(
+				has_filter( $hook, [ $this->manager, 'boot_on_demand' ] ),
+				sprintf( 'Deferred listener on %s should be released after boot.', $hook )
+			);
+		}
+	}
+
+	/**
+	 * Addons load on plugins_loaded 12+, after Core at 11 — a provider
+	 * registered any time before the manager boots must still be picked up.
+	 *
+	 * @return void
+	 */
+	public function test_provider_registered_late_is_still_booted() {
+		$this->assertFalse( is_admin(), 'Guard: this test requires a frontend request.' );
+
+		$this->use_unfired_boot_hooks( [ 'pum_alert_list' ] );
+
+		// Manager arms its listeners before the addon registers anything.
+		$this->manager->init();
+
+		$this->register_test_provider();
+
+		$alerts = apply_filters( 'pum_alert_list', [] );
+
+		$this->assertContains( $this->provider, $this->manager->get_providers() );
+		$this->assertContains( 'deferred_test_provider', wp_list_pluck( $alerts, 'code' ) );
+	}
+
+	/**
+	 * Addons can contribute their own deferred boot hooks, and those must be
+	 * honored as wake triggers.
+	 *
+	 * @return void
+	 */
+	public function test_addon_provided_deferred_hook_triggers_boot() {
+		$this->assertFalse( is_admin(), 'Guard: this test requires a frontend request.' );
+
+		$custom_hook = 'pum_test_addon_deferred_boot_hook';
+
+		$this->register_test_provider();
+
+		// Replace the defaults so the addon's hook is the only live trigger —
+		// several defaults have already fired in the test environment.
+		$this->use_unfired_boot_hooks( [ $custom_hook ] );
+
+		$this->manager->init();
+
+		$this->assertFalse( $this->is_booted(), 'Guard: should still be dormant before the custom hook fires.' );
+
+		// The addon's own hook wakes the manager, and passes its value through.
+		$this->assertSame( 'original-value', apply_filters( $custom_hook, 'original-value' ) );
+
+		$this->assertTrue( $this->is_booted(), 'An addon-provided hook should trigger boot.' );
+		$this->assertContains( $this->provider, $this->manager->get_providers() );
+	}
+
+	/**
+	 * get_providers() is an explicit demand for live providers, so it must
+	 * force a boot even on a frontend request that is still dormant.
+	 *
+	 * @return void
+	 */
+	public function test_get_providers_forces_boot_on_frontend() {
+		$this->assertFalse( is_admin(), 'Guard: this test requires a frontend request.' );
+
+		$this->use_unfired_boot_hooks( [ 'pum_alert_list' ] );
+		$this->register_test_provider();
+
+		$this->manager->init();
+		$this->assertFalse( $this->is_booted(), 'Guard: should be dormant before get_providers().' );
+
+		$providers = $this->manager->get_providers();
+
+		$this->assertTrue( $this->is_booted(), 'get_providers() should force a boot.' );
+		$this->assertContains( $this->provider, $providers );
+	}
+
+	/**
+	 * get_providers() must boot even when init() was never called at all.
+	 *
+	 * @return void
+	 */
+	public function test_get_providers_boots_without_prior_init() {
+		$this->register_test_provider();
+
+		$this->assertContains( $this->provider, $this->manager->get_providers() );
+		$this->assertTrue( $this->is_booted() );
+	}
+
+	/**
+	 * Repeated init()/boot/get_providers() calls must not re-resolve providers
+	 * or re-run their hook registration.
+	 *
+	 * @return void
+	 */
+	public function test_repeated_lifecycle_calls_resolve_providers_once() {
+		$resolve_count = 0;
+
+		add_filter(
+			'popup_maker/notification_providers',
+			function ( $providers ) use ( &$resolve_count ) {
+				++$resolve_count;
+				$providers[] = $this->provider;
+				return $providers;
+			}
+		);
+
+		$this->manager->init();
+		$this->manager->init();
+		$this->manager->get_providers();
+		$this->manager->get_providers();
+		$this->manager->boot_on_demand();
+		$this->manager->init();
+
+		$this->assertSame( 1, $resolve_count, 'Providers should resolve exactly once per request.' );
+		$this->assertCount(
+			1,
+			array_keys( $this->manager->get_providers(), $this->provider, true ),
+			'The provider should appear exactly once.'
+		);
+	}
+
+	/**
+	 * boot_on_demand() is hooked onto arbitrary filters, so it must return the
+	 * filtered value untouched.
+	 *
+	 * @return void
+	 */
+	public function test_boot_on_demand_passes_the_filtered_value_through() {
+		$this->assertSame( 'untouched', $this->manager->boot_on_demand( 'untouched' ) );
+		$this->assertTrue( $this->is_booted() );
+	}
+
+	/**
+	 * The pre-existing public entry point must keep working for any addon
+	 * still calling it.
+	 *
+	 * @return void
+	 */
+	public function test_register_lazy_boot_still_delegates_to_init() {
+		$this->assertFalse( is_admin(), 'Guard: this test requires a frontend request.' );
+
+		$this->use_unfired_boot_hooks( [ 'pum_alert_list' ] );
+		$this->register_test_provider();
+
+		$this->manager->register_lazy_boot();
+
+		$this->assertFalse( $this->is_booted(), 'register_lazy_boot() should behave like init().' );
+		$this->assertSame(
+			PHP_INT_MIN,
+			has_filter( 'pum_alert_list', [ $this->manager, 'boot_on_demand' ] )
+		);
+	}
+}


### PR DESCRIPTION
## Summary

- make the notification manager own admin-immediate versus frontend-lazy initialization
- funnel provider resolution through one idempotent boot path while preserving existing hooks and add-on registration timing
- detach deferred listeners after boot and handle already-fired hooks without leaving stale callbacks
- add focused lifecycle regression coverage

## Evidence

- focused PHPUnit after rebase: 13 tests, 54 assertions
- PHPCS: 3 changed files clean
- agent baseline before rebase: full PHPUnit 1,205 tests / 3,000 assertions, no failures; PHPStan introduced no new errors
- 6 regression tests fail on the prior implementation and pass here

No release behavior or public API is intentionally changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved notification startup behavior across dashboard and frontend pages.
  * Notifications now initialize immediately in the WordPress admin while remaining deferred on the frontend until needed.
  * On-demand access reliably initializes notifications when requested.
  * Deferred startup listeners are cleaned up after initialization, improving lifecycle consistency and preventing repeated provider setup.

* **Tests**
  * Added coverage for notification initialization, deferred triggers, on-demand loading, custom providers, and repeated access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->