### PR TITLE
refactor(rest): replace anonymous REST alias controllers with named classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+**Fixes**
+
+-   Fixed popup themes advertising an autosave endpoint through the standard WordPress REST namespace that WordPress itself does not provide, which could mislead editors and third-party tools.
+-   Fixed duplicate REST route handlers being registered when the REST API is initialized more than once in a single request.
+
 ## v1.25.0 - 2026-09-10
 
 **Security**

--- a/classes/Controllers/PostTypes.php
+++ b/classes/Controllers/PostTypes.php
@@ -20,6 +20,13 @@ use function PopupMaker\get_data_version;
 class PostTypes extends Controller {
 
 	/**
+	 * REST alias registrar.
+	 *
+	 * @var \PopupMaker\RestAPI\Alias\Registrar|null
+	 */
+	protected $rest_alias_registrar = null;
+
+	/**
 	 * Init controller.
 	 *
 	 * @return void
@@ -134,77 +141,28 @@ class PostTypes extends Controller {
 	 * @return void
 	 */
 	public function register_standard_rest_routes() {
-		$rest_bases = [
-			$this->get_type_key( 'popup' )       => 'popups',
-			$this->get_type_key( 'popup_theme' ) => 'popup-themes',
-		];
+		$this->get_rest_alias_registrar()->register();
+	}
 
-		foreach ( $rest_bases as $post_type => $rest_base ) {
-			$post_type_object = get_post_type_object( $post_type );
-
-			if ( ! $post_type_object || ! $post_type_object->show_in_rest || 'wp/v2' === $post_type_object->rest_namespace ) {
-				continue;
-			}
-
-			$controller = new class( $post_type, $rest_base ) extends \WP_REST_Posts_Controller {
-
-				/**
-				 * Set up a standard WordPress route for a Popup Maker post type.
-				 *
-				 * @param string $post_type Post type key.
-				 * @param string $rest_base REST collection base.
-				 */
-				public function __construct( $post_type, $rest_base ) {
-					parent::__construct( $post_type );
-
-					$this->namespace = 'wp/v2';
-					$this->rest_base = $rest_base;
-				}
-			};
-
-			$controller->register_routes();
-
-			$original_rest_base          = $post_type_object->rest_base;
-			$post_type_object->rest_base = $rest_base;
-
-			if ( post_type_supports( $post_type, 'revisions' ) && class_exists( '\\WP_REST_Revisions_Controller' ) ) {
-				$revisions = new class( $post_type ) extends \WP_REST_Revisions_Controller {
-
-					/**
-					 * Set up standard WordPress revision routes for a Popup Maker post type.
-					 *
-					 * @param string $post_type Parent post type key.
-					 */
-					public function __construct( $post_type ) {
-						parent::__construct( $post_type );
-
-						$this->namespace = 'wp/v2';
-					}
-				};
-
-				$revisions->register_routes();
-			}
-
-			if ( class_exists( '\\WP_REST_Autosaves_Controller' ) ) {
-				$autosaves = new class( $post_type ) extends \WP_REST_Autosaves_Controller {
-
-					/**
-					 * Set up standard WordPress autosave routes for a Popup Maker post type.
-					 *
-					 * @param string $post_type Parent post type key.
-					 */
-					public function __construct( $post_type ) {
-						parent::__construct( $post_type );
-
-						$this->namespace = 'wp/v2';
-					}
-				};
-
-				$autosaves->register_routes();
-			}
-
-			$post_type_object->rest_base = $original_rest_base;
+	/**
+	 * Get the REST alias registrar.
+	 *
+	 * Held on the controller so repeated `rest_api_init` calls reuse the same
+	 * registrar and cannot append duplicate route handlers.
+	 *
+	 * @return \PopupMaker\RestAPI\Alias\Registrar
+	 */
+	protected function get_rest_alias_registrar() {
+		if ( null === $this->rest_alias_registrar ) {
+			$this->rest_alias_registrar = new \PopupMaker\RestAPI\Alias\Registrar(
+				[
+					$this->get_type_key( 'popup' )       => 'popups',
+					$this->get_type_key( 'popup_theme' ) => 'popup-themes',
+				]
+			);
 		}
+
+		return $this->rest_alias_registrar;
 	}
 
 	/**

--- a/classes/RestAPI/Alias/AutosavesController.php
+++ b/classes/RestAPI/Alias/AutosavesController.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Standard namespace alias controller for Popup Maker post autosaves.
+ *
+ * @copyright (c) 2024, Code Atlantic LLC.
+ * @package PopupMaker\RestAPI\Alias
+ */
+
+namespace PopupMaker\RestAPI\Alias;
+
+defined( 'ABSPATH' ) || exit;
+
+use WP_REST_Autosaves_Controller;
+
+/**
+ * Exposes a Popup Maker post type's autosaves through the standard namespace.
+ *
+ * Mirrors the autosave routes Core registers under `popup-maker/v2`. Core only
+ * creates an autosave controller when the post type supports autosaves, so the
+ * registrar applies the same gate before constructing this class. Route
+ * definitions, schema, and permission checks are inherited unchanged.
+ *
+ * @since 1.26.0
+ */
+class AutosavesController extends WP_REST_Autosaves_Controller {
+
+	/**
+	 * Build an aliased autosaves controller.
+	 *
+	 * @param string $parent_post_type Parent post type key.
+	 * @param string $rest_namespace   REST namespace to expose the routes under.
+	 */
+	public function __construct( $parent_post_type, $rest_namespace ) {
+		parent::__construct( $parent_post_type );
+
+		$this->namespace = $rest_namespace;
+	}
+}

--- a/classes/RestAPI/Alias/PostsController.php
+++ b/classes/RestAPI/Alias/PostsController.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Standard namespace alias controller for Popup Maker post collections.
+ *
+ * @copyright (c) 2024, Code Atlantic LLC.
+ * @package PopupMaker\RestAPI\Alias
+ */
+
+namespace PopupMaker\RestAPI\Alias;
+
+defined( 'ABSPATH' ) || exit;
+
+use WP_REST_Posts_Controller;
+
+/**
+ * Exposes a Popup Maker post type through the standard `wp/v2` namespace.
+ *
+ * Popup Maker registers its post types under the versioned `popup-maker/v2`
+ * namespace. Generic block editors and third-party tooling discover content
+ * through `wp/v2`, so this controller re-registers the same Core routes under
+ * the standard namespace without redefining any route arguments itself.
+ *
+ * All request handling, schema, and permission behavior is inherited from
+ * WP_REST_Posts_Controller so the two namespaces stay in lockstep.
+ *
+ * @since 1.26.0
+ */
+class PostsController extends WP_REST_Posts_Controller {
+
+	/**
+	 * Build an aliased posts controller.
+	 *
+	 * @param string $post_type Post type key.
+	 * @param string $rest_namespace REST namespace to expose the routes under.
+	 * @param string $rest_base REST collection base.
+	 */
+	public function __construct( $post_type, $rest_namespace, $rest_base ) {
+		parent::__construct( $post_type );
+
+		$this->namespace = $rest_namespace;
+		$this->rest_base = $rest_base;
+	}
+}

--- a/classes/RestAPI/Alias/Registrar.php
+++ b/classes/RestAPI/Alias/Registrar.php
@@ -1,0 +1,226 @@
+<?php
+/**
+ * Registrar for standard namespace REST aliases.
+ *
+ * @copyright (c) 2024, Code Atlantic LLC.
+ * @package PopupMaker\RestAPI\Alias
+ */
+
+namespace PopupMaker\RestAPI\Alias;
+
+defined( 'ABSPATH' ) || exit;
+
+use WP_Post_Type;
+
+/**
+ * Registers `wp/v2` aliases for Popup Maker post types.
+ *
+ * Popup Maker exposes its post types under the versioned `popup-maker/v2`
+ * namespace, which keeps the plugin's own API stable but hides the content
+ * from generic editors and tooling that only look at `wp/v2`. This registrar
+ * re-registers Core's own controllers under the standard namespace.
+ *
+ * Two properties matter for correctness:
+ *
+ * - The alias set is derived from the same conditions Core uses, so a route
+ *   exists in `wp/v2` only when the equivalent route exists in the plugin
+ *   namespace. Revisions and autosaves follow `post_type_supports()` exactly
+ *   as `WP_Post_Type::get_revisions_rest_controller()` and
+ *   `get_autosave_rest_controller()` do.
+ * - Registration is idempotent. `rest_api_init` can fire more than once in a
+ *   single request (test suites and some integrations re-run it), and
+ *   registering the same route twice appends duplicate handlers.
+ *
+ * @since 1.26.0
+ */
+class Registrar {
+
+	/**
+	 * Namespace the aliases are published under.
+	 *
+	 * @var string
+	 */
+	const ALIAS_NAMESPACE = 'wp/v2';
+
+	/**
+	 * Post types already aliased against the current REST server.
+	 *
+	 * Keyed by post type so a repeated `rest_api_init` is a no-op rather than
+	 * a second set of handlers on the same routes. The map is discarded when
+	 * the REST server is replaced, because a new server starts with no routes
+	 * and must be populated again.
+	 *
+	 * @var array<string,bool>
+	 */
+	protected $registered = [];
+
+	/**
+	 * The REST server the current registration map belongs to.
+	 *
+	 * @var \WP_REST_Server|null
+	 */
+	protected $registered_server = null;
+
+	/**
+	 * Post types to alias, mapped to their standard collection base.
+	 *
+	 * @var array<string,string>
+	 */
+	protected $post_types = [];
+
+	/**
+	 * Build the registrar.
+	 *
+	 * @param array<string,string> $post_types Post type key => REST collection base.
+	 */
+	public function __construct( array $post_types ) {
+		$this->post_types = $post_types;
+	}
+
+	/**
+	 * Register aliases for every configured post type.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		$this->sync_with_current_server();
+
+		foreach ( $this->post_types as $post_type => $rest_base ) {
+			$this->register_post_type( (string) $post_type, (string) $rest_base );
+		}
+	}
+
+	/**
+	 * Drop the registration map when the REST server has been replaced.
+	 *
+	 * Route registration lives on the server object. Test suites and some
+	 * integrations swap in a fresh server mid-request, which discards every
+	 * previously registered route, so the guard must be rebuilt alongside it.
+	 *
+	 * @return void
+	 */
+	protected function sync_with_current_server() {
+		global $wp_rest_server;
+
+		if ( $this->registered_server !== $wp_rest_server ) {
+			$this->registered        = [];
+			$this->registered_server = $wp_rest_server;
+		}
+	}
+
+	/**
+	 * Register the alias routes for a single post type.
+	 *
+	 * @param string $post_type Post type key.
+	 * @param string $rest_base REST collection base.
+	 *
+	 * @return void
+	 */
+	protected function register_post_type( $post_type, $rest_base ) {
+		if ( isset( $this->registered[ $post_type ] ) ) {
+			return;
+		}
+
+		$post_type_object = get_post_type_object( $post_type );
+
+		if ( ! $this->should_alias( $post_type_object ) ) {
+			return;
+		}
+
+		// Mark before registering so a controller failure cannot cause a retry
+		// to append duplicate handlers for whatever did register successfully.
+		$this->registered[ $post_type ] = true;
+
+		$posts = new PostsController( $post_type, self::ALIAS_NAMESPACE, $rest_base );
+		$posts->register_routes();
+
+		$this->register_child_routes( $post_type_object, $rest_base );
+	}
+
+	/**
+	 * Register revision and autosave aliases for a post type.
+	 *
+	 * Core resolves the child controllers against the post type's declared
+	 * `rest_base`, so the property is pointed at the alias base for the
+	 * duration of the call and restored afterwards. The restore runs from a
+	 * `finally` block so a throwing controller cannot leave the global post
+	 * type object mutated for the rest of the request.
+	 *
+	 * @param WP_Post_Type $post_type_object Post type object.
+	 * @param string       $rest_base        REST collection base.
+	 *
+	 * @return void
+	 */
+	protected function register_child_routes( $post_type_object, $rest_base ) {
+		$post_type      = $post_type_object->name;
+		$original_base  = $post_type_object->rest_base;
+		$restore_needed = $original_base !== $rest_base;
+
+		if ( $restore_needed ) {
+			$post_type_object->rest_base = $rest_base;
+		}
+
+		try {
+			// Match Core's gate: revisions are only exposed when supported.
+			if ( post_type_supports( $post_type, 'revisions' ) ) {
+				$this->make_revisions_controller( $post_type )->register_routes();
+			}
+
+			// Match Core's gate: WordPress grants `autosave` implicitly with
+			// `editor`, and only registers autosave routes when it is present.
+			if ( post_type_supports( $post_type, 'autosave' ) ) {
+				$this->make_autosaves_controller( $post_type )->register_routes();
+			}
+		} finally {
+			if ( $restore_needed ) {
+				$post_type_object->rest_base = $original_base;
+			}
+		}
+	}
+
+	/**
+	 * Build the revisions alias controller.
+	 *
+	 * @param string $post_type Post type key.
+	 *
+	 * @return RevisionsController
+	 */
+	protected function make_revisions_controller( $post_type ) {
+		return new RevisionsController( $post_type, self::ALIAS_NAMESPACE );
+	}
+
+	/**
+	 * Build the autosaves alias controller.
+	 *
+	 * @param string $post_type Post type key.
+	 *
+	 * @return AutosavesController
+	 */
+	protected function make_autosaves_controller( $post_type ) {
+		return new AutosavesController( $post_type, self::ALIAS_NAMESPACE );
+	}
+
+	/**
+	 * Determine whether a post type should be aliased.
+	 *
+	 * @param WP_Post_Type|null $post_type_object Post type object.
+	 *
+	 * @return bool
+	 */
+	protected function should_alias( $post_type_object ) {
+		if ( ! $post_type_object instanceof WP_Post_Type ) {
+			return false;
+		}
+
+		if ( ! $post_type_object->show_in_rest ) {
+			return false;
+		}
+
+		// Already published under the standard namespace by Core.
+		if ( self::ALIAS_NAMESPACE === $post_type_object->rest_namespace ) {
+			return false;
+		}
+
+		return true;
+	}
+}

--- a/classes/RestAPI/Alias/RevisionsController.php
+++ b/classes/RestAPI/Alias/RevisionsController.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Standard namespace alias controller for Popup Maker post revisions.
+ *
+ * @copyright (c) 2024, Code Atlantic LLC.
+ * @package PopupMaker\RestAPI\Alias
+ */
+
+namespace PopupMaker\RestAPI\Alias;
+
+defined( 'ABSPATH' ) || exit;
+
+use WP_REST_Revisions_Controller;
+
+/**
+ * Exposes a Popup Maker post type's revisions through the standard namespace.
+ *
+ * Mirrors the revision routes Core already registers under `popup-maker/v2`
+ * so editors that resolve revisions through `wp/v2` see identical behavior.
+ * Route definitions, schema, and permission checks are inherited unchanged.
+ *
+ * @since 1.26.0
+ */
+class RevisionsController extends WP_REST_Revisions_Controller {
+
+	/**
+	 * Build an aliased revisions controller.
+	 *
+	 * @param string $parent_post_type Parent post type key.
+	 * @param string $rest_namespace   REST namespace to expose the routes under.
+	 */
+	public function __construct( $parent_post_type, $rest_namespace ) {
+		parent::__construct( $parent_post_type );
+
+		$this->namespace = $rest_namespace;
+	}
+}

--- a/tests/php/fixtures/class-pum-test-failing-alias-registrar.php
+++ b/tests/php/fixtures/class-pum-test-failing-alias-registrar.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * Alias registrar stub whose child controller fails to construct.
+ *
+ * @package Popup_Maker
+ */
+
+/**
+ * Registrar stub whose revisions controller fails to construct.
+ *
+ * Only the controller factory is overridden, so the real
+ * `register_child_routes()` runs and its `finally` restore is what the test
+ * actually exercises.
+ */
+class PUM_Test_Failing_Alias_Registrar extends \PopupMaker\RestAPI\Alias\Registrar {
+
+	/**
+	 * The rest_base observed while the mutation was in effect.
+	 *
+	 * @var string|null
+	 */
+	public $observed_base = null;
+
+	/**
+	 * Record the mutated value, then fail as a broken controller would.
+	 *
+	 * @param string $post_type Post type key.
+	 *
+	 * @throws \RuntimeException Always, simulating a controller that cannot be built.
+	 */
+	protected function make_revisions_controller( $post_type ) {
+		$post_type_object = get_post_type_object( $post_type );
+
+		$this->observed_base = $post_type_object->rest_base;
+
+		throw new \RuntimeException( 'controller construction failed' );
+	}
+}

--- a/tests/php/tests/REST_PostTypeAliases_Test.php
+++ b/tests/php/tests/REST_PostTypeAliases_Test.php
@@ -5,10 +5,43 @@
  * @package Popup_Maker
  */
 
+require_once dirname( __DIR__ ) . '/fixtures/class-pum-test-failing-alias-registrar.php';
+
 /**
  * Test standard WordPress REST aliases.
+ *
+ * These tests assert observable routing and response behavior rather than the
+ * classes that implement it, so the alias layer can be refactored without
+ * rewriting the suite.
  */
 class REST_PostTypeAliases_Test extends WP_UnitTestCase {
+
+	/**
+	 * Plugin REST namespace.
+	 *
+	 * @var string
+	 */
+	const PLUGIN_NS = 'popup-maker/v2';
+
+	/**
+	 * Standard REST namespace.
+	 *
+	 * @var string
+	 */
+	const ALIAS_NS = 'wp/v2';
+
+	/**
+	 * Reset the REST server before each test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+
+		global $wp_rest_server;
+
+		$wp_rest_server = null;
+	}
 
 	/**
 	 * Reset the REST server after each test.
@@ -24,24 +57,178 @@ class REST_PostTypeAliases_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test the standard aliases and existing versioned routes are registered.
+	 * Get all registered routes.
 	 *
-	 * @return void
+	 * @return array<string,mixed>
 	 */
-	public function test_post_type_routes_are_registered_in_both_namespaces() {
-		global $wp_rest_server;
-
-		$wp_rest_server = null;
-		$routes         = rest_get_server()->get_routes();
-
-		$this->assertArrayHasKey( '/popup-maker/v2/popups', $routes );
-		$this->assertArrayHasKey( '/popup-maker/v2/popup-themes', $routes );
-		$this->assertArrayHasKey( '/wp/v2/popups', $routes );
-		$this->assertArrayHasKey( '/wp/v2/popup-themes', $routes );
+	protected function get_routes() {
+		return rest_get_server()->get_routes();
 	}
 
 	/**
-	 * Test an authorized user can read a popup through the standard alias.
+	 * Count the handlers registered for a route.
+	 *
+	 * @param string $route Route pattern.
+	 *
+	 * @return int
+	 */
+	protected function count_handlers( $route ) {
+		$routes = $this->get_routes();
+
+		return isset( $routes[ $route ] ) ? count( $routes[ $route ] ) : 0;
+	}
+
+	/**
+	 * Post type collection bases under test.
+	 *
+	 * @return array<string,array{0:string,1:string}>
+	 */
+	public function post_type_provider() {
+		return [
+			'popup'       => [ 'popup', 'popups' ],
+			'popup_theme' => [ 'popup_theme', 'popup-themes' ],
+		];
+	}
+
+	/**
+	 * Collection and item routes exist in both namespaces.
+	 *
+	 * @dataProvider post_type_provider
+	 *
+	 * @param string $post_type Post type key.
+	 * @param string $rest_base REST collection base.
+	 *
+	 * @return void
+	 */
+	public function test_collection_and_item_routes_exist_in_both_namespaces( $post_type, $rest_base ) {
+		$routes = $this->get_routes();
+
+		foreach ( [ self::PLUGIN_NS, self::ALIAS_NS ] as $namespace ) {
+			$this->assertArrayHasKey(
+				'/' . $namespace . '/' . $rest_base,
+				$routes,
+				$post_type . ' collection missing from ' . $namespace
+			);
+			$this->assertArrayHasKey(
+				'/' . $namespace . '/' . $rest_base . '/(?P<id>[\d]+)',
+				$routes,
+				$post_type . ' item route missing from ' . $namespace
+			);
+		}
+	}
+
+	/**
+	 * The alias namespace exposes the same methods as the plugin namespace.
+	 *
+	 * @dataProvider post_type_provider
+	 *
+	 * @param string $post_type Post type key.
+	 * @param string $rest_base REST collection base.
+	 *
+	 * @return void
+	 */
+	public function test_alias_namespace_supports_same_methods( $post_type, $rest_base ) {
+		$routes = $this->get_routes();
+
+		foreach ( [ '', '/(?P<id>[\d]+)' ] as $suffix ) {
+			$plugin_methods = $this->collect_methods( $routes, '/' . self::PLUGIN_NS . '/' . $rest_base . $suffix );
+			$alias_methods  = $this->collect_methods( $routes, '/' . self::ALIAS_NS . '/' . $rest_base . $suffix );
+
+			$this->assertNotEmpty( $plugin_methods, $post_type . $suffix . ' has no plugin-namespace methods' );
+			$this->assertSame(
+				$plugin_methods,
+				$alias_methods,
+				$post_type . $suffix . ' methods differ between namespaces'
+			);
+		}
+	}
+
+	/**
+	 * Collect the sorted, unique HTTP methods registered for a route.
+	 *
+	 * @param array<string,mixed> $routes Registered routes.
+	 * @param string              $route  Route pattern.
+	 *
+	 * @return string[]
+	 */
+	protected function collect_methods( $routes, $route ) {
+		if ( ! isset( $routes[ $route ] ) ) {
+			return [];
+		}
+
+		$methods = [];
+
+		foreach ( $routes[ $route ] as $handler ) {
+			foreach ( array_keys( array_filter( $handler['methods'] ) ) as $method ) {
+				$methods[ $method ] = true;
+			}
+		}
+
+		$methods = array_keys( $methods );
+		sort( $methods );
+
+		return $methods;
+	}
+
+	/**
+	 * Revision routes mirror the plugin namespace wherever they exist.
+	 *
+	 * @dataProvider post_type_provider
+	 *
+	 * @param string $post_type Post type key.
+	 * @param string $rest_base REST collection base.
+	 *
+	 * @return void
+	 */
+	public function test_revision_routes_mirror_plugin_namespace( $post_type, $rest_base ) {
+		$this->assertTrue(
+			post_type_supports( $post_type, 'revisions' ),
+			$post_type . ' is expected to support revisions'
+		);
+
+		$routes = $this->get_routes();
+		$suffix = '/(?P<parent>[\d]+)/revisions';
+
+		$this->assertArrayHasKey( '/' . self::PLUGIN_NS . '/' . $rest_base . $suffix, $routes );
+		$this->assertArrayHasKey( '/' . self::ALIAS_NS . '/' . $rest_base . $suffix, $routes );
+	}
+
+	/**
+	 * Autosave routes appear in the alias namespace only when Core registers them.
+	 *
+	 * WordPress grants `autosave` support implicitly alongside `editor`, and
+	 * only registers autosave routes when the post type supports it. The alias
+	 * layer must apply the same gate so the two namespaces cannot drift.
+	 *
+	 * @dataProvider post_type_provider
+	 *
+	 * @param string $post_type Post type key.
+	 * @param string $rest_base REST collection base.
+	 *
+	 * @return void
+	 */
+	public function test_autosave_routes_match_core_support_gate( $post_type, $rest_base ) {
+		$routes   = $this->get_routes();
+		$suffix   = '/(?P<id>[\d]+)/autosaves';
+		$supports = post_type_supports( $post_type, 'autosave' );
+
+		$plugin_route = '/' . self::PLUGIN_NS . '/' . $rest_base . $suffix;
+		$alias_route  = '/' . self::ALIAS_NS . '/' . $rest_base . $suffix;
+
+		$this->assertSame(
+			$supports,
+			isset( $routes[ $plugin_route ] ),
+			$post_type . ' plugin-namespace autosaves should track autosave support'
+		);
+		$this->assertSame(
+			$supports,
+			isset( $routes[ $alias_route ] ),
+			$post_type . ' alias-namespace autosaves should track autosave support'
+		);
+	}
+
+	/**
+	 * An authorized user can read a popup through the standard alias.
 	 *
 	 * @return void
 	 */
@@ -61,5 +248,228 @@ class REST_PostTypeAliases_Test extends WP_UnitTestCase {
 
 		$this->assertSame( 200, $response->get_status() );
 		$this->assertSame( $popup_id, $response->get_data()['id'] );
+	}
+
+	/**
+	 * Both namespaces return the same item payload for the same popup.
+	 *
+	 * @return void
+	 */
+	public function test_both_namespaces_return_equivalent_item_payloads() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+				'post_title'  => 'Parity popup',
+			]
+		);
+
+		wp_set_current_user( $admin_id );
+
+		$plugin = rest_do_request( new WP_REST_Request( 'GET', '/popup-maker/v2/popups/' . $popup_id ) );
+		$alias  = rest_do_request( new WP_REST_Request( 'GET', '/wp/v2/popups/' . $popup_id ) );
+
+		$this->assertSame( 200, $plugin->get_status() );
+		$this->assertSame( 200, $alias->get_status() );
+
+		$plugin_data = $plugin->get_data();
+		$alias_data  = $alias->get_data();
+
+		$this->assertSame( $plugin_data['id'], $alias_data['id'] );
+		$this->assertSame( $plugin_data['title']['rendered'], $alias_data['title']['rendered'] );
+		$this->assertSame( $plugin_data['status'], $alias_data['status'] );
+	}
+
+	/**
+	 * The alias enforces the same permissions as the plugin namespace.
+	 *
+	 * @return void
+	 */
+	public function test_alias_denies_unauthorized_reads_of_private_popups() {
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'draft',
+				'post_title'  => 'Unpublished popup',
+			]
+		);
+
+		wp_set_current_user( 0 );
+
+		$response = rest_do_request( new WP_REST_Request( 'GET', '/wp/v2/popups/' . $popup_id ) );
+
+		$this->assertContains(
+			$response->get_status(),
+			[ 401, 403 ],
+			'Anonymous reads of a draft popup must not succeed through the alias'
+		);
+	}
+
+	/**
+	 * A revision created on a popup is readable through the alias namespace.
+	 *
+	 * @return void
+	 */
+	public function test_revisions_are_readable_through_the_alias() {
+		$admin_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+
+		$popup_id = $this->factory->post->create(
+			[
+				'post_type'    => 'popup',
+				'post_status'  => 'publish',
+				'post_title'   => 'Revisioned popup',
+				'post_content' => 'First revision.',
+			]
+		);
+
+		wp_update_post(
+			[
+				'ID'           => $popup_id,
+				'post_content' => 'Second revision.',
+			]
+		);
+
+		$response = rest_do_request( new WP_REST_Request( 'GET', '/wp/v2/popups/' . $popup_id . '/revisions' ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertNotEmpty( $response->get_data(), 'Expected at least one revision through the alias' );
+	}
+
+	/**
+	 * Repeated registration does not duplicate route handlers.
+	 *
+	 * `rest_api_init` can fire more than once per request; registering the same
+	 * route twice appends a second handler rather than replacing the first.
+	 *
+	 * @return void
+	 */
+	public function test_repeated_registration_does_not_duplicate_handlers() {
+		$route = '/wp/v2/popups';
+
+		$initial = $this->count_handlers( $route );
+
+		$this->assertGreaterThan( 0, $initial, 'Alias route should be registered before the repeat check' );
+
+		do_action( 'rest_api_init' );
+		do_action( 'rest_api_init' );
+
+		$this->assertSame(
+			$initial,
+			$this->count_handlers( $route ),
+			'Repeated rest_api_init must not append duplicate handlers'
+		);
+	}
+
+	/**
+	 * Registration restores any temporary post type property change.
+	 *
+	 * @dataProvider post_type_provider
+	 *
+	 * @param string $post_type Post type key.
+	 * @param string $rest_base REST collection base.
+	 *
+	 * @return void
+	 */
+	public function test_post_type_properties_are_restored_after_registration( $post_type, $rest_base ) {
+		$post_type_object = get_post_type_object( $post_type );
+
+		$before_base      = $post_type_object->rest_base;
+		$before_namespace = $post_type_object->rest_namespace;
+
+		do_action( 'rest_api_init' );
+
+		$this->assertSame( $before_base, $post_type_object->rest_base, $post_type . ' rest_base was not restored' );
+		$this->assertSame( $before_namespace, $post_type_object->rest_namespace, $post_type . ' rest_namespace changed' );
+	}
+
+	/**
+	 * A failure during child registration still restores the post type property.
+	 *
+	 * Guards the `finally` restore in the registrar: without it, a controller
+	 * that throws mid-registration would leave the global post type object
+	 * mutated for the remainder of the request.
+	 *
+	 * @return void
+	 */
+	public function test_property_is_restored_when_registration_throws() {
+		$post_type_object = get_post_type_object( 'popup' );
+		$original_base    = $post_type_object->rest_base;
+
+		// Alias under a base that differs from the declared one, so the
+		// registrar must actually mutate the property before restoring it.
+		$registrar = new PUM_Test_Failing_Alias_Registrar( [ 'popup' => 'alias-probe-popups' ] );
+
+		$caught = false;
+
+		// Register on the action WordPress expects, matching production timing.
+		$run = function () use ( $registrar ) {
+			$registrar->register();
+		};
+
+		add_action( 'rest_api_init', $run, 99 );
+
+		try {
+			do_action( 'rest_api_init' );
+		} catch ( \RuntimeException $e ) {
+			$caught = true;
+		} finally {
+			remove_action( 'rest_api_init', $run, 99 );
+		}
+
+		$this->assertTrue( $caught, 'The registration failure should have propagated' );
+		$this->assertSame(
+			'alias-probe-popups',
+			$registrar->observed_base,
+			'The registrar should have mutated rest_base before failing'
+		);
+		$this->assertSame(
+			$original_base,
+			$post_type_object->rest_base,
+			'rest_base must be restored even when registration fails'
+		);
+	}
+
+	/**
+	 * Popup Maker's own controllers are untouched by the alias layer.
+	 *
+	 * @return void
+	 */
+	public function test_plugin_namespace_controllers_are_unchanged() {
+		$routes = $this->get_routes();
+
+		foreach ( [ 'popups', 'popup-themes' ] as $rest_base ) {
+			$route = '/' . self::PLUGIN_NS . '/' . $rest_base;
+
+			$this->assertArrayHasKey( $route, $routes );
+
+			foreach ( $routes[ $route ] as $handler ) {
+				$controller = is_array( $handler['callback'] ) ? $handler['callback'][0] : null;
+
+				$this->assertInstanceOf(
+					'WP_REST_Posts_Controller',
+					$controller,
+					$route . ' should still be served by a Core posts controller'
+				);
+				$this->assertNotInstanceOf(
+					'PopupMaker\RestAPI\Alias\PostsController',
+					$controller,
+					$route . ' must not be served by the alias controller'
+				);
+			}
+		}
+	}
+
+	/**
+	 * Non-aliased Popup Maker post types are left alone.
+	 *
+	 * @return void
+	 */
+	public function test_other_post_types_are_not_aliased() {
+		$routes = $this->get_routes();
+
+		$this->assertArrayNotHasKey( '/wp/v2/ctas', $routes );
+		$this->assertArrayNotHasKey( '/wp/v2/pum_cta', $routes );
 	}
 }


### PR DESCRIPTION
Follow-up to the review discussion on #1394 ([thread](https://github.com/PopupMaker/Popup-Maker/pull/1394#discussion_r3983395672)): the `wp/v2` compatibility aliases were built from three anonymous subclasses declared inline in `PostTypes.php`. They were PHP 7.4-safe, but not a maintainable WordPress-style shape — the classes could not be referenced, extended, or tested by name.

## What changed

Named controllers under `PopupMaker\RestAPI\Alias` (`PostsController`, `RevisionsController`, `AutosavesController`) plus an explicit `Registrar`. `PostTypes.php` drops from 69 lines of inline class declarations to a single `register()` call.

No route definitions are duplicated. Each controller inherits its routes, schema, and permission callbacks from the matching Core controller, so the two namespaces stay in lockstep by construction.

## Two behavior bugs found while characterizing

Both were found by probing the **actual** route table rather than reading the code, and both are covered by tests that fail against the previous implementation.

**1. Phantom autosave routes on `popup_theme`.** Core gates autosave routes on `post_type_supports( 'autosave' )`, which WordPress grants implicitly alongside `editor`. `popup` declares `editor`; `popup_theme` does not. So Core registers no autosave routes for `popup_theme` under `popup-maker/v2` — but the anonymous autosaves controller was gated only on `class_exists()` and registered `/wp/v2/popup-themes/<id>/autosaves` anyway. Three routes existed in one namespace with no counterpart in the other. The registrar now applies Core's own gate.

**2. Registration was not idempotent.** A second `rest_api_init` in the same request appended a duplicate set of handlers — `/wp/v2/popups` went from 2 handlers to 4. The registrar now tracks what it registered against the current REST server, so repeat initialization is a no-op while a *replaced* server is still populated correctly.

Separately, post-type property mutation during child route registration now runs in `try`/`finally`, so a controller that fails to build cannot leave the global post type object mutated for the rest of the request. Note that this mutation is currently a no-op in practice — both post types already declare exactly the `rest_base` values the alias assigns — so this is a structural guarantee rather than a fix for a live defect.

## Before / after route matrix

41 route+method rows before, 38 after. The `popup-maker/v2` namespace is **byte-identical**; `wp/v2` loses only the three unsupported autosave routes.

| Route group | `popup-maker/v2` | `wp/v2` before | `wp/v2` after |
|---|---|---|---|
| popups collection + item | ✅ | ✅ | ✅ |
| popups revisions | ✅ | ✅ | ✅ |
| popups autosaves | ✅ | ✅ | ✅ |
| popup-themes collection + item | ✅ | ✅ | ✅ |
| popup-themes revisions | ✅ | ✅ | ✅ |
| **popup-themes autosaves** | ❌ (Core: no `editor`) | ⚠️ registered | ✅ removed |

## Revisions & autosaves

Answering the follow-up question in the thread: both post types already declare `revisions` in `supports`, and Core already registers revision routes for both under `popup-maker/v2`. No new implementation was needed — the correct outcome was to characterize and preserve Core's behavior, and to stop the alias layer from exceeding it.

## Checks

- **PHPUnit**: 1208 tests / 2997 assertions, 0 failures (baseline on `develop`: 1192 / 2946, also green). +16 tests, +51 assertions.
- **PHPCS**: clean on all changed files.
- **PHPStan**: 26 errors, identical to baseline, none in the new or changed files.
- **wp-env REST smoke** (WordPress 7.1 / PHP 8.3): 20 route patterns registered, symmetric across namespaces. Live HTTP: `/wp/v2/popups` → 200, `/wp/v2/popup-themes` → 200, `/wp/v2/popup-themes/1/autosaves` → 404.
- Tests verified to **fail** against the previous implementation on exactly the two defects above.

## Compatibility note worth knowing

The smoke test initially fataled with `Class "PopupMaker\RestAPI\Alias\Registrar" not found`. Root cause: `vendor-prefixed/composer/autoload_real.php` calls `setClassMapAuthoritative( true )`, so Composer consults only the classmap and never falls back to PSR-4 scanning. **Any** new class under `classes/` fatals until a full `composer install` regenerates the Strauss classmap — `composer dump-autoload` is not sufficient. Worth keeping in mind for release builds.

PHP 7.4+ and WordPress 6.7–7.1 compatible; no union types, no `match`, no named arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented popup themes from advertising a WordPress REST autosave endpoint that WordPress does not provide.
  - Prevented duplicate REST route handlers from being registered when the REST API initializes multiple times during a request.
  - Preserved consistent REST API behavior for popup content, revisions, and autosaves, including matching methods, responses, and permissions.
- **Tests**
  - Expanded coverage for REST routes, permissions, response consistency, repeated initialization, and registration failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->