### PR TITLE
[codex] Add opt-out for assistive notifications

### DIFF
--- a/classes/Admin/Settings.php
+++ b/classes/Admin/Settings.php
@@ -635,6 +635,11 @@ class PUM_Admin_Settings {
 								'type'  => 'checkbox',
 								'label' => __( 'Disable Popup Maker occasionally showing random tips to improve your popups.', 'popup-maker' ),
 							],
+							'disable_notifications'      => [
+								'type'  => 'checkbox',
+								'label' => __( 'Disable Popup Maker assistive notifications', 'popup-maker' ),
+								'desc'  => __( 'Popup Maker uses subtle dashboard notifications to highlight new features, optimization opportunities, split-test results, and issues that may affect conversions. Disable them if you prefer a quieter dashboard. Critical error and warning notices will still appear.', 'popup-maker' ),
+							],
 							'complete_uninstall'         => [
 								'type'     => 'checkbox',
 								'label'    => __( 'Delete all Popup Maker data on deactivation', 'popup-maker' ),

--- a/classes/Controllers/Admin/ToolbarNotifications.php
+++ b/classes/Controllers/Admin/ToolbarNotifications.php
@@ -62,7 +62,7 @@ class ToolbarNotifications extends Controller {
 	 * @return void
 	 */
 	public function print_marker_bootstrap() {
-		if ( ! current_user_can( $this->container->get_permission( 'edit_popups' ) ) ) {
+		if ( $this->notifications_disabled() || ! current_user_can( $this->container->get_permission( 'edit_popups' ) ) ) {
 			return;
 		}
 
@@ -134,7 +134,7 @@ class ToolbarNotifications extends Controller {
 	 * @return void
 	 */
 	public function maybe_enqueue_panel() {
-		if ( ! current_user_can( $this->container->get_permission( 'edit_popups' ) ) ) {
+		if ( $this->notifications_disabled() || ! current_user_can( $this->container->get_permission( 'edit_popups' ) ) ) {
 			return;
 		}
 
@@ -168,7 +168,7 @@ class ToolbarNotifications extends Controller {
 	public function inject_sidebar_marker() {
 		global $menu;
 
-		if ( ! is_array( $menu ) ) {
+		if ( $this->notifications_disabled() || ! is_array( $menu ) ) {
 			return;
 		}
 
@@ -229,6 +229,10 @@ class ToolbarNotifications extends Controller {
 	 * @return void
 	 */
 	public function inject_admin_bar_marker( $wp_admin_bar ) {
+		if ( $this->notifications_disabled() ) {
+			return;
+		}
+
 		if ( ! is_object( $wp_admin_bar ) || ! method_exists( $wp_admin_bar, 'get_node' ) ) {
 			return;
 		}
@@ -339,7 +343,7 @@ class ToolbarNotifications extends Controller {
 	 * @return void
 	 */
 	public function print_styles() {
-		if ( ! current_user_can( $this->container->get_permission( 'edit_popups' ) ) ) {
+		if ( $this->notifications_disabled() || ! current_user_can( $this->container->get_permission( 'edit_popups' ) ) ) {
 			return;
 		}
 
@@ -432,5 +436,17 @@ class ToolbarNotifications extends Controller {
 			}
 		</style>
 		<?php
+	}
+
+	/**
+	 * Whether assistive admin notifications have been disabled.
+	 *
+	 * Blocking error and warning alerts use the legacy inline surface and are
+	 * intentionally unaffected by this preference.
+	 *
+	 * @return bool
+	 */
+	protected function notifications_disabled() {
+		return (bool) pum_get_option( 'disable_notifications', false );
 	}
 }

--- a/classes/RestAPI/Notifications.php
+++ b/classes/RestAPI/Notifications.php
@@ -113,6 +113,13 @@ class Notifications extends WP_REST_Controller {
 	public function get_items( $request ) {
 		unset( $request );
 
+		if ( pum_get_option( 'disable_notifications', false ) ) {
+			$response = rest_ensure_response( [] );
+			$response->header( 'X-PM-Notifications-Count', '0' );
+
+			return $response;
+		}
+
 		$items = [];
 
 		foreach ( PUM_Utils_Alerts::get_alerts() as $alert ) {

--- a/classes/Utils/Alerts.php
+++ b/classes/Utils/Alerts.php
@@ -85,7 +85,13 @@ class PUM_Utils_Alerts {
 	 * @return bool
 	 */
 	public static function is_inline_eligible( $alert ) {
-		return ! self::is_panel_eligible( $alert ) || ! empty( $alert['display_inline'] );
+		$panel_eligible = self::is_panel_eligible( $alert );
+
+		if ( $panel_eligible && pum_get_option( 'disable_notifications', false ) ) {
+			return false;
+		}
+
+		return ! $panel_eligible || ! empty( $alert['display_inline'] );
 	}
 
 	/**

--- a/tests/php/tests/Notification_Manager_Loader_Test.php
+++ b/tests/php/tests/Notification_Manager_Loader_Test.php
@@ -145,26 +145,70 @@ class Notification_Manager_Loader_Test extends WP_UnitTestCase {
 	 * Disabled assistive notifications are omitted from the REST panel.
 	 */
 	public function test_disabled_assistive_notifications_return_an_empty_panel() {
+		global $menu;
+
+		$original_menu = $menu;
+
 		pum_update_option( 'disable_notifications', true );
 
-		add_filter(
-			'pum_alert_list',
-			static function ( $alerts ) {
-				$alerts[] = [
-					'code'    => 'test_assistive_notification',
-					'message' => 'Test notification.',
-					'type'    => 'info',
-				];
+		$filter = static function ( $alerts ) {
+			$alerts[] = [
+				'code'           => 'test_assistive_notification',
+				'message'        => 'Test notification.',
+				'type'           => 'info',
+				'display_inline' => true,
+			];
 
-				return $alerts;
-			}
+			return $alerts;
+		};
+
+		add_filter( 'pum_alert_list', $filter );
+
+		try {
+			$controller = new \PopupMaker\RestAPI\Notifications();
+			$response   = $controller->get_items( new WP_REST_Request( 'GET' ) );
+
+			$this->assertSame( [], $response->get_data() );
+			$this->assertSame( '0', $response->get_headers()['X-PM-Notifications-Count'] );
+
+			$menu = [
+				[ 'Popups', 'edit_posts', 'edit.php?post_type=popup' ],
+			];
+
+			PUM_Utils_Alerts::append_alert_count();
+
+			$this->assertSame( 'Popups', $menu[0][0] );
+		} finally {
+			remove_filter( 'pum_alert_list', $filter );
+			$menu = $original_menu;
+		}
+	}
+
+	/**
+	 * Disabled assistive notifications stay off the inline surface while
+	 * blocking and global notices remain eligible.
+	 */
+	public function test_disabled_assistive_notifications_preserve_blocking_inline_alerts() {
+		pum_update_option( 'disable_notifications', true );
+
+		$this->assertFalse(
+			PUM_Utils_Alerts::is_inline_eligible(
+				[
+					'type'           => 'success',
+					'display_inline' => true,
+				]
+			)
 		);
-
-		$controller = new \PopupMaker\RestAPI\Notifications();
-		$response   = $controller->get_items( new WP_REST_Request( 'GET' ) );
-
-		$this->assertSame( [], $response->get_data() );
-		$this->assertSame( '0', $response->get_headers()['X-PM-Notifications-Count'] );
+		$this->assertTrue( PUM_Utils_Alerts::is_inline_eligible( [ 'type' => 'warning' ] ) );
+		$this->assertTrue( PUM_Utils_Alerts::is_inline_eligible( [ 'type' => 'error' ] ) );
+		$this->assertTrue(
+			PUM_Utils_Alerts::is_inline_eligible(
+				[
+					'type'   => 'info',
+					'global' => true,
+				]
+			)
+		);
 	}
 
 	/**

--- a/tests/php/tests/Notification_Manager_Loader_Test.php
+++ b/tests/php/tests/Notification_Manager_Loader_Test.php
@@ -13,6 +13,15 @@ require_once dirname( __DIR__ ) . '/fixtures/class-pum-test-deferred-notificatio
 class Notification_Manager_Loader_Test extends WP_UnitTestCase {
 
 	/**
+	 * Restore the notification preference after each test.
+	 */
+	public function tearDown(): void {
+		pum_delete_option( 'disable_notifications' );
+
+		parent::tearDown();
+	}
+
+	/**
 	 * @runInSeparateProcess
 	 * @preserveGlobalState disabled
 	 *
@@ -130,5 +139,55 @@ class Notification_Manager_Loader_Test extends WP_UnitTestCase {
 			$deferred || $booted_prop->getValue( $manager ),
 			'Core should register the real manager for deferred boot on frontend requests.'
 		);
+	}
+
+	/**
+	 * Disabled assistive notifications are omitted from the REST panel.
+	 */
+	public function test_disabled_assistive_notifications_return_an_empty_panel() {
+		pum_update_option( 'disable_notifications', true );
+
+		add_filter(
+			'pum_alert_list',
+			static function ( $alerts ) {
+				$alerts[] = [
+					'code'    => 'test_assistive_notification',
+					'message' => 'Test notification.',
+					'type'    => 'info',
+				];
+
+				return $alerts;
+			}
+		);
+
+		$controller = new \PopupMaker\RestAPI\Notifications();
+		$response   = $controller->get_items( new WP_REST_Request( 'GET' ) );
+
+		$this->assertSame( [], $response->get_data() );
+		$this->assertSame( '0', $response->get_headers()['X-PM-Notifications-Count'] );
+	}
+
+	/**
+	 * Disabled assistive notifications do not render dashboard indicators.
+	 */
+	public function test_disabled_assistive_notifications_hide_dashboard_indicators() {
+		global $menu;
+
+		pum_update_option( 'disable_notifications', true );
+
+		$controller = new \PopupMaker\Controllers\Admin\ToolbarNotifications( \PopupMaker\plugin() );
+		$menu       = [
+			[ 'Popups', 'edit_posts', 'edit.php?post_type=popup' ],
+		];
+
+		$controller->inject_sidebar_marker();
+
+		ob_start();
+		$controller->print_styles();
+		$controller->print_marker_bootstrap();
+		$output = ob_get_clean();
+
+		$this->assertSame( 'Popups', $menu[0][0] );
+		$this->assertSame( '', $output );
 	}
 }

--- a/tests/php/tests/PUM_Admin_Settings_Test.php
+++ b/tests/php/tests/PUM_Admin_Settings_Test.php
@@ -62,6 +62,19 @@ class PUM_Admin_Settings_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The assistive notifications preference clearly explains its scope.
+	 */
+	public function test_fields_contains_disable_notifications_setting() {
+		$field = PUM_Admin_Settings::get_field( 'disable_notifications' );
+
+		$this->assertIsArray( $field );
+		$this->assertSame( 'checkbox', $field['type'] );
+		$this->assertSame( 'Disable Popup Maker assistive notifications', $field['label'] );
+		$this->assertStringContainsString( 'quieter dashboard', $field['desc'] );
+		$this->assertStringContainsString( 'Critical error and warning notices will still appear.', $field['desc'] );
+	}
+
+	/**
 	 * The settings payload contains only the lazy viewer shell.
 	 */
 	public function test_css_viewer_does_not_embed_styles_eagerly() {


### PR DESCRIPTION
## Issue

Popup Maker's assistive notification panel adds a green exclamation-mark indicator to the Popup Maker admin menu and frontend admin bar when panel-eligible notifications are available. Some administrators prefer a quieter dashboard and currently have no supported way to opt out of this notification surface.

Related support request: https://wordpress.org/support/topic/remove-excalamation-mark-in-admin-menu/

## Root cause and user impact

The notification toolbar controller always renders its marker, bootstrap, styles, and panel assets for eligible users. The REST endpoint likewise always returns panel-eligible informational notifications. Because there was no persisted preference checked by either layer, administrators could clear individual notifications but could not disable the assistive notification experience itself.

## Changes

- Add a `Disable Popup Maker assistive notifications` checkbox under Popup Maker's miscellaneous settings.
- Explain that these notifications cover features, optimization opportunities, split-test results, and conversion-impacting issues.
- Suppress the sidebar indicator, admin-bar indicator, marker bootstrap, styles, and panel assets when the preference is enabled.
- Return an empty notification-panel response with an explicit zero count while disabled.
- Keep critical error and warning notices on the existing inline surface so important breakage is not silently hidden.

## Validation

- `composer run tests` — 1,195 tests, 2,955 assertions, 20 environment-dependent skips.
- Focused notification/settings suite — 40 tests, 97 assertions, 3 skips.
- Notification filter suite — 5 tests, 17 assertions.
- PHP syntax checks passed for every changed PHP file.
- PHPCS reported no errors in changed files; existing warnings remain elsewhere in two touched legacy files.
- `git diff --check` passed.

## Known repository baseline

`composer run phpstan` currently reports 26 existing errors in unrelated files. None point to files changed by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a setting to disable Popup Maker assistive dashboard notifications, including feature highlights, optimization suggestions, split-test results, and conversion-related alerts.
  * Critical error and warning notices continue to appear when assistive notifications are disabled.

* **Improvements**
  * Disabling assistive notifications now removes related toolbar indicators and notification panel results for a quieter dashboard experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->