### PR TITLE
refactor(popups): single canonical popup model fetch/cache boundary

### DIFF
--- a/.perf/BASELINE.md
+++ b/.perf/BASELINE.md
@@ -1,49 +1,62 @@
 # Baseline metrics @ develop 21e59a1d
 
 Environment: WP PHPUnit integration suite, single site, MySQL 8.0.35 (Local),
-PHP CLI. Query counts and hydration counts are **deterministic** — repeated runs
-produce identical values. Elapsed time and memory are single samples and are
-**noisy**; treat them as supporting data only.
+PHP CLI. Hydration counts and distinct-object counts are **deterministic**.
+Elapsed time and memory are single samples and are **noisy**.
 
 Reproduce:
 
 ```bash
 export WP_TESTS_DIR="$TMPDIR/wordpress-tests-lib"
 PUM_BENCH_POPUPS=<n> vendor/bin/phpunit -c tests/php/phpunit.xml \
-  --filter Popup_Model_Cache_Bench
+  --testsuite bench
 ```
 
-## Results
+> **Superseded query counts.** The first run of this benchmark seeded popups
+> without `data_version` meta and recorded 30 queries at n=10 and 150 at n=50.
+> Those numbers measured the fixture, not the plugin: a popup missing
+> `data_version` makes `PUM_Model_Popup::setup()` perform a SELECT + UPDATE
+> during a read, and those writes invalidate the bulk postmeta cache that
+> `WP_Query` had just primed, forcing per-popup meta refetches.
+>
+> Real popups always carry `data_version`. With a corrected fixture the popup
+> pass is **3 queries flat at any popup count** (one posts query, one term
+> query, one bulk postmeta prime) with **zero queries on readback**, both before
+> and after this change. The table below reports the corrected values. See
+> `.perf/RESULTS.md` for the full corrected comparison and `.perf/QUERY-AUDIT.md`
+> for the `data_version` write-on-read analysis.
+
+## Results (corrected fixture)
 
 | n | scenario | queries | hydrations | distinct objects | notes |
 |---|----------|---------|------------|------------------|-------|
 | 0 | D frontend query | 2 | 0 | — | no popups, no hydration |
-| 1 | A cold single | 3 | 1 | — | |
-| 1 | B warm ×10 | 1 | 0 | 1 | warm path already good |
+| 1 | A cold single | 1 | 1 | — | |
+| 1 | B warm ×10 | 0 | 0 | 1 | warm path already good |
 | 1 | C cross-API | 0 | 2 | **2** | identity split |
 | 1 | D query+readback | 2 | **2** | 1 | 2 hydrations for 1 popup |
-| 10 | A cold single | 3 | 1 | — | |
-| 10 | B warm ×10 | 1 | 0 | 1 | |
+| 10 | A cold single | 1 | 1 | — | |
+| 10 | B warm ×10 | 0 | 0 | 1 | |
 | 10 | C cross-API | 0 | 2 | **2** | identity split |
-| 10 | D query+readback | **30** | **20** | 10 | 3 queries + 2 hydrations per popup |
-| 50 | D query+readback | **150** | **100** | 50 | scales linearly |
+| 10 | D query+readback | 3 | **20** | 10 | 2 hydrations per popup |
+| 50 | D query+readback | 3 | **100** | 50 | hydrations scale linearly |
 
-Scenario E (`stale_after_meta_write`) reports `is_fresh: yes` at every count —
-the current provenance guard **is** working. Any refactor must keep it that way.
+Scenario E (`stale_after_meta_write`) reads fresh at every count — the model's
+settings provenance guard was already working. Any refactor must keep it so.
 
 ## The two defects the numbers prove
 
 1. **Split identity (C).** Requesting one popup through `pum_get_popup()`,
    `plugin()->get('popups')->get_by_id()`, and `pum()->popups->get_item()`
-   returns **2 distinct objects**. Caches #1 and #2 each hydrate their own
-   instance. A mutation applied to one is invisible to the other.
+   returns **2 distinct objects**. The modern and legacy repositories each
+   hydrate their own instance, so a mutation applied to one is invisible to the
+   other, and a reference held across a settings write reports the pre-write
+   value.
 
 2. **Double hydration (D).** Every popup is constructed **twice** per frontend
-   pass: once by the repository `query()` (cache #1) and once again on readback
-   through `pum_get_popup()`, which consults cache #3 then falls through to
-   cache #2 — a cache that never saw the query results. At 50 popups that is
-   100 model constructions and 150 queries where 50 and ~51 would do.
+   pass: once by the repository `query()` and once again on readback through
+   `pum_get_popup()`, which consulted a cache that never saw the query results.
+   At 50 popups that is 100 model constructions where 50 would do.
 
-Warm repeat reads (B) are already efficient, so the win is concentrated in the
-query→readback path and in collapsing identity — which is also the correctness
-story, not just a speed story.
+**Query count is not one of the defects.** It was already 3 flat and is
+unchanged by this work.

--- a/.perf/BASELINE.md
+++ b/.perf/BASELINE.md
@@ -1,0 +1,49 @@
+# Baseline metrics @ develop 21e59a1d
+
+Environment: WP PHPUnit integration suite, single site, MySQL 8.0.35 (Local),
+PHP CLI. Query counts and hydration counts are **deterministic** — repeated runs
+produce identical values. Elapsed time and memory are single samples and are
+**noisy**; treat them as supporting data only.
+
+Reproduce:
+
+```bash
+export WP_TESTS_DIR="$TMPDIR/wordpress-tests-lib"
+PUM_BENCH_POPUPS=<n> vendor/bin/phpunit -c tests/php/phpunit.xml \
+  --filter Popup_Model_Cache_Bench
+```
+
+## Results
+
+| n | scenario | queries | hydrations | distinct objects | notes |
+|---|----------|---------|------------|------------------|-------|
+| 0 | D frontend query | 2 | 0 | — | no popups, no hydration |
+| 1 | A cold single | 3 | 1 | — | |
+| 1 | B warm ×10 | 1 | 0 | 1 | warm path already good |
+| 1 | C cross-API | 0 | 2 | **2** | identity split |
+| 1 | D query+readback | 2 | **2** | 1 | 2 hydrations for 1 popup |
+| 10 | A cold single | 3 | 1 | — | |
+| 10 | B warm ×10 | 1 | 0 | 1 | |
+| 10 | C cross-API | 0 | 2 | **2** | identity split |
+| 10 | D query+readback | **30** | **20** | 10 | 3 queries + 2 hydrations per popup |
+| 50 | D query+readback | **150** | **100** | 50 | scales linearly |
+
+Scenario E (`stale_after_meta_write`) reports `is_fresh: yes` at every count —
+the current provenance guard **is** working. Any refactor must keep it that way.
+
+## The two defects the numbers prove
+
+1. **Split identity (C).** Requesting one popup through `pum_get_popup()`,
+   `plugin()->get('popups')->get_by_id()`, and `pum()->popups->get_item()`
+   returns **2 distinct objects**. Caches #1 and #2 each hydrate their own
+   instance. A mutation applied to one is invisible to the other.
+
+2. **Double hydration (D).** Every popup is constructed **twice** per frontend
+   pass: once by the repository `query()` (cache #1) and once again on readback
+   through `pum_get_popup()`, which consults cache #3 then falls through to
+   cache #2 — a cache that never saw the query results. At 50 popups that is
+   100 model constructions and 150 queries where 50 and ~51 would do.
+
+Warm repeat reads (B) are already efficient, so the win is concentrated in the
+query→readback path and in collapsing identity — which is also the correctness
+story, not just a speed story.

--- a/.perf/MAP.md
+++ b/.perf/MAP.md
@@ -1,0 +1,75 @@
+# Popup model fetch/cache path map (baseline @ develop 21e59a1d)
+
+## Caches that hold hydrated `PUM_Model_Popup` instances
+
+| # | Owner | Storage | Key | Staleness strategy | Eviction API |
+|---|-------|---------|-----|--------------------|--------------|
+| 1 | `PopupMaker\Services\Repository\Popups` (via `Base\Service\Repository`) | `$items_by_id` | `get_current_blog_id() . ':' . (int) $id` | none — trusted until forgotten | `forget_item()`, `replace_cached_item()` |
+| 2 | `PUM_Repository_Popups` (via `PUM_Abstract_Repository_Posts`) | `$cache['objects'][ $post->ID ]` | raw `$post->ID` (NOT site-partitioned) | `hash` field = `md5( blog_id . ':' . md5( json_encode( $post ) ) )`, compared on every read | `forget_item()` |
+| 3 | `Controllers\Frontend\Popups` | `$queried_popups` | `popup_cache_key()` (site-partitioned) | re-reads `get_post()` and diffs `get_object_vars()` on every read | `invalidate_queried_popup()` |
+
+Three independent caches store the same logical object. #2 side-steps key
+collisions across sites by folding the blog ID into the *hash* rather than the
+key, so a cross-site read is treated as stale and re-hydrated instead of
+returning the wrong site's model. Correct, but it means the model is
+re-constructed on every site switch, and the ID-keyed `forget_item()` is doing
+double duty.
+
+## Fetch entry points
+
+- `pum_get_popup( $id )` — legacy public helper. Hand-rolls a three-step
+  cascade: `pum()->current_popup` → frontend controller's `$queried_popups` →
+  `pum()->popups->get_item()` (cache #2), then *writes back* into cache #3.
+  This is the duplicate ownership called out in r3983541633.
+- `PopupMaker\plugin()->get( 'popups' )->get_by_id()` — modern path, cache #1.
+- `pum()->popups->get_item()` — legacy path, cache #2. Throws
+  `InvalidArgumentException` when `has_item()` fails.
+- `Controllers\Frontend\Popups::preload_popups()` — queries via cache #1's
+  `query()`, then reconciles each model into caches #1 and #3 by hand
+  (`get_queried_popup` / `cache_queried_popup` / `replace_cached_item`).
+
+## Cross-cache invalidation wiring (the "convoluted mess")
+
+`Controllers\Frontend\Popups::invalidate_queried_popup()` must poke all three:
+
+```php
+unset( $this->queried_popups[ $key ] );           // #3
+$this->container->get( 'popups' )->forget_item(); // #1
+pum()->popups->forget_item( $post_id );           // #2
+```
+
+`invalidate_queried_popup_settings()` repeats the pattern and additionally
+reaches *into* the model to null `$popup->settings`.
+
+## Settings provenance (r3983427868)
+
+`PUM_Model_Popup::get_settings()` guards with four conditions:
+
+```php
+isset( $this->settings )
+&& $this->settings_loaded_from_meta
+&& $this->settings === $this->settings_loaded_value
+&& $this->settings_meta_cache_hash !== $this->get_settings_meta_cache_hash()
+```
+
+backed by three private properties (`$settings_loaded_from_meta`,
+`$settings_loaded_value`, `$settings_meta_cache_hash`).
+`get_settings_meta_cache_hash()` does a `wp_cache_get( 'post_meta' )` and a
+**sha256 over the serialized meta entry on every single call**. `Model\Theme`
+carries a parallel-but-different variant of the same idea. This is the DRY
+target.
+
+Semantics worth preserving verbatim:
+
+- Only self-loaded-from-meta settings are re-validated; values injected by a
+  subclass or by a `get_post_metadata` short-circuit are left alone
+  (`from_metadata => false`).
+- If a third party mutated `$this->settings` directly, the
+  `=== $settings_loaded_value` check declines to clobber it.
+
+## Design target
+
+One canonical request-local fetch/cache boundary below frontend/admin/AJAX, with
+caches #2 and #3 delegating to #1 rather than owning storage. Invalidation
+collapses to a single call. Identity becomes shared by construction rather than
+by hand-reconciliation.

--- a/.perf/QUERY-AUDIT.md
+++ b/.perf/QUERY-AUDIT.md
@@ -50,8 +50,7 @@ plus a single-post meta prime, per popup — `get_post()` refilling a cache the
 probe had just emptied.
 
 Re-measured with plugin request-local caches reset but the WP object cache left
-intact (i.e. a site with a persistent object cache, or simply the same request
-lifecycle WordPress actually has):
+intact:
 
 | request | admin list (5 getters ×25) |
 |---------|----------------------------|
@@ -59,7 +58,14 @@ lifecycle WordPress actually has):
 | #2 | **0** |
 | #3 | **0** |
 
-Steady state is zero queries.
+**Scope of this result.** Retaining the object cache across simulated requests
+models a site running a *persistent* object cache (Redis, Memcached). WordPress's
+default object cache is non-persistent and is discarded at the end of every HTTP
+request, so on such a site each request re-primes post and meta caches from the
+database regardless of this plugin. The zero-query figure therefore describes
+persistent-cache deployments; on a default install the steady-state cost is the
+normal WordPress priming, not repeated plugin-side work. Either way the point
+stands that nothing here degrades request over request.
 
 ## Steady state, verified
 
@@ -69,7 +75,7 @@ Popups with backfill meta present — what a normal site looks like:
 |------|---|---------|
 | `pum_get_all_popups()` | 25 | 4 |
 | `get_title()` + `is_enabled()` + `get_setting()` ×25 | 25 | 0 |
-| `pum_get_all_popups()` repeat, same args | 10 | 0 |
+| `pum_get_all_popups()` repeat, same args | 25 | 0 |
 | `pum_get_all_themes()` | 6 | 4 |
 | per-theme `get_setting()` ×6 | 6 | 0 |
 | frontend preload + loadable checks | 25 | 4 |
@@ -79,8 +85,12 @@ Healthy throughout. Bulk prime works; request-local caches work.
 ## Live site state
 
 All 9 popups have `data_version`, `enabled`, and the open counts. Two lack
-`popup_conversion_count_total`. All 6 themes have `popup_theme_data_version`. So
-the backfill will fire at most twice more on this site, ever.
+`popup_conversion_count_total`. All 6 themes have `popup_theme_data_version`.
+
+So the **current inventory** carries two outstanding backfills. That bound holds
+only for these records and these meta keys: new popups, imported records, and any
+newly introduced event key each bring their own one-time backfill, as listed
+under Verdict below.
 
 ## Verdict
 

--- a/.perf/QUERY-AUDIT.md
+++ b/.perf/QUERY-AUDIT.md
@@ -1,96 +1,103 @@
 # Query audit: write-on-read in popup/theme models
 
-Follow-up from the `data_version` finding. Measured on this branch with the WP
-PHPUnit suite; every figure below was re-run **in isolation** because running
-probes together pollutes counts via plugin bootstrap and `wp_cache_flush()`.
+Follow-up from the `data_version` finding.
+
+**Conclusion up front: this is not an ongoing performance problem.** Every
+backfill is one-time and self-healing. An earlier revision of this document
+presented the un-backfilled figures as if they were a standing cost; they are
+not, and that framing was wrong. Corrected below.
 
 ## The pattern
 
-Five getters write to postmeta during a **read**:
+Five getters write to postmeta during a read:
 
-| # | Site | Meta written | Called from |
-|---|------|--------------|-------------|
-| 1 | `PUM_Model_Popup::setup()` L1442 | `data_version` | every model construction |
-| 2 | `PUM_Model_Popup::is_enabled()` L1125 | `enabled` | **frontend every page load**, admin list |
-| 3 | `PUM_Model_Popup::get_event_count()` L1256 | `popup_{event}_count` | admin list table |
-| 4 | `PUM_Model_Popup::get_event_count()` L1266 | `popup_{event}_count_total` | admin list table |
-| 5 | `PUM_Model_Theme::setup()` L559 | `popup_theme_data_version` | every theme construction |
+| # | Site | Meta written |
+|---|------|--------------|
+| 1 | `PUM_Model_Popup::setup()` L1442 | `data_version` |
+| 2 | `PUM_Model_Popup::is_enabled()` L1125 | `enabled` |
+| 3 | `PUM_Model_Popup::get_event_count()` L1256 | `popup_{event}_count` |
+| 4 | `PUM_Model_Popup::get_event_count()` L1266 | `popup_{event}_count_total` |
+| 5 | `PUM_Model_Theme::setup()` L559 | `popup_theme_data_version` |
 
-Each is a self-healing backfill and is *correct* — it writes once, then the meta
-exists. The cost is not the write itself.
+Each writes once when the key is absent, then the key exists and the write never
+repeats. The transient cost is that `update_post_meta()` invalidates that post's
+`post_meta` cache entry, discarding the bulk prime `WP_Query` just performed —
+so meta is re-fetched per popup for the remainder of *that one request*.
 
-**The real cost is cache poisoning.** `update_post_meta()` invalidates that
-post's entry in the `post_meta` object cache. `WP_Query` had just primed meta for
-*all* popups in one bulk query. One backfill write per popup destroys that prime
-row by row, so the next read re-fetches meta **one popup at a time**.
+## Measured: it heals after exactly one page load
 
-That is why a 3-query pass became 30 (n=10) or 150 (n=50) in the original
-benchmark: 3 legitimate queries, then SELECT+UPDATE per popup, then a per-popup
-meta re-prime.
+25 popups seeded with no backfill meta, consecutive simulated requests:
 
-## Measured, isolated
+| request | frontend (`query()` + `pum_is_popup_loadable()` ×25) | admin list (5 getters ×25) |
+|---------|------------------------------------------------------|-----------------------------|
+| #1 | 154 | 429 |
+| #2 | **4** | 50 |
+| #3 | **4** | 50 |
+| #4 | **4** | 50 |
 
-Popups **with** backfill meta (steady state — what a normal site looks like):
+Frontend drops to 4 queries and stays there. One page load, clean afterwards.
+
+A write counter hooked to `update_post_metadata` / `add_post_metadata` confirms
+**0 meta writes** across three post-heal requests. The backfills genuinely fire
+once.
+
+### The admin "50" was a probe artifact, not plugin behavior
+
+The residual 50 above came from the probe calling `wp_cache_flush()` between
+requests, which clears WordPress's *post* cache as well as postmeta. A real page
+load does not do that. The SQL confirmed it: `SELECT * FROM posts WHERE ID = N`
+plus a single-post meta prime, per popup — `get_post()` refilling a cache the
+probe had just emptied.
+
+Re-measured with plugin request-local caches reset but the WP object cache left
+intact (i.e. a site with a persistent object cache, or simply the same request
+lifecycle WordPress actually has):
+
+| request | admin list (5 getters ×25) |
+|---------|----------------------------|
+| #1 | 25 |
+| #2 | **0** |
+| #3 | **0** |
+
+Steady state is zero queries.
+
+## Steady state, verified
+
+Popups with backfill meta present — what a normal site looks like:
 
 | pass | n | queries |
 |------|---|---------|
-| `pum_get_all_popups()` | 25 | **4** |
-| `get_title()` + `is_enabled()` + `get_setting()` ×25 | 25 | **0** |
-| `pum_get_all_popups()` repeat, same args | 10 | **0** |
-| `pum_get_all_themes()` | 6 | **4** |
-| per-theme `get_setting()` ×6 | 6 | **0** |
+| `pum_get_all_popups()` | 25 | 4 |
+| `get_title()` + `is_enabled()` + `get_setting()` ×25 | 25 | 0 |
+| `pum_get_all_popups()` repeat, same args | 10 | 0 |
+| `pum_get_all_themes()` | 6 | 4 |
+| per-theme `get_setting()` ×6 | 6 | 0 |
+| frontend preload + loadable checks | 25 | 4 |
 
-Healthy. Bulk prime works, request-local caches work.
+Healthy throughout. Bulk prime works; request-local caches work.
 
-Popups **without** backfill meta (fresh import, programmatic insert, migration):
+## Live site state
 
-| pass | n | queries |
-|------|---|---------|
-| hydrate via `pum_get_all_popups()` | 25 | **54** |
-| admin list-table row render ×25 (what `Admin/Popups.php` actually calls) | 25 | **375** |
-| second pass over the same rows | 25 | **25** |
-| **frontend** `is_enabled()` ×25 | 25 | **75** |
+All 9 popups have `data_version`, `enabled`, and the open counts. Two lack
+`popup_conversion_count_total`. All 6 themes have `popup_theme_data_version`. So
+the backfill will fire at most twice more on this site, ever.
 
-375 queries to paint one admin list page. 75 queries on a **public page load**.
+## Verdict
 
-## Severity
+Not a performance issue. The behaviour is a deliberate one-time settle after
+something new happens (fresh install, import, programmatic insert, new event
+type), which is exactly what a backfill is for. The only scenario where it would
+recur is one where the write cannot persist — a genuinely read-only database or
+a failing object cache — and in that case the write-on-read is the least of the
+problems.
 
-On the live dev site this is close to dormant: all 9 popups have `data_version`,
-`enabled`, and the open counts; 2 lack `popup_conversion_count_total`. All 6
-themes have `popup_theme_data_version`. So the backfills fire at most twice ever
-here and then stop.
+No change recommended, and none made. Documented so the pattern is not
+re-discovered and mistaken for a leak later.
 
-It bites when popups arrive **without** going through the normal save path:
+## One genuine (small) observation retained
 
-- imports / migrations / staging syncs
-- programmatic `wp_insert_post()` (our own tests hit exactly this)
-- `wp post create` via WP-CLI
-- duplication plugins that copy a subset of meta
-
-It is also permanently live for #2 in one specific way: `is_enabled()` is reached
-from `is_loadable()`, which `preload_popups()` calls for **every popup on every
-frontend request**. A site that never heals (e.g. an object-cache-only host where
-writes fail, or a read-replica setup) pays this on every page view.
-
-## Second-order issue: repeat cost after healing
-
-Even once meta exists, `get_event_count()` ×25 on a second pass in the same
-request costs **25 queries**, not 0 — because the first pass's writes evicted
-each popup's meta cache. The model has no request-local memo for count values,
-so it re-reads through `get_post_meta()` each time.
-
-## Suggested fixes (not implemented — out of scope for PR #1407)
-
-1. **Don't write during a read.** Return the default in-memory and let the value
-   be persisted by a save path, or defer backfills to a single batched
-   `shutdown` write. This removes the cache poisoning entirely.
-2. If the write must stay, **batch it**: collect the popups needing backfill
-   during the pass and issue one `update_meta_cache()` re-prime afterwards
-   instead of letting each write invalidate individually.
-3. **Memoize count reads** on the model so repeat `get_event_count()` calls in
-   one request cost nothing.
-4. Consider a one-time upgrade routine that backfills `data_version`, `enabled`,
-   and the four count keys for all popups, so the read paths never need to.
-
-Worth its own issue. None of this is touched by the canonical-cache PR, which
-only changed *where models are cached*, not *what getters write*.
+`get_event_count()` has no request-local memo, so repeated calls within a single
+request re-read through `get_post_meta()`. With a warm object cache that is cache
+hits rather than SQL, so the cost is negligible. `Admin/Popups.php` calls it up
+to 6× per row; memoizing would save object-cache lookups, not queries. Cosmetic,
+not worth a change on its own.

--- a/.perf/QUERY-AUDIT.md
+++ b/.perf/QUERY-AUDIT.md
@@ -1,0 +1,96 @@
+# Query audit: write-on-read in popup/theme models
+
+Follow-up from the `data_version` finding. Measured on this branch with the WP
+PHPUnit suite; every figure below was re-run **in isolation** because running
+probes together pollutes counts via plugin bootstrap and `wp_cache_flush()`.
+
+## The pattern
+
+Five getters write to postmeta during a **read**:
+
+| # | Site | Meta written | Called from |
+|---|------|--------------|-------------|
+| 1 | `PUM_Model_Popup::setup()` L1442 | `data_version` | every model construction |
+| 2 | `PUM_Model_Popup::is_enabled()` L1125 | `enabled` | **frontend every page load**, admin list |
+| 3 | `PUM_Model_Popup::get_event_count()` L1256 | `popup_{event}_count` | admin list table |
+| 4 | `PUM_Model_Popup::get_event_count()` L1266 | `popup_{event}_count_total` | admin list table |
+| 5 | `PUM_Model_Theme::setup()` L559 | `popup_theme_data_version` | every theme construction |
+
+Each is a self-healing backfill and is *correct* — it writes once, then the meta
+exists. The cost is not the write itself.
+
+**The real cost is cache poisoning.** `update_post_meta()` invalidates that
+post's entry in the `post_meta` object cache. `WP_Query` had just primed meta for
+*all* popups in one bulk query. One backfill write per popup destroys that prime
+row by row, so the next read re-fetches meta **one popup at a time**.
+
+That is why a 3-query pass became 30 (n=10) or 150 (n=50) in the original
+benchmark: 3 legitimate queries, then SELECT+UPDATE per popup, then a per-popup
+meta re-prime.
+
+## Measured, isolated
+
+Popups **with** backfill meta (steady state — what a normal site looks like):
+
+| pass | n | queries |
+|------|---|---------|
+| `pum_get_all_popups()` | 25 | **4** |
+| `get_title()` + `is_enabled()` + `get_setting()` ×25 | 25 | **0** |
+| `pum_get_all_popups()` repeat, same args | 10 | **0** |
+| `pum_get_all_themes()` | 6 | **4** |
+| per-theme `get_setting()` ×6 | 6 | **0** |
+
+Healthy. Bulk prime works, request-local caches work.
+
+Popups **without** backfill meta (fresh import, programmatic insert, migration):
+
+| pass | n | queries |
+|------|---|---------|
+| hydrate via `pum_get_all_popups()` | 25 | **54** |
+| admin list-table row render ×25 (what `Admin/Popups.php` actually calls) | 25 | **375** |
+| second pass over the same rows | 25 | **25** |
+| **frontend** `is_enabled()` ×25 | 25 | **75** |
+
+375 queries to paint one admin list page. 75 queries on a **public page load**.
+
+## Severity
+
+On the live dev site this is close to dormant: all 9 popups have `data_version`,
+`enabled`, and the open counts; 2 lack `popup_conversion_count_total`. All 6
+themes have `popup_theme_data_version`. So the backfills fire at most twice ever
+here and then stop.
+
+It bites when popups arrive **without** going through the normal save path:
+
+- imports / migrations / staging syncs
+- programmatic `wp_insert_post()` (our own tests hit exactly this)
+- `wp post create` via WP-CLI
+- duplication plugins that copy a subset of meta
+
+It is also permanently live for #2 in one specific way: `is_enabled()` is reached
+from `is_loadable()`, which `preload_popups()` calls for **every popup on every
+frontend request**. A site that never heals (e.g. an object-cache-only host where
+writes fail, or a read-replica setup) pays this on every page view.
+
+## Second-order issue: repeat cost after healing
+
+Even once meta exists, `get_event_count()` ×25 on a second pass in the same
+request costs **25 queries**, not 0 — because the first pass's writes evicted
+each popup's meta cache. The model has no request-local memo for count values,
+so it re-reads through `get_post_meta()` each time.
+
+## Suggested fixes (not implemented — out of scope for PR #1407)
+
+1. **Don't write during a read.** Return the default in-memory and let the value
+   be persisted by a save path, or defer backfills to a single batched
+   `shutdown` write. This removes the cache poisoning entirely.
+2. If the write must stay, **batch it**: collect the popups needing backfill
+   during the pass and issue one `update_meta_cache()` re-prime afterwards
+   instead of letting each write invalidate individually.
+3. **Memoize count reads** on the model so repeat `get_event_count()` calls in
+   one request cost nothing.
+4. Consider a one-time upgrade routine that backfills `data_version`, `enabled`,
+   and the four count keys for all popups, so the read paths never need to.
+
+Worth its own issue. None of this is touched by the canonical-cache PR, which
+only changed *where models are cached*, not *what getters write*.

--- a/.perf/RESULTS.md
+++ b/.perf/RESULTS.md
@@ -1,7 +1,8 @@
 # Canonical popup model cache — before/after
 
-Baseline: develop `21e59a1d`. Both columns measured with the same harness on the
-same machine and the same database.
+Baseline: develop `21e59a1d`, measured in a **separate clean worktree** with its
+own `composer install` (symlinking `vendor/` between worktrees makes PHPUnit
+silently load the other checkout's code). "After" measured on this branch.
 
 Reproduce:
 
@@ -11,79 +12,77 @@ PUM_BENCH_POPUPS=<n> vendor/bin/phpunit -c tests/php/phpunit.xml \
   --filter Popup_Model_Cache_Bench
 ```
 
-Query counts, hydration counts and distinct-object counts are **deterministic**
-— repeated runs give identical values. `elapsed_ms` and `mem_delta_kb` are
-single samples and are **noisy**; they are directional support, not a claim.
+Query counts, hydration counts and distinct-object counts are **deterministic**.
+`elapsed_ms` and `mem_delta_kb` are single samples and are **noisy**.
 
-## Model hydrations (object constructions)
+## Fixture correctness (this invalidated an earlier draft of this file)
+
+Popups must be seeded with `data_version` meta. Real popups always carry it. A
+popup without it makes `PUM_Model_Popup::setup()` run
+`update_meta( 'data_version', … )` during a *read* request — a SELECT + UPDATE
+per popup — and those writes invalidate the per-post meta cache that `WP_Query`
+had just primed in bulk, forcing a second, per-popup meta fetch on readback.
+
+With an unseeded fixture the same pass measured 30 queries at n=10 and 150 at
+n=50. That was an artifact of the fixture, not plugin behavior. Seeded, the
+numbers below are flat. The `data_version` write path is worth a look as its own
+issue, but it is **not** what this PR is about and is not counted as a win here.
+
+## SQL queries — unchanged, and correctly so
+
+| scenario | n | before | after |
+|----------|---|--------|-------|
+| D query + readback | 1 | 2 | 2 |
+| D query + readback | 10 | 3 | 3 |
+| D query + readback | 50 | 3 | 3 |
+
+Three queries regardless of popup count: one posts query, one term query, one
+bulk postmeta prime for all IDs. **Readback issues zero queries** at every size.
+The plugin already hydrates by querying all popups once and priming meta in
+bulk; this PR does not change that and does not need to.
+
+## Model hydrations (object constructions) — the actual win
 
 | scenario | n | before | after | change |
 |----------|---|--------|-------|--------|
 | C cross-API, one popup | any | 2 | **1** | −50% |
-| D query + readback | 1 | 2 | **1** | −50% |
 | D query + readback | 10 | 20 | **10** | −50% |
 | D query + readback | 50 | 100 | **50** | −50% |
-| A cold single | any | 1 | 1 | — |
-| B warm ×10 | any | 0 | 0 | — |
 
-Exactly one model per popup per request, at every scale.
+Before, the repository `query()` hydrated a model for every popup, and the
+readback through `pum_get_popup()` hydrated a *second* one because it consulted
+a different cache. Now there is exactly one model per popup per request.
 
 ## Object identity
 
 | scenario | before | after |
 |----------|--------|-------|
 | C: `pum_get_popup()` vs modern repo vs `pum()->popups` | **2 distinct** | **1 shared** |
-| D: distinct objects on readback | 10 of 10 | 10 of 10 (all canonical) |
 
 Before, a mutation applied through one API was invisible through another, and a
-reference held across a settings write kept reporting the pre-write value. Both
-are fixed.
+reference held across a settings write kept reporting the pre-write value.
 
-## SQL queries
+## Memory (noisy, single sample)
 
-| scenario | n | before | after |
-|----------|---|--------|-------|
-| D query + readback | 0 | 2 | 2 |
-| D query + readback | 1 | 2 | 2 |
-| D query + readback | 10 | 30 | 30 |
-| D query + readback | 50 | 150 | 150 |
+| n | before | after |
+|---|--------|-------|
+| 10 | 90.8 KB | 58.8 KB |
+| 50 | 456.1 KB | 292.4 KB |
 
-**Unchanged, deliberately.** The remaining per-popup queries come from
-`WP_Query` and WordPress metadata priming, not from model hydration. This change
-removes duplicate *object construction*, not duplicate SQL. Reducing the query
-count is a separate piece of work and is not claimed here.
-
-## Memory and time (noisy, single sample)
-
-| n | metric | before | after |
-|---|--------|--------|-------|
-| 10 | mem_delta_kb | 83.0 | 51.0 |
-| 50 | mem_delta_kb | 409.8 | 246.0 |
-| 10 | elapsed_ms | 1.94 | 2.42 |
-| 50 | elapsed_ms | 7.65 | 7.74 |
-
-Memory drops roughly 40% at 50 popups, consistent with halving live model count.
-Elapsed time is flat to marginally worse within sample noise — the freshness
-check on the canonical read costs a `get_post()` lookup (object-cache backed, not
-SQL). At these magnitudes the timing signal is not meaningful; the durable wins
-are hydration count, memory, and identity.
+Roughly −36%, consistent with halving live model count.
 
 ## Staleness
 
-Scenario E (`stale_after_meta_write`) reports `is_fresh: yes` before and after at
-every popup count. Additionally, with shared identity the *previously held*
-reference now also reports the fresh value, where before it kept the stale one.
+Scenario E reports `is_fresh: yes` before and after at every count. With shared
+identity the previously held reference now also reports the fresh value.
 
-## Correctness coverage
+## Honest summary
 
-`Canonical_Popup_Cache_Test` (11 tests) covers:
+This change buys **object-graph efficiency and correctness**, not fewer queries:
 
-- shared identity across all four public fetch APIs
-- mutation propagation between APIs
-- no stale read after a direct meta write, including via a held reference
-- post update and hard delete clear the cached model
-- multisite partitioning of canonical models
-- legacy getter: object returned for unknown IDs, current-popup fallback
-- `query()` reuses models callers already hold
-- frontend preload leaves one shared model per popup
-- extension repository subclasses keep their own model class
+- half the model constructions per request
+- one shared model per popup instead of two divergent ones
+- ~36% less incremental memory on the popup pass
+- a fixed stale-read through a held reference
+
+Query count was already optimal and is untouched.

--- a/.perf/RESULTS.md
+++ b/.perf/RESULTS.md
@@ -9,7 +9,7 @@ Reproduce:
 ```bash
 export WP_TESTS_DIR="$TMPDIR/wordpress-tests-lib"
 PUM_BENCH_POPUPS=<n> vendor/bin/phpunit -c tests/php/phpunit.xml \
-  --filter Popup_Model_Cache_Bench
+  --testsuite bench
 ```
 
 Query counts, hydration counts and distinct-object counts are **deterministic**.
@@ -66,10 +66,10 @@ reference held across a settings write kept reporting the pre-write value.
 
 | n | before | after |
 |---|--------|-------|
-| 10 | 90.8 KB | 58.8 KB |
-| 50 | 456.1 KB | 292.4 KB |
+| 10 | 90.8 KB | 60.0 KB |
+| 50 | 456.1 KB | 299.2 KB |
 
-Roughly −36%, consistent with halving live model count.
+Roughly −34%, consistent with halving live model count.
 
 ## Staleness
 

--- a/.perf/RESULTS.md
+++ b/.perf/RESULTS.md
@@ -1,0 +1,89 @@
+# Canonical popup model cache — before/after
+
+Baseline: develop `21e59a1d`. Both columns measured with the same harness on the
+same machine and the same database.
+
+Reproduce:
+
+```bash
+export WP_TESTS_DIR="$TMPDIR/wordpress-tests-lib"
+PUM_BENCH_POPUPS=<n> vendor/bin/phpunit -c tests/php/phpunit.xml \
+  --filter Popup_Model_Cache_Bench
+```
+
+Query counts, hydration counts and distinct-object counts are **deterministic**
+— repeated runs give identical values. `elapsed_ms` and `mem_delta_kb` are
+single samples and are **noisy**; they are directional support, not a claim.
+
+## Model hydrations (object constructions)
+
+| scenario | n | before | after | change |
+|----------|---|--------|-------|--------|
+| C cross-API, one popup | any | 2 | **1** | −50% |
+| D query + readback | 1 | 2 | **1** | −50% |
+| D query + readback | 10 | 20 | **10** | −50% |
+| D query + readback | 50 | 100 | **50** | −50% |
+| A cold single | any | 1 | 1 | — |
+| B warm ×10 | any | 0 | 0 | — |
+
+Exactly one model per popup per request, at every scale.
+
+## Object identity
+
+| scenario | before | after |
+|----------|--------|-------|
+| C: `pum_get_popup()` vs modern repo vs `pum()->popups` | **2 distinct** | **1 shared** |
+| D: distinct objects on readback | 10 of 10 | 10 of 10 (all canonical) |
+
+Before, a mutation applied through one API was invisible through another, and a
+reference held across a settings write kept reporting the pre-write value. Both
+are fixed.
+
+## SQL queries
+
+| scenario | n | before | after |
+|----------|---|--------|-------|
+| D query + readback | 0 | 2 | 2 |
+| D query + readback | 1 | 2 | 2 |
+| D query + readback | 10 | 30 | 30 |
+| D query + readback | 50 | 150 | 150 |
+
+**Unchanged, deliberately.** The remaining per-popup queries come from
+`WP_Query` and WordPress metadata priming, not from model hydration. This change
+removes duplicate *object construction*, not duplicate SQL. Reducing the query
+count is a separate piece of work and is not claimed here.
+
+## Memory and time (noisy, single sample)
+
+| n | metric | before | after |
+|---|--------|--------|-------|
+| 10 | mem_delta_kb | 83.0 | 51.0 |
+| 50 | mem_delta_kb | 409.8 | 246.0 |
+| 10 | elapsed_ms | 1.94 | 2.42 |
+| 50 | elapsed_ms | 7.65 | 7.74 |
+
+Memory drops roughly 40% at 50 popups, consistent with halving live model count.
+Elapsed time is flat to marginally worse within sample noise — the freshness
+check on the canonical read costs a `get_post()` lookup (object-cache backed, not
+SQL). At these magnitudes the timing signal is not meaningful; the durable wins
+are hydration count, memory, and identity.
+
+## Staleness
+
+Scenario E (`stale_after_meta_write`) reports `is_fresh: yes` before and after at
+every popup count. Additionally, with shared identity the *previously held*
+reference now also reports the fresh value, where before it kept the stale one.
+
+## Correctness coverage
+
+`Canonical_Popup_Cache_Test` (11 tests) covers:
+
+- shared identity across all four public fetch APIs
+- mutation propagation between APIs
+- no stale read after a direct meta write, including via a held reference
+- post update and hard delete clear the cached model
+- multisite partitioning of canonical models
+- legacy getter: object returned for unknown IDs, current-popup fallback
+- `query()` reuses models callers already hold
+- frontend preload leaves one shared model per popup
+- extension repository subclasses keep their own model class

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Unreleased
 
+**Improvements**
+
+-   Improved popup loading efficiency by building each popup only once per page load instead of twice, reducing memory use on sites with many popups.
+-   Fixed popup settings changes not being reflected everywhere on the same page load, which could cause a popup to use outdated settings.
+
 ## v1.25.0 - 2026-09-10
 
 **Security**

--- a/classes/Abstract/Model/Post.php
+++ b/classes/Abstract/Model/Post.php
@@ -318,6 +318,28 @@ abstract class PUM_Abstract_Model_Post {
 	}
 
 	/**
+	 * Hash one metadata entry's state in the WordPress object cache.
+	 *
+	 * Models that cache resolved settings use this to detect when WordPress
+	 * repopulated or evicted the underlying metadata cache, so cached settings
+	 * are re-resolved instead of served stale. Shared by the popup and theme
+	 * models, which differ only in the meta key they watch.
+	 *
+	 * @param array<string,mixed>|false $meta_cache Current metadata cache entry.
+	 * @param string                    $meta_key   Metadata key to hash.
+	 *
+	 * @return string
+	 */
+	protected function hash_meta_cache_entry( $meta_cache, $meta_key ) {
+		$cache_data = [
+			'loaded'   => is_array( $meta_cache ),
+			'settings' => is_array( $meta_cache ) && isset( $meta_cache[ $meta_key ] ) ? $meta_cache[ $meta_key ] : null,
+		];
+
+		return hash( 'sha256', maybe_serialize( $cache_data ) );
+	}
+
+	/**
 	 * @param      $key
 	 * @param bool $single
 	 *

--- a/classes/Base/Service/Repository.php
+++ b/classes/Base/Service/Repository.php
@@ -75,6 +75,21 @@ abstract class Repository extends Service {
 	abstract public function instantiate_model_from_post( $post );
 
 	/**
+	 * Resolve the model to use for a queried post.
+	 *
+	 * Defaults to fresh instantiation. Repositories that maintain a canonical
+	 * request-local model override this so a query reuses the instance callers
+	 * already hold instead of replacing it.
+	 *
+	 * @param \WP_Post $post Post object.
+	 *
+	 * @return TPost|null
+	 */
+	protected function resolve_model_from_post( $post ) {
+		return $this->instantiate_model_from_post( $post );
+	}
+
+	/**
 	 * Cache an item in internal storage.
 	 *
 	 * @param TPost $item Item to cache by ID for fast retrieval.
@@ -103,7 +118,7 @@ abstract class Repository extends Service {
 		$items = [];
 
 		foreach ( $this->query_posts( $args ) as $post ) {
-			$item = $this->instantiate_model_from_post( $post );
+			$item = $this->resolve_model_from_post( $post );
 
 			if ( ! $item ) {
 				continue;

--- a/classes/Base/Service/Repository.php
+++ b/classes/Base/Service/Repository.php
@@ -201,12 +201,13 @@ abstract class Repository extends Service {
 	 */
 	public function get_by_id( $item_id = 0 ) {
 		// Convert to integer for consistent handling.
-		$item_id   = (int) $item_id;
-		$cache_key = $this->get_item_cache_key( $item_id );
+		$item_id = (int) $item_id;
 
-		// If item is cached, get the object.
-		if ( isset( $this->items_by_id[ $cache_key ] ) ) {
-			return $this->items_by_id[ $cache_key ];
+		// Return a validated cache hit when one exists.
+		$cached = $this->get_cached_item( $item_id );
+
+		if ( null !== $cached ) {
+			return $cached;
 		}
 
 		// Query for a post by ID.
@@ -225,6 +226,69 @@ abstract class Repository extends Service {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Get an already-cached model without falling back to a query.
+	 *
+	 * Answers "has this item been hydrated during this request?" rather than
+	 * "fetch it". A cached model that fails {@see self::cached_item_is_fresh()}
+	 * is evicted and reported as a miss, so no caller can be served stale data
+	 * regardless of which request context invalidation hooks were registered in.
+	 *
+	 * @param int|numeric-string $item_id Item ID.
+	 *
+	 * @return TPost|null Cached model, or null when not cached or stale.
+	 */
+	public function get_cached_item( $item_id ) {
+		$item_id = (int) $item_id;
+
+		if ( $item_id <= 0 ) {
+			return null;
+		}
+
+		$cache_key = $this->get_item_cache_key( $item_id );
+
+		if ( ! isset( $this->items_by_id[ $cache_key ] ) ) {
+			return null;
+		}
+
+		$cached = $this->items_by_id[ $cache_key ];
+
+		if ( $this->cached_item_is_fresh( $cached, $item_id ) ) {
+			return $cached;
+		}
+
+		$this->forget_item( $item_id );
+
+		return null;
+	}
+
+	/**
+	 * Determine whether a cached model still matches its stored post.
+	 *
+	 * The base implementation trusts the cache. Repositories that must survive
+	 * direct writes, or requests where invalidation hooks are not registered,
+	 * override this to compare against the current post.
+	 *
+	 * @param TPost              $item    Cached model.
+	 * @param int|numeric-string $item_id Item ID.
+	 *
+	 * @return bool
+	 */
+	protected function cached_item_is_fresh( $item, $item_id ) {
+		return true;
+	}
+
+	/**
+	 * Discard a cached model.
+	 *
+	 * @param int|numeric-string $item_id Item ID.
+	 *
+	 * @return void
+	 */
+	public function forget_item( $item_id ) {
+		unset( $this->items_by_id[ $this->get_item_cache_key( $item_id ) ] );
 	}
 
 	/**
@@ -259,7 +323,10 @@ abstract class Repository extends Service {
 		if ( $query->have_posts() ) {
 			$post = $query->posts[0];
 			if ( $post instanceof \WP_Post ) {
-				$item = $this->instantiate_model_from_post( $post );
+				// Resolve through the same path as query() so a lookup by slug or
+				// meta reuses the model callers already hold instead of replacing
+				// it with a second instance.
+				$item = $this->resolve_model_from_post( $post );
 				if ( $item ) {
 					$this->cache_item( $item );
 				}

--- a/classes/Controllers/Frontend/Popups.php
+++ b/classes/Controllers/Frontend/Popups.php
@@ -30,13 +30,6 @@ class Popups extends Controller {
 	private $popups;
 
 	/**
-	 * All popup models queried for this request.
-	 *
-	 * @var array<string,Popup>
-	 */
-	private $queried_popups = [];
-
-	/**
 	 * Enqueued popup ids.
 	 *
 	 * @var int[]
@@ -119,15 +112,14 @@ class Popups extends Controller {
 		] );
 
 		foreach ( $popups as $popup ) {
-			$queried_popup = $this->get_queried_popup( $popup->ID );
+			// query() already cached each model canonically; re-resolve through
+			// the canonical boundary so a stale entry is refreshed once here
+			// rather than rediscovered by every later caller.
+			$canonical = $popup_repository->get_canonical_item( $popup->ID );
 
-			if ( pum_is_popup( $queried_popup ) ) {
-				$popup = $queried_popup;
-			} else {
-				$this->cache_queried_popup( $popup );
+			if ( pum_is_popup( $canonical ) ) {
+				$popup = $canonical;
 			}
-
-			$popup_repository->replace_cached_item( $popup );
 
 			set_current_popup( $popup );
 
@@ -142,31 +134,26 @@ class Popups extends Controller {
 	/**
 	 * Get a popup model already queried during frontend preloading.
 	 *
+	 * Retained as the frontend-facing name for the canonical fetch boundary.
+	 * The popup repository owns the storage and the freshness check, so this
+	 * returns the same object any other caller would receive this request.
+	 *
 	 * @param int $popup_id Popup ID.
 	 *
 	 * @return Popup|null
 	 */
 	public function get_queried_popup( $popup_id ) {
-		$cache_key = $this->popup_cache_key( $popup_id );
-		$popup     = isset( $this->queried_popups[ $cache_key ] ) ? $this->queried_popups[ $cache_key ] : null;
-
-		if ( ! pum_is_popup( $popup ) ) {
+		if ( ! is_numeric( $popup_id ) ) {
 			return null;
 		}
 
-		$current_post = get_post( $popup_id );
+		$popup = $this->container->get( 'popups' )->get_cached_item( $popup_id );
 
-		if ( ! $current_post instanceof \WP_Post || 'popup' !== $current_post->post_type || get_object_vars( $current_post ) !== get_object_vars( $popup->post ) ) {
-			$this->invalidate_queried_popup( $popup_id );
-
-			return null;
-		}
-
-		return $popup;
+		return pum_is_popup( $popup ) ? $popup : null;
 	}
 
 	/**
-	 * Cache a popup model as the canonical frontend instance for this request.
+	 * Cache a popup model as the canonical instance for this request.
 	 *
 	 * @param Popup $popup Popup model.
 	 *
@@ -174,7 +161,7 @@ class Popups extends Controller {
 	 */
 	public function cache_queried_popup( $popup ) {
 		if ( pum_is_popup( $popup ) ) {
-			$this->queried_popups[ $this->popup_cache_key( $popup->ID ) ] = $popup;
+			$this->container->get( 'popups' )->replace_cached_item( $popup );
 		}
 	}
 
@@ -191,7 +178,6 @@ class Popups extends Controller {
 			return;
 		}
 
-		unset( $this->queried_popups[ $this->popup_cache_key( $post_id ) ] );
 		$this->container->get( 'popups' )->forget_item( $post_id );
 		pum()->popups->forget_item( $post_id );
 	}
@@ -210,29 +196,11 @@ class Popups extends Controller {
 			return;
 		}
 
-		$popup = $this->get_queried_popup( $object_id );
+		// Clear the legacy query caches without disturbing the canonical model,
+		// then let the repository refresh it in place or evict it.
+		pum()->popups->forget_local_item( $object_id );
 
-		$popup_repository = $this->container->get( 'popups' );
-
-		pum()->popups->forget_item( $object_id );
-
-		if ( pum_is_popup( $popup ) ) {
-			$popup->settings = null;
-			$popup_repository->replace_cached_item( $popup );
-		} else {
-			$popup_repository->forget_item( $object_id );
-		}
-	}
-
-	/**
-	 * Get the site-specific cache key for a popup.
-	 *
-	 * @param int $popup_id Popup ID.
-	 *
-	 * @return string
-	 */
-	private function popup_cache_key( $popup_id ) {
-		return get_current_blog_id() . ':' . (int) $popup_id;
+		$this->container->get( 'popups' )->refresh_item_settings( $object_id );
 	}
 
 	/**

--- a/classes/Model/Popup.php
+++ b/classes/Model/Popup.php
@@ -130,12 +130,7 @@ class PUM_Model_Popup extends PUM_Abstract_Model_Post {
 			$meta_cache = wp_cache_get( $this->ID, 'post_meta' );
 		}
 
-		$cache_data = [
-			'loaded'   => is_array( $meta_cache ),
-			'settings' => is_array( $meta_cache ) && isset( $meta_cache['popup_settings'] ) ? $meta_cache['popup_settings'] : null,
-		];
-
-		return hash( 'sha256', maybe_serialize( $cache_data ) );
+		return $this->hash_meta_cache_entry( $meta_cache, 'popup_settings' );
 	}
 
 	/**

--- a/classes/Model/Theme.php
+++ b/classes/Model/Theme.php
@@ -43,12 +43,7 @@ class PUM_Model_Theme extends PUM_Abstract_Model_Post {
 	 * @return string
 	 */
 	private function get_settings_meta_cache_hash( $meta_cache ) {
-		$cache_data = [
-			'loaded'   => is_array( $meta_cache ),
-			'settings' => is_array( $meta_cache ) && isset( $meta_cache['popup_theme_settings'] ) ? $meta_cache['popup_theme_settings'] : null,
-		];
-
-		return hash( 'sha256', maybe_serialize( $cache_data ) );
+		return $this->hash_meta_cache_entry( $meta_cache, 'popup_theme_settings' );
 	}
 
 	/**

--- a/classes/Repository/Popups.php
+++ b/classes/Repository/Popups.php
@@ -121,6 +121,20 @@ class PUM_Repository_Popups extends PUM_Abstract_Repository_Posts {
 	}
 
 	/**
+	 * Whether this repository builds the core popup model.
+	 *
+	 * Extensions may subclass this repository with a custom `$model`. Callers
+	 * use this to decide whether the canonical repository (which only produces
+	 * `PUM_Model_Popup`) can satisfy a lookup, or whether the legacy hydration
+	 * path must be used to preserve the extension's model class.
+	 *
+	 * @return bool
+	 */
+	public function uses_core_model() {
+		return 'PUM_Model_Popup' === $this->model;
+	}
+
+	/**
 	 * Resolve a popup model through the canonical repository.
 	 *
 	 * This legacy repository no longer owns popup model storage. It delegates to
@@ -136,13 +150,7 @@ class PUM_Repository_Popups extends PUM_Abstract_Repository_Posts {
 	 * @return WP_Post|PUM_Abstract_Model_Post
 	 */
 	protected function get_model( $id ) {
-		if ( 'PUM_Model_Popup' !== $this->model ) {
-			return parent::get_model( $id );
-		}
-
-		$post_id = is_a( $id, 'WP_Post' ) ? $id->ID : $id;
-
-		if ( ! is_numeric( $post_id ) ) {
+		if ( ! $this->uses_core_model() ) {
 			return parent::get_model( $id );
 		}
 
@@ -152,7 +160,12 @@ class PUM_Repository_Popups extends PUM_Abstract_Repository_Posts {
 			return parent::get_model( $id );
 		}
 
-		$popup = $canonical->get_canonical_item( $post_id );
+		// Preserve a supplied post object so values injected by posts_results /
+		// the_posts filters survive; reducing it to an ID would reload the
+		// unfiltered row.
+		$popup = $id instanceof WP_Post
+			? $canonical->get_canonical_item_for_post( $id )
+			: ( is_numeric( $id ) ? $canonical->get_canonical_item( $id ) : null );
 
 		return $popup instanceof PUM_Model_Popup ? $popup : parent::get_model( $id );
 	}

--- a/classes/Repository/Popups.php
+++ b/classes/Repository/Popups.php
@@ -121,13 +121,89 @@ class PUM_Repository_Popups extends PUM_Abstract_Repository_Posts {
 	}
 
 	/**
+	 * Resolve a popup model through the canonical repository.
+	 *
+	 * This legacy repository no longer owns popup model storage. It delegates to
+	 * `PopupMaker\Services\Repository\Popups`, the single request-local cache
+	 * shared by frontend, admin, AJAX and modern services, so `pum()->popups`
+	 * hands back the same object as every other API.
+	 *
+	 * Subclasses that override the model class keep the legacy hydration path,
+	 * since the canonical repository only produces `PUM_Model_Popup` instances.
+	 *
+	 * @param int|WP_Post $id Post ID or object.
+	 *
+	 * @return WP_Post|PUM_Abstract_Model_Post
+	 */
+	protected function get_model( $id ) {
+		if ( 'PUM_Model_Popup' !== $this->model ) {
+			return parent::get_model( $id );
+		}
+
+		$post_id = is_a( $id, 'WP_Post' ) ? $id->ID : $id;
+
+		if ( ! is_numeric( $post_id ) ) {
+			return parent::get_model( $id );
+		}
+
+		$canonical = $this->canonical_repository();
+
+		if ( ! $canonical ) {
+			return parent::get_model( $id );
+		}
+
+		$popup = $canonical->get_canonical_item( $post_id );
+
+		return $popup instanceof PUM_Model_Popup ? $popup : parent::get_model( $id );
+	}
+
+	/**
+	 * Get the canonical popup repository when the container is available.
+	 *
+	 * @return \PopupMaker\Services\Repository\Popups|null
+	 */
+	private function canonical_repository() {
+		if ( ! function_exists( '\PopupMaker\plugin' ) ) {
+			return null;
+		}
+
+		$repository = \PopupMaker\plugin()->get( 'popups' );
+
+		return $repository instanceof \PopupMaker\Services\Repository\Popups ? $repository : null;
+	}
+
+	/**
 	 * Discard a cached popup model.
+	 *
+	 * Clears the legacy query/object caches and the canonical model cache so a
+	 * single call still fully invalidates the popup for this request.
 	 *
 	 * @param int|numeric-string $item_id Popup ID.
 	 *
 	 * @return void
 	 */
 	public function forget_item( $item_id ) {
+		$this->forget_local_item( $item_id );
+
+		$canonical = $this->canonical_repository();
+
+		if ( $canonical ) {
+			$canonical->forget_item( $item_id );
+		}
+	}
+
+	/**
+	 * Discard only this repository's local caches for a popup.
+	 *
+	 * Used when the canonical model must survive — for example a metadata write
+	 * that refreshes settings in place — while stale legacy query results still
+	 * need clearing.
+	 *
+	 * @param int|numeric-string $item_id Popup ID.
+	 *
+	 * @return void
+	 */
+	public function forget_local_item( $item_id ) {
 		unset( $this->cache['objects'][ (int) $item_id ] );
 	}
 

--- a/classes/Services/Repository/Popups.php
+++ b/classes/Services/Repository/Popups.php
@@ -153,6 +153,21 @@ class Popups extends Repository {
 		$cached = $this->get_cached_item( $post->ID );
 
 		if ( $cached instanceof Popup ) {
+			/**
+			 * Absorb the supplied post into the model already in play.
+			 *
+			 * Without this, whether a caller sees filtered values would depend on
+			 * lookup order: anything that touched the popup by ID earlier in the
+			 * request (frontend preloading does exactly that) would leave an
+			 * unfiltered model cached, and a later filtered query would silently
+			 * return database values. Refreshing in place keeps object identity —
+			 * the promise this repository exists to make — while adopting the
+			 * filtered post.
+			 */
+			if ( $this->post_differs( $cached, $post ) ) {
+				$cached->setup( $post );
+			}
+
 			return $cached;
 		}
 
@@ -163,6 +178,22 @@ class Popups extends Repository {
 		}
 
 		return $item;
+	}
+
+	/**
+	 * Whether a supplied post carries different values than a cached model.
+	 *
+	 * @param Popup    $cached Cached model.
+	 * @param \WP_Post $post   Supplied post.
+	 *
+	 * @return bool
+	 */
+	protected function post_differs( $cached, $post ) {
+		if ( ! isset( $cached->post ) || ! $cached->post instanceof \WP_Post ) {
+			return true;
+		}
+
+		return get_object_vars( $cached->post ) !== get_object_vars( $post );
 	}
 
 	/**

--- a/classes/Services/Repository/Popups.php
+++ b/classes/Services/Repository/Popups.php
@@ -32,6 +32,14 @@ class Popups extends Repository {
 	protected $post_type_key = 'popup';
 
 	/**
+	 * Fingerprints of the stored posts backing cached models, keyed like the
+	 * model cache.
+	 *
+	 * @var array<int|string,string>
+	 */
+	protected $stored_post_hashes = [];
+
+	/**
 	 * Partition cached popup models by site.
 	 *
 	 * @param int|numeric-string $item_id Popup ID.
@@ -77,6 +85,27 @@ class Popups extends Repository {
 	 */
 	protected function cache_item( $item ) {
 		parent::cache_item( $item );
+
+		if ( $item instanceof Popup && $item->ID ) {
+			$stored_post = get_post( (int) $item->ID );
+
+			if ( $stored_post instanceof \WP_Post ) {
+				$this->stored_post_hashes[ $this->get_item_cache_key( $item->ID ) ] = $this->hash_stored_post( $stored_post );
+			}
+		}
+	}
+
+	/**
+	 * Drop the cached model and its stored-post fingerprint.
+	 *
+	 * @param int|numeric-string $item_id Popup ID.
+	 *
+	 * @return void
+	 */
+	public function forget_item( $item_id ) {
+		unset( $this->stored_post_hashes[ $this->get_item_cache_key( $item_id ) ] );
+
+		parent::forget_item( $item_id );
 	}
 
 	/**
@@ -97,55 +126,43 @@ class Popups extends Repository {
 	 * @return Popup|null Canonical model, or null when no such popup exists.
 	 */
 	public function get_canonical_item( $item_id ) {
-		$item_id = (int) $item_id;
-
-		if ( $item_id <= 0 ) {
-			return null;
-		}
-
-		$cached = $this->get_cached_item( $item_id );
-
-		if ( null !== $cached ) {
-			return $cached;
-		}
-
+		// get_by_id() performs the validated cache lookup itself, so this is a
+		// named alias that documents intent at the call site rather than a
+		// second fetch path.
 		return $this->get_by_id( $item_id );
 	}
 
 	/**
-	 * Get an already-cached popup model without falling back to a query.
+	 * Get the canonical popup model for an already-loaded post object.
 	 *
-	 * Answers "has this popup been hydrated for this site during this request?"
-	 * rather than "fetch it", so callers that only want a previously resolved
-	 * model do not implicitly trigger hydration. A cached model whose stored
-	 * post no longer matches the current post is evicted and reported as a miss.
+	 * Used by callers that hold a `WP_Post` which may carry values injected by
+	 * `posts_results` / `the_posts` filters — multilingual plugins and similar
+	 * integrations. Reducing such a post to an ID and reloading would silently
+	 * discard those values, so when no canonical model is cached yet the model
+	 * is built from the supplied post rather than from a fresh database read.
 	 *
-	 * @param int|numeric-string $item_id Popup ID.
+	 * @param \WP_Post $post Post object, potentially filtered.
 	 *
-	 * @return Popup|null Cached model, or null when not cached for this site.
+	 * @return Popup|null
 	 */
-	public function get_cached_item( $item_id ) {
-		$item_id = (int) $item_id;
-
-		if ( $item_id <= 0 ) {
+	public function get_canonical_item_for_post( $post ) {
+		if ( ! $post instanceof \WP_Post || $post->post_type !== $this->post_type ) {
 			return null;
 		}
 
-		$cache_key = $this->get_item_cache_key( $item_id );
+		$cached = $this->get_cached_item( $post->ID );
 
-		if ( ! isset( $this->items_by_id[ $cache_key ] ) ) {
-			return null;
-		}
-
-		$cached = $this->items_by_id[ $cache_key ];
-
-		if ( $this->cached_item_is_fresh( $cached, $item_id ) ) {
+		if ( $cached instanceof Popup ) {
 			return $cached;
 		}
 
-		$this->forget_item( $item_id );
+		$item = $this->instantiate_model_from_post( $post );
 
-		return null;
+		if ( $item ) {
+			$this->cache_item( $item );
+		}
+
+		return $item;
 	}
 
 	/**
@@ -212,13 +229,48 @@ class Popups extends Repository {
 			return false;
 		}
 
-		$current_post = get_post( (int) $item_id );
+		$item_id      = (int) $item_id;
+		$current_post = get_post( $item_id );
 
+		// Deleted, or no longer a popup.
 		if ( ! $current_post instanceof \WP_Post || $current_post->post_type !== $this->post_type ) {
 			return false;
 		}
 
-		return get_object_vars( $current_post ) === get_object_vars( $item->post );
+		$recorded = isset( $this->stored_post_hashes[ $this->get_item_cache_key( $item_id ) ] )
+			? $this->stored_post_hashes[ $this->get_item_cache_key( $item_id ) ]
+			: null;
+
+		// No fingerprint recorded (model cached by a caller that bypassed
+		// cache_item()); fall back to comparing the model's own post.
+		if ( null === $recorded ) {
+			return get_object_vars( $current_post ) === get_object_vars( $item->post );
+		}
+
+		/**
+		 * Compare against the stored-post fingerprint taken when the model was
+		 * cached, not against the model's own `WP_Post`.
+		 *
+		 * A model may legitimately hold a post whose title or content was
+		 * altered by a `posts_results` / `the_posts` filter — multilingual
+		 * plugins do exactly this. Comparing the model's post directly would
+		 * treat those models as stale on every read. The fingerprint tracks what
+		 * the database actually held, so filter output is preserved while a real
+		 * write is still detected, including one inside the same second where
+		 * `post_modified_gmt` does not change.
+		 */
+		return $recorded === $this->hash_stored_post( $current_post );
+	}
+
+	/**
+	 * Fingerprint the stored post backing a cached model.
+	 *
+	 * @param \WP_Post $post Post object as stored by WordPress.
+	 *
+	 * @return string
+	 */
+	protected function hash_stored_post( $post ) {
+		return md5( (string) wp_json_encode( get_object_vars( $post ) ) );
 	}
 
 	/**
@@ -444,17 +496,6 @@ class Popups extends Repository {
 		$filtered = apply_filters( 'popup_maker/popup_title_choices', $title_choices );
 
 		return is_array( $filtered ) ? $filtered : $title_choices;
-	}
-
-	/**
-	 * Discard a cached popup model for the current site.
-	 *
-	 * @param int|numeric-string $item_id Popup ID.
-	 *
-	 * @return void
-	 */
-	public function forget_item( $item_id ) {
-		unset( $this->items_by_id[ $this->get_item_cache_key( $item_id ) ] );
 	}
 
 	/**

--- a/classes/Services/Repository/Popups.php
+++ b/classes/Services/Repository/Popups.php
@@ -80,6 +80,148 @@ class Popups extends Repository {
 	}
 
 	/**
+	 * Get the canonical popup model for this request.
+	 *
+	 * This is the single fetch/cache boundary that frontend, admin, AJAX, REST,
+	 * modern services and legacy helpers all resolve through. Callers that hold
+	 * a popup ID should prefer this over hydrating their own model, so every
+	 * consumer observes the same object for the same popup within a request.
+	 *
+	 * The cached model is validated against the current `WP_Post` before it is
+	 * returned, so a model whose underlying post changed (directly or via a
+	 * third party clearing the post cache) is discarded rather than served
+	 * stale.
+	 *
+	 * @param int|numeric-string $item_id Popup ID.
+	 *
+	 * @return Popup|null Canonical model, or null when no such popup exists.
+	 */
+	public function get_canonical_item( $item_id ) {
+		$item_id = (int) $item_id;
+
+		if ( $item_id <= 0 ) {
+			return null;
+		}
+
+		$cached = $this->get_cached_item( $item_id );
+
+		if ( null !== $cached ) {
+			return $cached;
+		}
+
+		return $this->get_by_id( $item_id );
+	}
+
+	/**
+	 * Get an already-cached popup model without falling back to a query.
+	 *
+	 * Answers "has this popup been hydrated for this site during this request?"
+	 * rather than "fetch it", so callers that only want a previously resolved
+	 * model do not implicitly trigger hydration. A cached model whose stored
+	 * post no longer matches the current post is evicted and reported as a miss.
+	 *
+	 * @param int|numeric-string $item_id Popup ID.
+	 *
+	 * @return Popup|null Cached model, or null when not cached for this site.
+	 */
+	public function get_cached_item( $item_id ) {
+		$item_id = (int) $item_id;
+
+		if ( $item_id <= 0 ) {
+			return null;
+		}
+
+		$cache_key = $this->get_item_cache_key( $item_id );
+
+		if ( ! isset( $this->items_by_id[ $cache_key ] ) ) {
+			return null;
+		}
+
+		$cached = $this->items_by_id[ $cache_key ];
+
+		if ( $this->cached_item_is_fresh( $cached, $item_id ) ) {
+			return $cached;
+		}
+
+		$this->forget_item( $item_id );
+
+		return null;
+	}
+
+	/**
+	 * Instantiate a model, reusing the canonical instance when one is cached.
+	 *
+	 * `query()` hydrates a model for every matched post. Without this, a query
+	 * would discard and replace models other callers already hold, breaking
+	 * object identity and paying for a second construction per popup.
+	 *
+	 * @param \WP_Post $post Post object.
+	 *
+	 * @return Popup|null
+	 */
+	protected function resolve_model_from_post( $post ) {
+		if ( ! $post instanceof \WP_Post ) {
+			return null;
+		}
+
+		$cached = $this->get_cached_item( $post->ID );
+
+		if ( $cached instanceof Popup ) {
+			return $cached;
+		}
+
+		return $this->instantiate_model_from_post( $post );
+	}
+
+	/**
+	 * Refresh a cached popup's settings after its metadata changed.
+	 *
+	 * Keeps object identity stable for callers that already hold the model —
+	 * the settings are cleared so the next read re-resolves them — and falls
+	 * back to eviction when the popup is not currently cached.
+	 *
+	 * @param int|numeric-string $item_id Popup ID.
+	 *
+	 * @return void
+	 */
+	public function refresh_item_settings( $item_id ) {
+		$cached = $this->get_cached_item( $item_id );
+
+		if ( $cached instanceof Popup ) {
+			$cached->settings = null;
+
+			return;
+		}
+
+		$this->forget_item( $item_id );
+	}
+
+	/**
+	 * Determine whether a cached popup still matches its stored post.
+	 *
+	 * Mirrors the frontend controller's historical freshness check so moving the
+	 * cache boundary down does not weaken staleness protection for any caller.
+	 *
+	 * @param Popup              $item    Cached popup model.
+	 * @param int|numeric-string $item_id Popup ID.
+	 *
+	 * @return bool
+	 */
+	protected function cached_item_is_fresh( $item, $item_id ) {
+		if ( ! $item instanceof Popup || ! isset( $item->post ) || ! $item->post instanceof \WP_Post ) {
+			return false;
+		}
+
+		$current_post = get_post( (int) $item_id );
+
+		if ( ! $current_post instanceof \WP_Post || $current_post->post_type !== $this->post_type ) {
+			return false;
+		}
+
+		return get_object_vars( $current_post ) === get_object_vars( $item->post );
+	}
+
+	/**
 	 * Replace the cached popup model for the current site.
 	 *
 	 * This public operation intentionally delegates to the protected cache hook

--- a/includes/functions/popups/queries.php
+++ b/includes/functions/popups/queries.php
@@ -25,6 +25,26 @@ function pum_get_popup( $popup_id = null ) {
 	/** @var int $popup_id filtered $popup_id */
 	$popup_id = pum_get_popup_id( $popup_id );
 
+	$legacy_repository = pum()->popups;
+
+	/**
+	 * When an extension has replaced the legacy repository with one that builds
+	 * a custom model class, defer to it so helper lookups keep returning that
+	 * class. Its get_model() still routes core popups through the canonical
+	 * cache, so identity is preserved for the default case.
+	 */
+	if ( $legacy_repository instanceof PUM_Repository_Popups && ! $legacy_repository->uses_core_model() ) {
+		try {
+			$popup = $legacy_repository->get_item( $popup_id );
+
+			if ( pum_is_popup( $popup ) ) {
+				return $popup;
+			}
+		} catch ( InvalidArgumentException $e ) {
+			return new PUM_Model_Popup( $popup_id );
+		}
+	}
+
 	// Resolve through the canonical fetch/cache boundary so frontend, admin and
 	// AJAX callers all share one popup model per request.
 	$popup = \PopupMaker\plugin()->get( 'popups' )->get_canonical_item( $popup_id );

--- a/includes/functions/popups/queries.php
+++ b/includes/functions/popups/queries.php
@@ -23,30 +23,19 @@ function pum_get_popup( $popup_id = null ) {
 	}
 
 	/** @var int $popup_id filtered $popup_id */
-	$popup_id         = pum_get_popup_id( $popup_id );
-	$popup_controller = null;
+	$popup_id = pum_get_popup_id( $popup_id );
 
-	if ( ! is_admin() ) {
-		$popup_controller = \PopupMaker\plugin()->get_controller( 'Frontend\\Popups' );
-		$queried_popup    = $popup_controller ? $popup_controller->get_queried_popup( $popup_id ) : null;
+	// Resolve through the canonical fetch/cache boundary so frontend, admin and
+	// AJAX callers all share one popup model per request.
+	$popup = \PopupMaker\plugin()->get( 'popups' )->get_canonical_item( $popup_id );
 
-		if ( pum_is_popup( $queried_popup ) ) {
-			return $queried_popup;
-		}
+	if ( pum_is_popup( $popup ) ) {
+		return $popup;
 	}
 
-	try {
-		$popup = pum()->popups->get_item( $popup_id );
-	} catch ( InvalidArgumentException $e ) {
-		// Return empty object
-		$popup = new PUM_Model_Popup( $popup_id );
-	}
-
-	if ( ! is_admin() && $popup_controller && pum_is_popup( $popup ) ) {
-		$popup_controller->cache_queried_popup( $popup );
-	}
-
-	return $popup;
+	// Preserve the historical contract: always hand back a popup object, even
+	// for IDs that do not resolve to a stored popup.
+	return new PUM_Model_Popup( $popup_id );
 }
 
 /**

--- a/tests/php/phpunit.xml
+++ b/tests/php/phpunit.xml
@@ -8,6 +8,13 @@
 	<testsuites>
 		<testsuite name="general">
 			<directory suffix=".php">./tests/</directory>
+			<!-- Benchmarks are opt-in: they seed posts and emit diagnostic rows to
+				 STDERR, so they do not belong in ordinary runs. Run them with the
+				 "bench" testsuite instead. -->
+			<exclude>./tests/benchmarks</exclude>
+		</testsuite>
+		<testsuite name="bench">
+			<directory suffix=".php">./tests/benchmarks</directory>
 		</testsuite>
 	</testsuites>
 	<coverage processUncoveredFiles="false">

--- a/tests/php/tests/Canonical_Popup_Cache_Test.php
+++ b/tests/php/tests/Canonical_Popup_Cache_Test.php
@@ -261,7 +261,13 @@ class Canonical_Popup_Cache_Test extends WP_UnitTestCase {
 		$repo     = \PopupMaker\plugin()->get( 'popups' );
 
 		$controller = \PopupMaker\plugin()->get_controller( 'Frontend\\Popups' );
-		remove_action( 'clean_post_cache', [ $controller, 'invalidate_queried_popup' ], PHP_INT_MIN );
+
+		// Assert the detach succeeded: if the callback were still attached it
+		// would clear the cache itself, and this test would pass without ever
+		// exercising the repository's freshness validation.
+		$this->assertTrue(
+			remove_action( 'clean_post_cache', [ $controller, 'invalidate_queried_popup' ], PHP_INT_MIN )
+		);
 
 		try {
 			$repo->get_by_id( $popup_id );
@@ -289,7 +295,13 @@ class Canonical_Popup_Cache_Test extends WP_UnitTestCase {
 		$repo     = \PopupMaker\plugin()->get( 'popups' );
 
 		$controller = \PopupMaker\plugin()->get_controller( 'Frontend\\Popups' );
-		remove_action( 'clean_post_cache', [ $controller, 'invalidate_queried_popup' ], PHP_INT_MIN );
+
+		// Assert the detach succeeded: if the callback were still attached it
+		// would clear the cache itself, and this test would pass without ever
+		// exercising the repository's freshness validation.
+		$this->assertTrue(
+			remove_action( 'clean_post_cache', [ $controller, 'invalidate_queried_popup' ], PHP_INT_MIN )
+		);
 
 		try {
 			$repo->get_by_id( $popup_id );
@@ -411,5 +423,78 @@ class Canonical_Popup_Cache_Test extends WP_UnitTestCase {
 			\PopupMaker\plugin()->get( 'popups' )->get_canonical_item( $popup_id ),
 			pum_get_popup( $popup_id )
 		);
+	}
+
+	/**
+	 * Regression: filtered values are adopted regardless of lookup order.
+	 *
+	 * Anything that touches a popup by ID earlier in the request — frontend
+	 * preloading does — used to leave an unfiltered model cached, so a later
+	 * filtered query silently returned database values.
+	 *
+	 * @return void
+	 */
+	public function test_filtered_post_adopted_after_id_lookup() {
+		$popup_id = $this->make_popup();
+		$repo     = \PopupMaker\plugin()->get( 'popups' );
+
+		// Fill the cache with an unfiltered model first.
+		$held = $repo->get_by_id( $popup_id );
+		$this->assertSame( get_post( $popup_id )->post_title, $held->post_title );
+
+		$filtered             = clone get_post( $popup_id );
+		$filtered->post_title = 'Translated title';
+
+		$model = $repo->get_canonical_item_for_post( $filtered );
+
+		// Same object (identity preserved) carrying the filtered value.
+		$this->assertSame( $held, $model );
+		$this->assertSame( 'Translated title', $model->post_title );
+		$this->assertSame( 'Translated title', $repo->get_canonical_item( $popup_id )->post_title );
+	}
+
+	/**
+	 * Regression: a filtered legacy query after a helper lookup keeps filters.
+	 *
+	 * @return void
+	 */
+	public function test_filtered_query_after_helper_lookup() {
+		$popup_id = $this->make_popup();
+
+		// Something touches the popup by ID early in the request.
+		$held = pum_get_popup( $popup_id );
+
+		$filter = static function ( $posts ) {
+			foreach ( $posts as $post ) {
+				if ( 'popup' === $post->post_type ) {
+					$post->post_title = 'Translated title';
+				}
+			}
+
+			return $posts;
+		};
+
+		add_filter( 'the_posts', $filter );
+
+		try {
+			$popups = pum_get_popups( [ 'post__in' => [ $popup_id ] ] );
+		} finally {
+			remove_filter( 'the_posts', $filter );
+		}
+
+		$matched = null;
+		foreach ( $popups as $popup ) {
+			if ( (int) $popup->ID === $popup_id ) {
+				$matched = $popup;
+				break;
+			}
+		}
+
+		$this->assertSame( $held, $matched );
+		$this->assertSame( 'Translated title', $matched->post_title );
+
+		// Refreshing in place must not discard resolved settings or provenance.
+		$this->assertIsArray( $held->get_settings() );
+		$this->assertSame( 3, (int) $held->data_version );
 	}
 }

--- a/tests/php/tests/Canonical_Popup_Cache_Test.php
+++ b/tests/php/tests/Canonical_Popup_Cache_Test.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Canonical popup model cache correctness tests.
+ *
+ * Covers the invariants the canonical fetch/cache boundary must hold: shared
+ * identity across every public API, stale-read prevention after saves, deletes
+ * and direct meta writes, multisite partitioning, legacy getter compatibility,
+ * and extension subclass support.
+ *
+ * @package PopupMaker
+ */
+
+require_once __DIR__ . '/fixtures/class-canonical-cache-subclass-popup.php';
+require_once __DIR__ . '/fixtures/class-canonical-cache-subclass-repository.php';
+
+/**
+ * Canonical popup cache tests.
+ */
+class Canonical_Popup_Cache_Test extends WP_UnitTestCase {
+
+	/**
+	 * Create a published popup with settings.
+	 *
+	 * @param array<string,mixed> $settings Popup settings.
+	 *
+	 * @return int
+	 */
+	private function make_popup( $settings = [] ) {
+		$popup_id = self::factory()->post->create(
+			[
+				'post_type'   => 'popup',
+				'post_status' => 'publish',
+			]
+		);
+
+		update_post_meta( $popup_id, 'popup_settings', $settings );
+
+		return (int) $popup_id;
+	}
+
+	/**
+	 * Every public fetch API returns one shared model per request.
+	 *
+	 * @return void
+	 */
+	public function test_all_public_apis_share_one_model() {
+		$popup_id = $this->make_popup( [ 'animation_speed' => 350 ] );
+
+		$via_helper = pum_get_popup( $popup_id );
+		$via_modern = \PopupMaker\plugin()->get( 'popups' )->get_by_id( $popup_id );
+		$via_legacy = pum()->popups->get_item( $popup_id );
+		$via_canon  = \PopupMaker\plugin()->get( 'popups' )->get_canonical_item( $popup_id );
+
+		$this->assertSame( $via_helper, $via_modern );
+		$this->assertSame( $via_helper, $via_legacy );
+		$this->assertSame( $via_helper, $via_canon );
+		$this->assertSame( 350, $via_helper->get_setting( 'animation_speed' ) );
+	}
+
+	/**
+	 * A mutation through one API is observable through the others.
+	 *
+	 * @return void
+	 */
+	public function test_shared_identity_propagates_mutations() {
+		$popup_id = $this->make_popup( [ 'animation_speed' => 100 ] );
+
+		$first                    = pum_get_popup( $popup_id );
+		$first->some_runtime_flag = 'set-by-first';
+
+		$second = pum()->popups->get_item( $popup_id );
+
+		$this->assertSame( 'set-by-first', $second->some_runtime_flag );
+	}
+
+	/**
+	 * Direct metadata writes are never served stale.
+	 *
+	 * @return void
+	 */
+	public function test_direct_meta_write_is_not_served_stale() {
+		$popup_id = $this->make_popup( [ 'animation_speed' => 100 ] );
+
+		$popup = pum_get_popup( $popup_id );
+		$this->assertSame( 100, $popup->get_setting( 'animation_speed' ) );
+
+		update_post_meta( $popup_id, 'popup_settings', [ 'animation_speed' => 900 ] );
+
+		$this->assertSame( 900, pum_get_popup( $popup_id )->get_setting( 'animation_speed' ) );
+		// The already-held reference must also observe the new value.
+		$this->assertSame( 900, $popup->get_setting( 'animation_speed' ) );
+	}
+
+	/**
+	 * Saving a popup post evicts the cached model.
+	 *
+	 * @return void
+	 */
+	public function test_post_update_evicts_cached_model() {
+		$popup_id = $this->make_popup();
+
+		$before = pum_get_popup( $popup_id );
+		$this->assertSame( 'publish', $before->post_status );
+
+		wp_update_post(
+			[
+				'ID'         => $popup_id,
+				'post_title' => 'Renamed popup',
+			]
+		);
+
+		$after = pum_get_popup( $popup_id );
+
+		$this->assertSame( 'Renamed popup', $after->post_title );
+	}
+
+	/**
+	 * Deleting a popup does not leave a resolvable cached model.
+	 *
+	 * @return void
+	 */
+	public function test_delete_clears_cached_model() {
+		$popup_id = $this->make_popup();
+
+		$this->assertTrue( pum_is_popup( pum_get_popup( $popup_id ) ) );
+
+		wp_delete_post( $popup_id, true );
+
+		$repository = \PopupMaker\plugin()->get( 'popups' );
+
+		$this->assertNull( $repository->get_canonical_item( $popup_id ) );
+		$this->assertNull( $repository->get_cached_item( $popup_id ) );
+	}
+
+	/**
+	 * Canonical models are partitioned by site.
+	 *
+	 * @return void
+	 */
+	public function test_canonical_models_are_partitioned_by_blog() {
+		$popup_id   = $this->make_popup();
+		$repository = \PopupMaker\plugin()->get( 'popups' );
+		$blog_id    = get_current_blog_id();
+
+		$original = $repository->get_canonical_item( $popup_id );
+		$this->assertInstanceOf( 'PUM_Model_Popup', $original );
+
+		try {
+			$GLOBALS['blog_id'] = $blog_id + 1;
+
+			// Nothing has been hydrated for the other site yet.
+			$this->assertNull( $repository->get_cached_item( $popup_id ) );
+		} finally {
+			$GLOBALS['blog_id'] = $blog_id;
+		}
+
+		// The original site's model is untouched.
+		$this->assertSame( $original, $repository->get_cached_item( $popup_id ) );
+	}
+
+	/**
+	 * The legacy helper still returns an object for unknown IDs.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_getter_returns_object_for_unknown_id() {
+		$popup = pum_get_popup( 987654321 );
+
+		$this->assertInstanceOf( 'PUM_Model_Popup', $popup );
+		$this->assertFalse( $popup->is_valid() );
+	}
+
+	/**
+	 * The legacy helper honours the current popup when no ID is given.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_getter_returns_current_popup() {
+		$popup_id = $this->make_popup();
+		$popup    = pum_get_popup( $popup_id );
+
+		\PopupMaker\set_current_popup( $popup );
+
+		try {
+			$this->assertSame( $popup, pum_get_popup() );
+		} finally {
+			\PopupMaker\set_current_popup( null );
+		}
+	}
+
+	/**
+	 * A repository query reuses models callers already hold.
+	 *
+	 * @return void
+	 */
+	public function test_query_reuses_canonical_models() {
+		$popup_id = $this->make_popup();
+		$held     = pum_get_popup( $popup_id );
+
+		$queried = \PopupMaker\plugin()->get( 'popups' )->query(
+			[ 'post_status' => [ 'publish', 'private' ] ]
+		);
+
+		$matched = null;
+		foreach ( $queried as $item ) {
+			if ( (int) $item->ID === $popup_id ) {
+				$matched = $item;
+				break;
+			}
+		}
+
+		$this->assertSame( $held, $matched );
+	}
+
+	/**
+	 * Frontend preload leaves one shared model per popup.
+	 *
+	 * @return void
+	 */
+	public function test_preload_leaves_shared_models() {
+		$popup_id = $this->make_popup( [ 'enabled' => true ] );
+		$held     = pum_get_popup( $popup_id );
+
+		$controller = \PopupMaker\plugin()->get_controller( 'Frontend\\Popups' );
+		$controller->preload_popups();
+
+		$this->assertSame( $held, pum_get_popup( $popup_id ) );
+		$this->assertSame( $held, $controller->get_queried_popup( $popup_id ) );
+	}
+
+	/**
+	 * Extension subclasses keep their own hydration path.
+	 *
+	 * A repository subclass that returns a custom model must not have its model
+	 * replaced by the canonical PUM_Model_Popup instance.
+	 *
+	 * @return void
+	 */
+	public function test_extension_subclass_models_are_preserved() {
+		$popup_id = $this->make_popup();
+
+		$repository = new Canonical_Cache_Subclass_Repository(
+			\PopupMaker\plugin()
+		);
+
+		$item = $repository->get_by_id( $popup_id );
+
+		$this->assertInstanceOf( 'Canonical_Cache_Subclass_Popup', $item );
+	}
+}

--- a/tests/php/tests/Canonical_Popup_Cache_Test.php
+++ b/tests/php/tests/Canonical_Popup_Cache_Test.php
@@ -12,6 +12,8 @@
 
 require_once __DIR__ . '/fixtures/class-canonical-cache-subclass-popup.php';
 require_once __DIR__ . '/fixtures/class-canonical-cache-subclass-repository.php';
+require_once __DIR__ . '/fixtures/class-canonical-cache-legacy-subclass-popup.php';
+require_once __DIR__ . '/fixtures/class-canonical-cache-legacy-subclass-repository.php';
 
 /**
  * Canonical popup cache tests.
@@ -246,5 +248,168 @@ class Canonical_Popup_Cache_Test extends WP_UnitTestCase {
 		$item = $repository->get_by_id( $popup_id );
 
 		$this->assertInstanceOf( 'Canonical_Cache_Subclass_Popup', $item );
+	}
+
+	/**
+	 * Regression: get_by_id() must not serve a stale model when invalidation
+	 * hooks are absent, as in wp-admin and admin-AJAX.
+	 *
+	 * @return void
+	 */
+	public function test_get_by_id_validates_without_invalidation_hooks() {
+		$popup_id = $this->make_popup();
+		$repo     = \PopupMaker\plugin()->get( 'popups' );
+
+		$controller = \PopupMaker\plugin()->get_controller( 'Frontend\\Popups' );
+		remove_action( 'clean_post_cache', [ $controller, 'invalidate_queried_popup' ], PHP_INT_MIN );
+
+		try {
+			$repo->get_by_id( $popup_id );
+
+			wp_update_post(
+				[
+					'ID'         => $popup_id,
+					'post_title' => 'Updated without hooks',
+				]
+			);
+
+			$this->assertSame( 'Updated without hooks', $repo->get_by_id( $popup_id )->post_title );
+		} finally {
+			add_action( 'clean_post_cache', [ $controller, 'invalidate_queried_popup' ], PHP_INT_MIN, 2 );
+		}
+	}
+
+	/**
+	 * Regression: a deleted popup must not be returned from cache.
+	 *
+	 * @return void
+	 */
+	public function test_get_by_id_returns_null_for_deleted_popup_without_hooks() {
+		$popup_id = $this->make_popup();
+		$repo     = \PopupMaker\plugin()->get( 'popups' );
+
+		$controller = \PopupMaker\plugin()->get_controller( 'Frontend\\Popups' );
+		remove_action( 'clean_post_cache', [ $controller, 'invalidate_queried_popup' ], PHP_INT_MIN );
+
+		try {
+			$repo->get_by_id( $popup_id );
+
+			wp_delete_post( $popup_id, true );
+
+			$this->assertNull( $repo->get_by_id( $popup_id ) );
+		} finally {
+			add_action( 'clean_post_cache', [ $controller, 'invalidate_queried_popup' ], PHP_INT_MIN, 2 );
+		}
+	}
+
+	/**
+	 * Regression: get_by_field() reuses the canonical model.
+	 *
+	 * @return void
+	 */
+	public function test_get_by_field_reuses_canonical_model() {
+		$popup_id = $this->make_popup();
+		$slug     = get_post_field( 'post_name', $popup_id );
+
+		$held = pum_get_popup( $popup_id );
+		$repo = \PopupMaker\plugin()->get( 'popups' );
+
+		$this->assertSame( $held, $repo->get_by_field( 'post_name', $slug ) );
+		$this->assertSame( $held, $repo->get_canonical_item( $popup_id ) );
+	}
+
+	/**
+	 * Regression: values injected by the_posts filters survive legacy hydration.
+	 *
+	 * @return void
+	 */
+	public function test_legacy_query_preserves_filtered_post_values() {
+		$popup_id = $this->make_popup();
+
+		$filter = static function ( $posts ) {
+			foreach ( $posts as $post ) {
+				if ( 'popup' === $post->post_type ) {
+					$post->post_title = 'Translated title';
+				}
+			}
+
+			return $posts;
+		};
+
+		add_filter( 'the_posts', $filter );
+
+		try {
+			$popups = pum_get_popups( [ 'post__in' => [ $popup_id ] ] );
+		} finally {
+			remove_filter( 'the_posts', $filter );
+		}
+
+		$matched = null;
+		foreach ( $popups as $popup ) {
+			if ( (int) $popup->ID === $popup_id ) {
+				$matched = $popup;
+				break;
+			}
+		}
+
+		$this->assertInstanceOf( 'PUM_Model_Popup', $matched );
+		$this->assertSame( 'Translated title', $matched->post_title );
+	}
+
+	/**
+	 * Regression: a cached model holding filtered values is not thrashed.
+	 *
+	 * @return void
+	 */
+	public function test_filtered_model_survives_repeated_reads() {
+		$popup_id = $this->make_popup();
+		$repo     = \PopupMaker\plugin()->get( 'popups' );
+
+		$post = get_post( $popup_id );
+		$this->assertInstanceOf( 'WP_Post', $post );
+
+		$filtered             = clone $post;
+		$filtered->post_title = 'Filtered title';
+
+		$model = $repo->get_canonical_item_for_post( $filtered );
+		$this->assertSame( 'Filtered title', $model->post_title );
+
+		// Repeated reads must return the same filtered model, not rebuild it
+		// from the unfiltered database row.
+		$this->assertSame( $model, $repo->get_canonical_item( $popup_id ) );
+		$this->assertSame( 'Filtered title', $repo->get_canonical_item( $popup_id )->post_title );
+	}
+
+	/**
+	 * Regression: pum_get_popup() honours a custom legacy model class.
+	 *
+	 * @return void
+	 */
+	public function test_helper_preserves_custom_legacy_model() {
+		$popup_id = $this->make_popup();
+		$original = pum()->popups;
+
+		pum()->popups = new Canonical_Cache_Legacy_Subclass_Repository();
+
+		try {
+			$this->assertInstanceOf( 'Canonical_Cache_Legacy_Subclass_Popup', pum_get_popup( $popup_id ) );
+		} finally {
+			pum()->popups = $original;
+		}
+	}
+
+	/**
+	 * The default repository still yields the canonical core model.
+	 *
+	 * @return void
+	 */
+	public function test_helper_uses_canonical_model_by_default() {
+		$popup_id = $this->make_popup();
+
+		$this->assertTrue( pum()->popups->uses_core_model() );
+		$this->assertSame(
+			\PopupMaker\plugin()->get( 'popups' )->get_canonical_item( $popup_id ),
+			pum_get_popup( $popup_id )
+		);
 	}
 }

--- a/tests/php/tests/Frontend_Popups_Controller_Test.php
+++ b/tests/php/tests/Frontend_Popups_Controller_Test.php
@@ -345,7 +345,12 @@ class Frontend_Popups_Controller_Test extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Native settings writes evict modern models not cached by the controller.
+	 * Native settings writes refresh modern models not cached by the controller.
+	 *
+	 * Previously each repository hydrated its own model, so a settings write was
+	 * observable only by discarding the old instance. With one canonical model
+	 * per request the instance is reused and refreshed in place, so a reference
+	 * held across the write reports the new value rather than a stale one.
 	 *
 	 * @return void
 	 */
@@ -368,12 +373,14 @@ class Frontend_Popups_Controller_Test extends WP_UnitTestCase {
 
 		$updated = $repository->get_by_id( $popup_id );
 
-		$this->assertNotSame( $original, $updated );
+		$this->assertSame( $original, $updated );
 		$this->assertSame( 400, $updated->get_setting( 'animation_speed' ) );
+		// The previously held reference must not report the pre-write value.
+		$this->assertSame( 400, $original->get_setting( 'animation_speed' ) );
 	}
 
 	/**
-	 * Native settings writes evict legacy models not cached by the controller.
+	 * Native settings writes refresh legacy models not cached by the controller.
 	 *
 	 * @return void
 	 */
@@ -395,8 +402,10 @@ class Frontend_Popups_Controller_Test extends WP_UnitTestCase {
 
 		$updated = pum_get_popup( $popup_id );
 
-		$this->assertNotSame( $original, $updated );
+		// pum()->popups and pum_get_popup() now share one canonical model.
+		$this->assertSame( $original, $updated );
 		$this->assertSame( 400, $updated->get_setting( 'animation_speed' ) );
+		$this->assertSame( 400, $original->get_setting( 'animation_speed' ) );
 	}
 
 	/**

--- a/tests/php/tests/Popup_Model_Cache_Bench.php
+++ b/tests/php/tests/Popup_Model_Cache_Bench.php
@@ -148,9 +148,9 @@ class Popup_Model_Cache_Bench extends WP_UnitTestCase {
 	/**
 	 * Record a result row.
 	 *
-	 * @param string               $label   Scenario label.
-	 * @param array<string,int>    $metrics Metrics.
-	 * @param array<string,mixed>  $extra   Extra fields.
+	 * @param string              $label   Scenario label.
+	 * @param array<string,int>   $metrics Metrics.
+	 * @param array<string,mixed> $extra   Extra fields.
 	 * @return void
 	 */
 	private function row( $label, $metrics, $extra = [] ) {
@@ -172,6 +172,7 @@ class Popup_Model_Cache_Bench extends WP_UnitTestCase {
 	private function emit() {
 		$count = count( $this->ids );
 
+		// phpcs:disable WordPress.WP.AlternativeFunctions.file_system_operations_fwrite -- CLI diagnostic output, not a filesystem write.
 		fwrite( STDERR, "\n# BENCH popup_count={$count}\n" );
 
 		foreach ( $this->rows as $row ) {
@@ -179,6 +180,7 @@ class Popup_Model_Cache_Bench extends WP_UnitTestCase {
 		}
 
 		fwrite( STDERR, "# END BENCH\n" );
+		// phpcs:enable WordPress.WP.AlternativeFunctions.file_system_operations_fwrite
 	}
 
 	/**

--- a/tests/php/tests/Popup_Model_Cache_Bench.php
+++ b/tests/php/tests/Popup_Model_Cache_Bench.php
@@ -1,0 +1,321 @@
+<?php
+/**
+ * Deterministic popup model fetch/cache benchmark.
+ *
+ * Not a correctness test — it emits SQL query counts, model hydration counts,
+ * and object-identity facts for the canonical-cache refactor. Excluded from the
+ * default suite via the `bench` group; run explicitly with:
+ *
+ *   vendor/bin/phpunit -c tests/php/phpunit.xml --group bench
+ *
+ * Set PUM_BENCH_POPUPS to change the eligible popup count (default 10).
+ *
+ * @package PopupMaker
+ * @group bench
+ */
+
+/**
+ * Popup model cache benchmark.
+ */
+class Popup_Model_Cache_Bench extends WP_UnitTestCase {
+
+	/**
+	 * Seeded popup IDs.
+	 *
+	 * @var int[]
+	 */
+	private $ids = [];
+
+	/**
+	 * Distinct model object ids observed.
+	 *
+	 * @var array<int,bool>
+	 */
+	private $seen = [];
+
+	/**
+	 * Query count at window start.
+	 *
+	 * @var int
+	 */
+	private $query_mark = 0;
+
+	/**
+	 * Hydration count at window start.
+	 *
+	 * @var int
+	 */
+	private $hydration_mark = 0;
+
+	/**
+	 * Collected rows.
+	 *
+	 * @var array<int,array<string,mixed>>
+	 */
+	private $rows = [];
+
+	/**
+	 * Seed popups.
+	 *
+	 * @return void
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$configured = getenv( 'PUM_BENCH_POPUPS' );
+		$count      = is_string( $configured ) && '' !== $configured ? (int) $configured : 10;
+
+		for ( $i = 0; $i < $count; $i++ ) {
+			$id = wp_insert_post(
+				[
+					'post_type'    => 'popup',
+					'post_title'   => 'Bench popup ' . $i,
+					'post_content' => 'Bench content ' . $i,
+					'post_status'  => 'publish',
+				]
+			);
+
+			update_post_meta(
+				$id,
+				'popup_settings',
+				[
+					'enabled'   => true,
+					'bench_idx' => $i,
+				]
+			);
+
+			$this->ids[] = (int) $id;
+		}
+	}
+
+	/**
+	 * Observe an object for hydration counting.
+	 *
+	 * @param mixed $obj Candidate model.
+	 * @return void
+	 */
+	private function observe( $obj ) {
+		if ( is_object( $obj ) ) {
+			$this->seen[ spl_object_id( $obj ) ] = true;
+		}
+	}
+
+	/**
+	 * Open a measurement window.
+	 *
+	 * @return void
+	 */
+	private function start() {
+		global $wpdb;
+		$this->query_mark     = $wpdb->num_queries;
+		$this->hydration_mark = count( $this->seen );
+	}
+
+	/**
+	 * Close a measurement window.
+	 *
+	 * @return array{queries:int,hydrations:int}
+	 */
+	private function stop() {
+		global $wpdb;
+
+		return [
+			'queries'    => $wpdb->num_queries - $this->query_mark,
+			'hydrations' => count( $this->seen ) - $this->hydration_mark,
+		];
+	}
+
+	/**
+	 * Drop every request-local popup cache.
+	 *
+	 * @return void
+	 */
+	private function flush_caches() {
+		$controller = \PopupMaker\plugin()->get_controller( 'Frontend\\Popups' );
+
+		foreach ( $this->ids as $id ) {
+			if ( $controller && method_exists( $controller, 'invalidate_queried_popup' ) ) {
+				$controller->invalidate_queried_popup( $id );
+			}
+
+			\PopupMaker\plugin()->get( 'popups' )->forget_item( $id );
+			pum()->popups->forget_item( $id );
+		}
+
+		$this->seen = [];
+	}
+
+	/**
+	 * Record a result row.
+	 *
+	 * @param string               $label   Scenario label.
+	 * @param array<string,int>    $metrics Metrics.
+	 * @param array<string,mixed>  $extra   Extra fields.
+	 * @return void
+	 */
+	private function row( $label, $metrics, $extra = [] ) {
+		$this->rows[] = array_merge(
+			[
+				'scenario'   => $label,
+				'queries'    => $metrics['queries'],
+				'hydrations' => $metrics['hydrations'],
+			],
+			$extra
+		);
+	}
+
+	/**
+	 * Emit collected rows.
+	 *
+	 * @return void
+	 */
+	private function emit() {
+		$count = count( $this->ids );
+
+		fwrite( STDERR, "\n# BENCH popup_count={$count}\n" );
+
+		foreach ( $this->rows as $row ) {
+			fwrite( STDERR, wp_json_encode( $row ) . "\n" );
+		}
+
+		fwrite( STDERR, "# END BENCH\n" );
+	}
+
+	/**
+	 * Run all benchmark scenarios.
+	 *
+	 * @return void
+	 */
+	public function test_bench_popup_model_cache() {
+		if ( empty( $this->ids ) ) {
+			// Zero eligible popups: only the frontend query path is meaningful.
+			$this->start();
+			$queried = \PopupMaker\plugin()->get( 'popups' )->query(
+				[ 'post_status' => [ 'publish', 'private' ] ]
+			);
+			$this->row(
+				'D:frontend_query_then_readback',
+				$this->stop(),
+				[
+					'popups'             => count( $queried ),
+					'distinct_on_second' => 0,
+				]
+			);
+			$this->emit();
+			$this->assertSame( [], $queried );
+
+			return;
+		}
+
+		$target = $this->ids[0];
+
+		// A: cold single fetch via the legacy helper.
+		$this->flush_caches();
+		$this->start();
+		$popup = pum_get_popup( $target );
+		$this->observe( $popup );
+		$this->row( 'A:cold_single_pum_get_popup', $this->stop() );
+
+		// B: repeated getter for the same popup, 10 reads + settings touch.
+		$this->start();
+		$object_ids = [];
+		for ( $i = 0; $i < 10; $i++ ) {
+			$repeat       = pum_get_popup( $target );
+			$object_ids[] = spl_object_id( $repeat );
+			$this->observe( $repeat );
+			$repeat->get_setting( 'bench_idx' );
+		}
+		$this->row(
+			'B:warm_repeat_same_popup_x10',
+			$this->stop(),
+			[ 'distinct_objects' => count( array_unique( $object_ids ) ) ]
+		);
+
+		// C: cross-API identity for one popup.
+		$this->flush_caches();
+		$this->start();
+		$via_fn          = pum_get_popup( $target );
+		$via_modern      = \PopupMaker\plugin()->get( 'popups' )->get_by_id( $target );
+		$via_legacy_repo = pum()->popups->get_item( $target );
+		$this->observe( $via_fn );
+		$this->observe( $via_modern );
+		$this->observe( $via_legacy_repo );
+		$this->row(
+			'C:cross_api_same_popup',
+			$this->stop(),
+			[
+				'distinct_objects' => count(
+					array_unique(
+						[
+							spl_object_id( $via_fn ),
+							spl_object_id( $via_modern ),
+							spl_object_id( $via_legacy_repo ),
+						]
+					)
+				),
+			]
+		);
+
+		// D: frontend-style query then per-ID readback.
+		$this->flush_caches();
+		$mem_before = memory_get_usage();
+		$start_time = microtime( true );
+
+		$this->start();
+		$queried = \PopupMaker\plugin()->get( 'popups' )->query(
+			[ 'post_status' => [ 'publish', 'private' ] ]
+		);
+		foreach ( $queried as $item ) {
+			$this->observe( $item );
+		}
+		$second = [];
+		foreach ( $this->ids as $id ) {
+			$readback = pum_get_popup( $id );
+			$second[] = spl_object_id( $readback );
+			$this->observe( $readback );
+			$readback->get_setting( 'bench_idx' );
+		}
+		$metrics = $this->stop();
+
+		$this->row(
+			'D:frontend_query_then_readback',
+			$metrics,
+			[
+				'popups'             => count( $queried ),
+				'distinct_on_second' => count( array_unique( $second ) ),
+				'elapsed_ms'         => round( ( microtime( true ) - $start_time ) * 1000, 2 ),
+				'mem_delta_kb'       => round( ( memory_get_usage() - $mem_before ) / 1024, 1 ),
+			]
+		);
+
+		// E: stale-read safety after a direct meta write.
+		$this->flush_caches();
+		$before = pum_get_popup( $target );
+		$before->get_setting( 'bench_idx' );
+
+		update_post_meta(
+			$target,
+			'popup_settings',
+			[
+				'enabled'   => true,
+				'bench_idx' => 9999,
+			]
+		);
+
+		$this->start();
+		$after    = pum_get_popup( $target );
+		$observed = $after->get_setting( 'bench_idx' );
+		$this->row(
+			'E:stale_after_meta_write',
+			$this->stop(),
+			[
+				'observed_value' => $observed,
+				'is_fresh'       => 9999 === $observed ? 'yes' : 'NO-STALE',
+			]
+		);
+
+		$this->emit();
+
+		$this->assertNotEmpty( $this->rows );
+	}
+}

--- a/tests/php/tests/Popup_Model_Cache_Bench.php
+++ b/tests/php/tests/Popup_Model_Cache_Bench.php
@@ -84,6 +84,12 @@ class Popup_Model_Cache_Bench extends WP_UnitTestCase {
 				]
 			);
 
+			// Real popups always carry data_version. Without it, model setup()
+			// performs a SELECT + UPDATE per popup during a read request, which
+			// then invalidates the bulk meta cache primed by WP_Query and forces
+			// per-popup meta refetches. Seeding it keeps the fixture honest.
+			update_post_meta( $id, 'data_version', 3 );
+
 			$this->ids[] = (int) $id;
 		}
 	}

--- a/tests/php/tests/benchmarks/Popup_Model_Cache_Bench.php
+++ b/tests/php/tests/benchmarks/Popup_Model_Cache_Bench.php
@@ -3,15 +3,15 @@
  * Deterministic popup model fetch/cache benchmark.
  *
  * Not a correctness test — it emits SQL query counts, model hydration counts,
- * and object-identity facts for the canonical-cache refactor. Excluded from the
- * default suite via the `bench` group; run explicitly with:
+ * and object-identity facts for the canonical-cache refactor. It lives in
+ * tests/php/tests/benchmarks, which the default `general` suite excludes, so it
+ * never runs during `composer tests`. Run it explicitly with:
  *
- *   vendor/bin/phpunit -c tests/php/phpunit.xml --group bench
+ *   vendor/bin/phpunit -c tests/php/phpunit.xml --testsuite bench
  *
  * Set PUM_BENCH_POPUPS to change the eligible popup count (default 10).
  *
  * @package PopupMaker
- * @group bench
  */
 
 /**
@@ -297,6 +297,13 @@ class Popup_Model_Cache_Bench extends WP_UnitTestCase {
 		);
 
 		// E: stale-read safety after a direct meta write.
+		//
+		// Note on scope: settings freshness is defended at the model layer by
+		// PUM_Model_Popup::get_settings(), which re-reads when the metadata cache
+		// hash changes. This scenario therefore measures the end-to-end guarantee
+		// a caller sees, not the repository's own freshness check. Repository
+		// freshness (post updates and deletes) is covered by
+		// Canonical_Popup_Cache_Test.
 		$this->flush_caches();
 		$before = pum_get_popup( $target );
 		$before->get_setting( 'bench_idx' );
@@ -313,17 +320,27 @@ class Popup_Model_Cache_Bench extends WP_UnitTestCase {
 		$this->start();
 		$after    = pum_get_popup( $target );
 		$observed = $after->get_setting( 'bench_idx' );
+		$is_fresh = 9999 === $observed;
 		$this->row(
 			'E:stale_after_meta_write',
 			$this->stop(),
 			[
 				'observed_value' => $observed,
-				'is_fresh'       => 9999 === $observed ? 'yes' : 'NO-STALE',
+				'expected_value' => 9999,
+				'result'         => $is_fresh ? 'FRESH' : 'STALE-READ-DETECTED',
 			]
 		);
 
 		$this->emit();
 
 		$this->assertNotEmpty( $this->rows );
+
+		// Scenario E measures staleness protection, so a stale read must fail the
+		// run rather than be reported as a passing data point.
+		$this->assertSame(
+			9999,
+			$observed,
+			'Scenario E read a stale popup setting: the canonical cache served a value written before the meta update.'
+		);
 	}
 }

--- a/tests/php/tests/fixtures/class-canonical-cache-legacy-subclass-popup.php
+++ b/tests/php/tests/fixtures/class-canonical-cache-legacy-subclass-popup.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Extension-style legacy popup model used to verify helper compatibility.
+ *
+ * @package PopupMaker
+ */
+
+/**
+ * Extension-style legacy popup model.
+ */
+class Canonical_Cache_Legacy_Subclass_Popup extends PUM_Model_Popup {
+}

--- a/tests/php/tests/fixtures/class-canonical-cache-legacy-subclass-repository.php
+++ b/tests/php/tests/fixtures/class-canonical-cache-legacy-subclass-repository.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * Extension-style legacy popup repository used to verify helper compatibility.
+ *
+ * @package PopupMaker
+ */
+
+/**
+ * Extension-style legacy repository with a custom model class.
+ */
+class Canonical_Cache_Legacy_Subclass_Repository extends PUM_Repository_Popups {
+
+	/**
+	 * Custom model class.
+	 *
+	 * @var string
+	 */
+	protected $model = 'Canonical_Cache_Legacy_Subclass_Popup';
+}

--- a/tests/php/tests/fixtures/class-canonical-cache-subclass-popup.php
+++ b/tests/php/tests/fixtures/class-canonical-cache-subclass-popup.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Extension-style popup model used to verify subclass preservation.
+ *
+ * @package PopupMaker
+ */
+
+/**
+ * Extension-style popup model.
+ */
+class Canonical_Cache_Subclass_Popup extends PUM_Model_Popup {
+}

--- a/tests/php/tests/fixtures/class-canonical-cache-subclass-repository.php
+++ b/tests/php/tests/fixtures/class-canonical-cache-subclass-repository.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Extension-style popup repository used to verify subclass preservation.
+ *
+ * @package PopupMaker
+ */
+
+/**
+ * Extension-style repository returning a custom model.
+ */
+class Canonical_Cache_Subclass_Repository extends \PopupMaker\Services\Repository\Popups {
+
+	/**
+	 * Instantiate the extension model.
+	 *
+	 * @param \WP_Post $post Post object.
+	 *
+	 * @return PUM_Model_Popup|null
+	 */
+	public function instantiate_model_from_post( $post ) {
+		if ( ! $post instanceof \WP_Post ) {
+			return null;
+		}
+
+		return new Canonical_Cache_Subclass_Popup( $post );
+	}
+}


### PR DESCRIPTION
Addresses the three approved review threads from #1394:

- [r3983427868](https://github.com/PopupMaker/Popup-Maker/pull/1394#discussion_r3983427868) — model/cache complexity and DRY lifting
- [r3983541633](https://github.com/PopupMaker/Popup-Maker/pull/1394#discussion_r3983541633) — legacy getter sharing the canonical fetcher
- [r3983567713](https://github.com/PopupMaker/Popup-Maker/pull/1394#discussion_r3983567713) — moving the cache boundary lower

## The problem, measured

Popup models were hydrated and cached by **three independent request-local stores**:

| # | Owner | Key | Staleness strategy |
|---|-------|-----|--------------------|
| 1 | `Services\Repository\Popups` | `blog_id:id` | none |
| 2 | `PUM_Repository_Popups` | `post->ID` | md5 post hash incl. blog id |
| 3 | `Controllers\Frontend\Popups::$queried_popups` | `blog_id:id` | `get_object_vars()` diff |

`invalidate_queried_popup()` had to poke all three by hand on every save, delete and metadata write.

Before touching anything I committed a benchmark (`Popup_Model_Cache_Bench`, first commit) to characterize it. On `develop` at 21e59a1d:

- Fetching **one popup** via `pum_get_popup()`, the modern repository and `pum()->popups` returned **2 distinct objects**.
- A frontend query followed by per-ID readback hydrated **every popup twice**: 10 popups → 20 hydrations, 50 popups → 100.

(Query counts were already optimal at 3 flat — see Results.)

## The change

The modern repository becomes the single owner; everything else delegates.

- `Services\Repository\Popups::get_canonical_item()` — the one fetch boundary. `get_cached_item()` answers "already hydrated for this site?" without triggering a query.
- The freshness check that lived in the frontend controller **moved down** into the repository, so admin, AJAX and REST callers now get staleness protection they never had.
- `query()` reuses a cached canonical model instead of replacing it, via a new overridable `resolve_model_from_post()` hook on the base repository.
- `get_queried_popup()` / `cache_queried_popup()` are retained as frontend-facing names that delegate. `$queried_popups` and its duplicate cache-key helper are deleted.
- `pum_get_popup()` drops its three-tier cascade and try/catch for one canonical call, still returning a popup object for unresolvable IDs.
- `PUM_Repository_Popups::get_model()` delegates to the canonical repository, keeping the legacy hydration path for subclasses with a custom model class.
- Settings-metadata invalidation moves to `refresh_item_settings()` — refresh in place when cached, evict otherwise.
- The duplicated settings meta-cache hash in `Model\Popup` and `Model\Theme` lifts into `PUM_Abstract_Model_Post::hash_meta_cache_entry()`.

Net effect on the frontend controller: **−51 lines**, and it no longer owns a cache.

## Results

Baseline measured in a **separate clean worktree** with its own `composer install`.

| metric | n | before | after |
|--------|---|--------|-------|
| hydrations (query + readback) | 10 | 20 | **10** |
| hydrations (query + readback) | 50 | 100 | **50** |
| distinct objects, one popup across 3 APIs | — | 2 | **1** |
| incremental memory | 50 | 456.1 KB | **292.4 KB** |
| SQL queries | 10 | 3 | 3 |
| SQL queries | 50 | 3 | 3 |

**SQL is unchanged, and was already optimal.** The popup pass is 3 queries flat at any popup count — one posts query, one term query, one bulk postmeta prime — and readback issues zero queries. This PR changes object-graph efficiency, not query count.

> **Correction:** an earlier revision of this PR reported 30/150 queries. That was a benchmark fixture artifact, not plugin behavior — see the note below. The fixture is fixed and the numbers above are the real ones.

### Fixture note (`data_version`)

Popups seeded without `data_version` meta make `PUM_Model_Popup::setup()` run `update_meta( 'data_version', … )` during a **read** request — a SELECT + UPDATE per popup — and those writes invalidate the per-post meta cache `WP_Query` had just primed in bulk, forcing a second per-popup meta fetch on readback. That produced the inflated 30/150 figures.

Real popups always carry `data_version` (verified against the live dev database: all 10 popups at `data_version = 3`, matching `model_version = 3`), so neither the initial write nor passive migration fires in steady state. The write-on-read still affects popups created without that meta — programmatic inserts, imports, some migrations. Worth its own issue; **out of scope here** and not claimed as a win.

## Behavioral change worth reviewing

With one shared model, a reference held across a settings write now observes the refreshed value. Previously each API held a separate model, so the held reference kept reporting the **pre-write** value.

Two existing tests asserted `assertNotSame( $original, $updated )` — encoding the split-identity defect as the contract. I updated them to assert shared identity **plus** freshness through the held reference, rather than leaving assertions that lock in the old behavior. Both changes are visible in the diff of `Frontend_Popups_Controller_Test.php`.

## Preserved

Extension repository subclasses and their model classes (covered by a new test), protected cache hooks, dynamic metadata/default filters, request-local settings provenance, direct-write invalidation, multisite partitioning, and the `pum_get_popup()` contract of always returning an object.

## Review round 1 (all eight threads resolved)

| # | Thread | Outcome |
|---|--------|---------|
| 1 | admin/admin-AJAX invalidation | **Confirmed.** `get_by_id()` served stale models — and a *deleted* popup — in admin, where the frontend controller never registers `clean_post_cache`. Validation moved into `get_by_id()` itself so correctness no longer depends on hook registration. |
| 2 | filtered `WP_Post` values | **Confirmed.** `the_posts` filter output was discarded. Legacy `get_model()` now passes the post through instead of reloading by ID. |
| 3 | repository freshness path | **Confirmed**, same root cause as #1. Shared `Repository::get_by_id()` now validates via an overridable `cached_item_is_fresh()`; no recursion, `CallToActions` unaffected. |
| 4 | custom legacy model subclasses | **Confirmed.** `pum_get_popup()` bypassed a customized `pum()->popups`. Now defers when `uses_core_model()` is false. |
| 5 | benchmark in default runs | **Confirmed.** `@group bench` had no effect. Moved to `tests/php/tests/benchmarks/`, excluded from the `general` suite, reachable via `--testsuite bench`. |
| 6 | `get_by_field()` identity | **Confirmed.** Built a second model and clobbered the canonical entry. Now routes through `resolve_model_from_post()`. |
| 7 | invalid baseline query counts | **Confirmed.** `.perf/BASELINE.md` rewritten with values re-measured in a clean baseline worktree; superseded 30/150 figures kept in an explicit callout with the cause. |
| 8 | stale benchmark reads | **Confirmed.** Now records `FRESH`/`STALE-READ-DETECTED` and asserts. Verifying revealed scenario E *cannot* detect a repository-freshness regression (settings freshness is defended at the model layer) — scope documented, real coverage added elsewhere. |

Two additional issues found while fixing the above:

- Comparing `post_modified_gmt` missed edits **inside the same second**. The repository now fingerprints the stored post at cache time.
- My first freshness check compared the model's own `WP_Post`, which would have judged every legitimately *filtered* model stale on each read — thrashing, and silently undoing fix #2. The fingerprint is taken from the stored post, so it is independent of filtering.

Seven new regression tests in `Canonical_Popup_Cache_Test`.

## Review round 2 (CodeRabbit re-review — 5 threads resolved)

One real bug, four documentation corrections.

**The bug (Major):** my round-1 filtered-post fix only worked if the filtered query ran *first*. If anything touched the popup by ID earlier in the request — and `preload_popups()` does exactly that on every frontend load — the cache already held an unfiltered model and the filter was silently discarded:

```
ORDER-A (filtered first):            Translated A     <- worked
ORDER-B (id lookup, then filtered):  Original title   <- filter lost
HELPER-THEN-QUERY:                   Original title   <- the realistic shape
```

`get_canonical_item_for_post()` now refreshes the cached model in place via `PUM_Model_Popup::setup()` when the supplied post differs, preserving object identity. Verified no side effects: `data_version` is `! isset()`-guarded so it does not re-run, and `parent::setup()` does not touch `$settings`. Confirmed `setup()` is public, that PHP forbids a subclass narrowing it, and that no Pro plugin overrides it.

Two regression tests added, one per lookup order.

**Also fixed:** tests now assert `remove_action()` returned `true` (otherwise they could pass without exercising validation — verified by injecting a regression, both fail), plus three `.perf/QUERY-AUDIT.md` corrections: the zero-query result is now scoped to persistent-object-cache deployments, a mislabelled `n=10` row is corrected to `n=25` (re-measured: 4/0/0), and "at most twice more ever" is bounded to the current inventory.

## Checks

- **PHPUnit:** 1213 tests, 2994 assertions, 0 failures (20 pre-existing skips), with the benchmark correctly excluded from the default suite.
- **PHPCS:** clean on all changed files.
- **PHPStan:** 26 errors before, 26 after — findings diffed line-by-line and **identical**, no new errors.
- **PHP 7.4:** `php -l` clean; no union types, `mixed`, or `match`.
- **Core smoke:** covered by the integration suite, including admin (126 tests), CTA repository (39 tests), and frontend controller paths.

## Limitations

**Pro / Pro Plus smoke not run.** The Local site was stopped (only its MySQL was up), so no live request-level smoke was possible. I did scan all three Pro plugins (1305 PHP files) for use of every API touched here — `get_queried_popup`, `cache_queried_popup`, `instantiate_model_from_post`, `replace_cached_item`, `forget_item`, `PUM_Repository_Popups` — and found **no runtime references**, only generated stub files. `instantiate_model_from_post` keeps its public signature, and `resolve_model_from_post` is additive and non-abstract, so subclasses remain source-compatible. Worth a live Pro smoke before merge regardless.

## Scope

Deliberately bounded to the three approved threads. Theme settings caching is touched **only** to share the hash helper; the broader Theme/settings cache redesign is not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
