### PR TITLE
Refactor lazy admin component registry

### DIFF
--- a/classes/Admin.php
+++ b/classes/Admin.php
@@ -70,7 +70,41 @@ class PUM_Admin {
 	}
 
 	/**
+	 * Post types whose editor screens own a legacy admin component.
+	 *
+	 * Keys are post types, values are the class initialized for that editor.
+	 *
+	 * @return array<string,class-string>
+	 */
+	private static function post_type_components() {
+		return [
+			'popup'       => 'PUM_Admin_Popups',
+			'popup_theme' => 'PUM_Admin_Themes',
+		];
+	}
+
+	/**
+	 * Plugin pages that own a legacy admin component.
+	 *
+	 * Keys are page definition keys from PUM_Admin_Pages::get_page_definitions(),
+	 * not slugs, because slugs are filterable and translated per site.
+	 *
+	 * @return array<string,class-string>
+	 */
+	private static function page_components() {
+		return [
+			'subscribers' => 'PUM_Admin_Subscribers',
+			'settings'    => 'PUM_Admin_Settings',
+			'tools'       => 'PUM_Admin_Tools',
+			'extensions'  => 'PUM_Admin_Extend',
+		];
+	}
+
+	/**
 	 * Initialize admin components used by the current request.
+	 *
+	 * Screen components load only when their post type or resolved page slug
+	 * matches, so unrelated admin requests never autoload them.
 	 *
 	 * @param array<string,string> $page_slugs Resolved admin page slugs.
 	 *
@@ -81,33 +115,49 @@ class PUM_Admin {
 		$page       = self::requested_page();
 		$page_slugs = is_array( $page_slugs ) ? $page_slugs : [];
 
-		if ( 'popup' === $post_type ) {
-			PUM_Admin_Popups::init();
+		foreach ( self::post_type_components() as $component_post_type => $component ) {
+			if ( $component_post_type === $post_type ) {
+				$component::init();
+			}
 		}
 
-		if ( 'popup_theme' === $post_type ) {
-			PUM_Admin_Themes::init();
+		foreach ( self::page_components() as $page_key => $component ) {
+			if ( isset( $page_slugs[ $page_key ] ) && $page_slugs[ $page_key ] === $page ) {
+				$component::init();
+			}
 		}
 
-		if ( isset( $page_slugs['subscribers'] ) && $page_slugs['subscribers'] === $page ) {
-			PUM_Admin_Subscribers::init();
-		}
-
-		if ( isset( $page_slugs['settings'] ) && $page_slugs['settings'] === $page ) {
-			PUM_Admin_Settings::init();
-		}
-
-		if ( isset( $page_slugs['tools'] ) && $page_slugs['tools'] === $page ) {
-			PUM_Admin_Tools::init();
-		}
-
-		if ( isset( $page_slugs['extensions'] ) && $page_slugs['extensions'] === $page ) {
-			PUM_Admin_Extend::init();
-		}
-
-		if ( in_array( $post_type, [ 'popup', 'popup_theme' ], true ) || in_array( $page, $page_slugs, true ) || 'popup-maker-call-to-actions' === $page ) {
+		if ( self::request_has_upsell_context( $post_type, $page, $page_slugs ) ) {
 			PUM_Upsell::init();
 		}
+	}
+
+	/**
+	 * Whether the current request should initialize premium upsells.
+	 *
+	 * Upsells cover every Popup Maker context, including registered pages that
+	 * have no screen component of their own, such as Help & Support and pages
+	 * added by other plugins through the pum_admin_pages filter.
+	 *
+	 * @param string               $post_type  Current post type.
+	 * @param string               $page       Requested page slug.
+	 * @param array<string,string> $page_slugs Resolved admin page slugs.
+	 *
+	 * @return bool
+	 */
+	private static function request_has_upsell_context( $post_type, $page, $page_slugs ) {
+		if (
+			is_string( $post_type ) &&
+			array_key_exists( $post_type, self::post_type_components() )
+		) {
+			return true;
+		}
+
+		if ( in_array( $page, $page_slugs, true ) ) {
+			return true;
+		}
+
+		return 'popup-maker-call-to-actions' === $page;
 	}
 
 	/**

--- a/tests/php/tests/PUM_Admin_Loader_Test.php
+++ b/tests/php/tests/PUM_Admin_Loader_Test.php
@@ -408,6 +408,326 @@ class PUM_Admin_Loader_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Popup editor requests load only the popup screen component.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_popup_post_type_loads_popup_components_only() {
+		global $pagenow;
+
+		$pagenow           = 'edit.php';
+		$_GET['post_type'] = 'popup';
+		set_current_screen( 'edit-popup' );
+		remove_all_actions( 'admin_menu' );
+
+		PUM_Admin::init();
+		do_action( 'admin_menu' );
+
+		$this->assertSame( 10, has_action( 'edit_form_top', [ 'PUM_Admin_Popups', 'add_popup_id' ] ) );
+		$this->assertTrue( class_exists( 'PUM_Upsell', false ) );
+		$this->assertFalse( has_action( 'add_meta_boxes', [ 'PUM_Admin_Themes', 'meta_box' ] ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Subscribers', false ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Settings', false ) );
+		$this->assertFalse( has_action( 'admin_init', [ 'PUM_Admin_Tools', 'emodal_process_import' ] ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Extend', false ) );
+	}
+
+	/**
+	 * Theme editor requests load only the theme screen component.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_popup_theme_post_type_loads_theme_components_only() {
+		global $pagenow;
+
+		$pagenow           = 'edit.php';
+		$_GET['post_type'] = 'popup_theme';
+		set_current_screen( 'edit-popup_theme' );
+		remove_all_actions( 'admin_menu' );
+
+		PUM_Admin::init();
+		do_action( 'admin_menu' );
+
+		$this->assertSame( 10, has_action( 'add_meta_boxes', [ 'PUM_Admin_Themes', 'meta_box' ] ) );
+		$this->assertTrue( class_exists( 'PUM_Upsell', false ) );
+		$this->assertFalse( has_action( 'edit_form_top', [ 'PUM_Admin_Popups', 'add_popup_id' ] ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Settings', false ) );
+		$this->assertFalse( has_action( 'admin_init', [ 'PUM_Admin_Tools', 'emodal_process_import' ] ) );
+	}
+
+	/**
+	 * Tools requests load only the tools screen component.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_tools_request_loads_tools_components_only() {
+		global $pagenow;
+
+		$pagenow      = 'edit.php';
+		$_GET['page'] = 'pum-tools';
+		set_current_screen( 'popup_page_pum-tools' );
+		remove_all_actions( 'admin_menu' );
+
+		PUM_Admin::init();
+		do_action( 'admin_menu' );
+
+		$this->assertSame( 10, has_action( 'admin_init', [ 'PUM_Admin_Tools', 'emodal_process_import' ] ) );
+		$this->assertTrue( class_exists( 'PUM_Upsell', false ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Settings', false ) );
+		$this->assertFalse( has_action( 'edit_form_top', [ 'PUM_Admin_Popups', 'add_popup_id' ] ) );
+		$this->assertFalse( has_action( 'add_meta_boxes', [ 'PUM_Admin_Themes', 'meta_box' ] ) );
+	}
+
+	/**
+	 * Extend requests load only the extensions screen component.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_extensions_request_loads_extend_components_only() {
+		global $pagenow;
+
+		$pagenow      = 'edit.php';
+		$_GET['page'] = 'pum-extensions';
+		set_current_screen( 'popup_page_pum-extensions' );
+		remove_all_actions( 'admin_menu' );
+
+		PUM_Admin::init();
+		do_action( 'admin_menu' );
+
+		$this->assertTrue( class_exists( 'PUM_Admin_Extend', false ) );
+		$this->assertTrue( class_exists( 'PUM_Upsell', false ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Settings', false ) );
+		$this->assertFalse( has_action( 'admin_init', [ 'PUM_Admin_Tools', 'emodal_process_import' ] ) );
+	}
+
+	/**
+	 * Subscribers requests load the subscribers screen once storage exists.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_subscribers_request_loads_subscribers_components() {
+		global $pagenow;
+
+		// Declare the page through the filter rather than writing the schema
+		// option, so the isolated process never re-runs the install routine.
+		add_filter(
+			'pum_admin_pages',
+			function ( $pages ) {
+				$pages['subscribers'] = [
+					'page_title' => 'Subscribers',
+					'capability' => 'manage_options',
+					'callback'   => [ 'PUM_Admin_Subscribers', 'page' ],
+				];
+
+				return $pages;
+			}
+		);
+
+		$pagenow      = 'edit.php';
+		$_GET['page'] = 'pum-subscribers';
+		set_current_screen( 'popup_page_pum-subscribers' );
+		remove_all_actions( 'admin_menu' );
+
+		PUM_Admin::init();
+		do_action( 'admin_menu' );
+
+		$this->assertTrue( class_exists( 'PUM_Admin_Subscribers', false ) );
+		$this->assertTrue( class_exists( 'PUM_Upsell', false ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Settings', false ) );
+	}
+
+	/**
+	 * The Call to Actions screen initializes upsells without a screen component.
+	 *
+	 * The CTA screen is registered by a controller rather than the legacy page
+	 * definitions, so it matches the upsell context by explicit slug only.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_call_to_actions_page_loads_upsell_without_screen_components() {
+		global $pagenow;
+
+		$pagenow      = 'edit.php';
+		$_GET['page'] = 'popup-maker-call-to-actions';
+		set_current_screen( 'popup_page_popup-maker-call-to-actions' );
+		remove_all_actions( 'admin_menu' );
+
+		PUM_Admin::init();
+		do_action( 'admin_menu' );
+
+		$this->assertTrue( class_exists( 'PUM_Upsell', false ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Settings', false ) );
+		$this->assertFalse( has_action( 'admin_init', [ 'PUM_Admin_Tools', 'emodal_process_import' ] ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Subscribers', false ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Extend', false ) );
+	}
+
+	/**
+	 * Registered pages without a screen handler still initialize upsells.
+	 *
+	 * The Support page has no entry in the component registry, but it is a
+	 * registered plugin page, so the upsell context must still match it.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_support_page_loads_upsell_without_screen_components() {
+		global $pagenow;
+
+		$pagenow      = 'edit.php';
+		$_GET['page'] = 'pum-support';
+		set_current_screen( 'popup_page_pum-support' );
+		remove_all_actions( 'admin_menu' );
+
+		PUM_Admin::init();
+		do_action( 'admin_menu' );
+
+		$this->assertTrue( class_exists( 'PUM_Upsell', false ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Settings', false ) );
+		$this->assertFalse( has_action( 'admin_init', [ 'PUM_Admin_Tools', 'emodal_process_import' ] ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Subscribers', false ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Extend', false ) );
+	}
+
+	/**
+	 * Third-party pages added through the filter participate in upsell context.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_filter_added_page_loads_upsell_without_screen_components() {
+		global $pagenow;
+
+		add_filter(
+			'pum_admin_pages',
+			function ( $pages ) {
+				$pages['partner_screen'] = [
+					'page_title' => 'Partner Screen',
+					'capability' => 'manage_options',
+					'menu_slug'  => 'partner-screen',
+					'callback'   => '__return_null',
+				];
+
+				return $pages;
+			}
+		);
+
+		$pagenow      = 'edit.php';
+		$_GET['page'] = 'partner-screen';
+		set_current_screen( 'popup_page_partner-screen' );
+		remove_all_actions( 'admin_menu' );
+
+		PUM_Admin::init();
+		do_action( 'admin_menu' );
+
+		$this->assertTrue( class_exists( 'PUM_Upsell', false ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Settings', false ) );
+		$this->assertFalse( has_action( 'admin_init', [ 'PUM_Admin_Tools', 'emodal_process_import' ] ) );
+	}
+
+	/**
+	 * Unrelated admin screens initialize no screen components and no upsell.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_unrelated_admin_page_loads_no_request_components() {
+		global $pagenow;
+
+		$pagenow      = 'edit.php';
+		$_GET['page'] = 'some-other-plugin';
+		set_current_screen( 'edit-post' );
+		remove_all_actions( 'admin_menu' );
+
+		PUM_Admin::init();
+		do_action( 'admin_menu' );
+
+		$this->assertFalse( class_exists( 'PUM_Upsell', false ) );
+		$this->assertFalse( has_action( 'edit_form_top', [ 'PUM_Admin_Popups', 'add_popup_id' ] ) );
+		$this->assertFalse( has_action( 'add_meta_boxes', [ 'PUM_Admin_Themes', 'meta_box' ] ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Settings', false ) );
+		$this->assertFalse( has_action( 'admin_init', [ 'PUM_Admin_Tools', 'emodal_process_import' ] ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Subscribers', false ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Extend', false ) );
+	}
+
+	/**
+	 * A popup editor request reached through a plugin page slug loads both.
+	 *
+	 * Post type and page matching are independent, so an overlapping request
+	 * must initialize every matching component rather than the first match.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_overlapping_post_type_and_page_loads_both_components() {
+		global $pagenow;
+
+		$pagenow           = 'edit.php';
+		$_GET['post_type'] = 'popup';
+		$_GET['page']      = 'pum-settings';
+		set_current_screen( 'popup_page_pum-settings' );
+		remove_all_actions( 'admin_menu' );
+
+		PUM_Admin::init();
+		do_action( 'admin_menu' );
+
+		$this->assertSame( 10, has_action( 'edit_form_top', [ 'PUM_Admin_Popups', 'add_popup_id' ] ) );
+		$this->assertSame( 10, has_action( 'admin_init', [ 'PUM_Admin_Settings', 'save' ] ) );
+		$this->assertTrue( class_exists( 'PUM_Upsell', false ) );
+		$this->assertFalse( has_action( 'add_meta_boxes', [ 'PUM_Admin_Themes', 'meta_box' ] ) );
+		$this->assertFalse( has_action( 'admin_init', [ 'PUM_Admin_Tools', 'emodal_process_import' ] ) );
+	}
+
+	/**
+	 * Non-array page slugs degrade to post-type matching without errors.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 *
+	 * @return void
+	 */
+	public function test_non_array_page_slugs_still_match_post_type_components() {
+		global $pagenow;
+
+		$pagenow           = 'edit.php';
+		$_GET['post_type'] = 'popup';
+		set_current_screen( 'edit-popup' );
+
+		PUM_Admin::init_request_components( 'not-an-array' );
+
+		$this->assertSame( 10, has_action( 'edit_form_top', [ 'PUM_Admin_Popups', 'add_popup_id' ] ) );
+		$this->assertTrue( class_exists( 'PUM_Upsell', false ) );
+		$this->assertFalse( class_exists( 'PUM_Admin_Settings', false ) );
+	}
+
+	/**
 	 * @return void
 	 */
 	public function tearDown(): void {


### PR DESCRIPTION
## Summary

- replace branching request setup with explicit post-type and page component maps
- key page routing by definition keys so filtered/translated slugs remain safe
- derive upsell context from the same mappings to prevent drift
- preserve lazy loading and characterize existing third-party page behavior

## Evidence

- focused PHPUnit after rebase: 26 tests, 134 assertions
- PHPCS: 2 changed files clean
- agent baseline before rebase: full PHPUnit 1,203 tests / 2,998 assertions, no failures; PHPStan clean
- included-file bootstrap evidence was byte-identical before and after on unrelated and settings admin screens

No public/filterable registry API is added.